### PR TITLE
Fix WebSocket connection issues and duplicate room joins

### DIFF
--- a/src/app/meeting/[botId]/hooks/use-meeting-data.ts
+++ b/src/app/meeting/[botId]/hooks/use-meeting-data.ts
@@ -1,8 +1,7 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import { useBotData } from '@/hooks/use-bot-data'
 import { useBotActions } from '@/hooks/use-bot-actions'
 import { useCoachingWebSocket } from '@/hooks/use-coaching-websocket'
-import { useWebSocket } from '@/contexts/websocket-context'
 
 interface UseMeetingDataProps {
   botId: string
@@ -18,18 +17,9 @@ export function useMeetingData({ botId }: UseMeetingDataProps) {
     isPaused,
   } = useBotActions()
   const [meetingState, setMeetingState] = useState<any>(null)
-  const { joinRoom, leaveRoom } = useWebSocket()
 
-  // Join WebSocket room on mount
-  useEffect(() => {
-    console.log('[MeetingPage] Joining room:', `bot:${botId}`)
-    joinRoom(`bot:${botId}`)
-
-    return () => {
-      console.log('[MeetingPage] Leaving room:', `bot:${botId}`)
-      leaveRoom(`bot:${botId}`)
-    }
-  }, [botId, joinRoom, leaveRoom])
+  // Room joining is handled by useBotWebSocket in use-bot-data.ts
+  // No need to join again here
 
   // Handle meeting state updates
   const handleMeetingState = useCallback((data: any) => {

--- a/src/services/websocket-service.ts
+++ b/src/services/websocket-service.ts
@@ -51,6 +51,12 @@ class WebSocketService {
   }
 
   private buildWebSocketUrl(): string {
+    // Use dedicated WebSocket URL if available
+    if (process.env.NEXT_PUBLIC_WS_URL) {
+      return `${process.env.NEXT_PUBLIC_WS_URL}/ws/connect`
+    }
+
+    // Fallback to deriving from API URL
     const backendUrl =
       process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
     // Remove /api/v1 suffix if present and convert to ws://


### PR DESCRIPTION
- Remove duplicate room join from use-meeting-data.ts (already handled by use-bot-websocket)
- Use NEXT_PUBLIC_WS_URL environment variable for WebSocket connections
- Fix session creation to only occur when bot is actively recording
- Re-enable WebSocket auto-connection when authenticated