### PR TITLE
fix: stop 401 polling in active-sessions-card

### DIFF
--- a/src/components/client-portal/active-sessions-card.tsx
+++ b/src/components/client-portal/active-sessions-card.tsx
@@ -5,7 +5,8 @@
 
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -25,15 +26,10 @@ interface ActiveSession {
 export function ActiveSessionsCard() {
   const [activeSessions, setActiveSessions] = useState<ActiveSession[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const router = useRouter()
+  const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
-  useEffect(() => {
-    fetchActiveSessions()
-    // Poll every 30 seconds
-    const interval = setInterval(fetchActiveSessions, 30000)
-    return () => clearInterval(interval)
-  }, [])
-
-  const fetchActiveSessions = async () => {
+  const fetchActiveSessions = useCallback(async () => {
     try {
       const token = localStorage.getItem('auth_token')
       if (!token) return
@@ -52,6 +48,14 @@ export function ActiveSessionsCard() {
         headers,
       })
 
+      if (response.status === 401) {
+        // Token expired — stop polling and redirect to login
+        if (intervalRef.current) clearInterval(intervalRef.current)
+        localStorage.removeItem('auth_token')
+        router.push('/login')
+        return
+      }
+
       if (response.ok) {
         const data = await response.json()
         setActiveSessions(data)
@@ -61,7 +65,16 @@ export function ActiveSessionsCard() {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [router])
+
+  useEffect(() => {
+    fetchActiveSessions()
+    // Poll every 30 seconds
+    intervalRef.current = setInterval(fetchActiveSessions, 30000)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [fetchActiveSessions])
 
   const formatDuration = (seconds: number) => {
     const mins = Math.floor(seconds / 60)


### PR DESCRIPTION
## Summary

- **ActiveSessionsCard** was polling `/client-portal/active-sessions` every 30s with raw `fetch()`. When JWT expired, it kept sending stale tokens causing continuous 401 errors in production (~every 2 min, confirmed via Grafana/Loki).
- Now handles 401: stops polling, clears stale token, redirects to `/login`.

## Root Cause

Found via Loki logs in Grafana — all production warning logs were 401s on this single endpoint with `user_email=null` (expired/missing token). The component had no 401 handling, just `if (response.ok)` which silently swallowed auth failures while polling continued.

## Test plan
- [ ] Client portal dashboard loads without errors
- [ ] Active sessions card polls correctly with valid token
- [ ] On token expiry, user is redirected to login (no more 401 spam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)