### PR TITLE
fix: eliminate 401 noise, add confetti, hide video

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@tiptap/react": "^3.15.3",
     "@tiptap/starter-kit": "^3.15.3",
     "axios": "^1.10.0",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -58,6 +59,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ dependencies:
   axios:
     specifier: ^1.10.0
     version: 1.10.0
+  canvas-confetti:
+    specifier: ^1.9.4
+    version: 1.9.4
   class-variance-authority:
     specifier: ^0.7.1
     version: 0.7.1
@@ -145,6 +148,9 @@ devDependencies:
   '@tailwindcss/postcss':
     specifier: ^4
     version: 4.1.11
+  '@types/canvas-confetti':
+    specifier: ^1.9.0
+    version: 1.9.0
   '@types/node':
     specifier: ^20
     version: 20.19.4
@@ -2815,6 +2821,10 @@ packages:
     dev: true
     optional: true
 
+  /@types/canvas-confetti@1.9.0:
+    resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
+    dev: true
+
   /@types/d3-array@3.2.1:
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
     dev: false
@@ -3505,6 +3515,10 @@ packages:
 
   /caniuse-lite@1.0.30001727:
     resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
+    dev: false
+
+  /canvas-confetti@1.9.4:
+    resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
     dev: false
 
   /ccount@2.0.1:

--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 import Link from 'next/link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -126,12 +127,12 @@ export default function ClientDashboard() {
 
   const fetchDashboardData = async () => {
     try {
-      const token = localStorage.getItem('auth_token')
-      if (!token) {
-        console.error('No auth token found')
+      if (!isTokenValid()) {
+        handleAuthExpired()
         return
       }
 
+      const token = localStorage.getItem('auth_token')
       const apiUrl =
         process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
       const headers: Record<string, string> = {
@@ -146,7 +147,7 @@ export default function ClientDashboard() {
 
       if (!response.ok) {
         if (response.status === 401) {
-          console.error('Unauthorized - token may be expired')
+          handleAuthExpired()
           return
         }
         throw new Error('Failed to fetch dashboard')

--- a/src/app/client-portal/profile/page.tsx
+++ b/src/app/client-portal/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
+import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 import { useAuth } from '@/contexts/auth-context'
 import {
   Card,
@@ -79,6 +80,10 @@ export default function ClientProfilePage() {
 
   const fetchProfileData = async () => {
     try {
+      if (!isTokenValid()) {
+        handleAuthExpired()
+        return
+      }
       const token = localStorage.getItem('auth_token')
       const apiUrl =
         process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
@@ -89,6 +94,10 @@ export default function ClientProfilePage() {
         },
       })
 
+      if (response.status === 401) {
+        handleAuthExpired()
+        return
+      }
       if (!response.ok) throw new Error('Failed to fetch profile')
 
       const data = await response.json()
@@ -104,6 +113,7 @@ export default function ClientProfilePage() {
 
   const fetchClientInfo = async () => {
     try {
+      if (!isTokenValid()) return
       const token = localStorage.getItem('auth_token')
       const apiUrl =
         process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
@@ -117,6 +127,10 @@ export default function ClientProfilePage() {
       }
       const response = await fetch(`${apiUrl}/client/dashboard`, { headers })
 
+      if (response.status === 401) {
+        handleAuthExpired()
+        return
+      }
       if (!response.ok) return
 
       const data = await response.json()

--- a/src/app/clients/[clientId]/components/goals-tree-view.tsx
+++ b/src/app/clients/[clientId]/components/goals-tree-view.tsx
@@ -20,6 +20,7 @@ import { SprintKanbanBoard } from '@/components/sprints/sprint-kanban-board'
 import { CommitmentKanbanBoard } from '@/components/commitments/commitment-kanban-board'
 import { ClientCommitmentService } from '@/services/client-commitment-service'
 import { toast } from 'sonner'
+import { useConfetti } from '@/hooks/use-confetti'
 import { useGoals } from '@/hooks/queries/use-goals'
 import { useTargets } from '@/hooks/queries/use-targets'
 import { useSprints } from '@/hooks/queries/use-sprints'
@@ -322,6 +323,7 @@ export function GoalsTreeView({
   const [hideCompletedVisions, setHideCompletedVisions] = useState(false)
   const [hideCompletedOutcomes, setHideCompletedOutcomes] = useState(false)
   const [hideCompletedSprints, setHideCompletedSprints] = useState(false)
+  const { fireConfetti } = useConfetti()
 
   // Fetch all data
   const { data: goals = [], isLoading: goalsLoading } = useGoals(clientId)
@@ -499,6 +501,9 @@ export function GoalsTreeView({
     })
 
     toast.success(`Moved to ${statusLabels[newStatus]}`)
+    if (newStatus === 'completed') {
+      fireConfetti({ intensity: 'medium' })
+    }
 
     try {
       await ClientCommitmentService.updateCommitment(commitmentId, {

--- a/src/app/clients/[clientId]/components/sprint-kanban-section.tsx
+++ b/src/app/clients/[clientId]/components/sprint-kanban-section.tsx
@@ -23,6 +23,7 @@ import {
 import { differenceInDays, isAfter, isBefore } from 'date-fns'
 import { formatDate } from '@/lib/date-utils'
 import { toast } from 'sonner'
+import { useConfetti } from '@/hooks/use-confetti'
 
 interface SprintKanbanSectionProps {
   clientId: string
@@ -53,6 +54,7 @@ function SprintAccordionItem({
   clientId,
 }: SprintAccordionItemProps) {
   const queryClient = useQueryClient()
+  const { fireConfetti } = useConfetti()
 
   // Calculate sprint stats
   const totalCommitments = commitments.length
@@ -248,6 +250,9 @@ function SprintAccordionItem({
                 }
               })
               toast.success(`Moved to ${statusLabels[newStatus]}`)
+              if (newStatus === 'completed') {
+                fireConfetti({ intensity: 'medium' })
+              }
               try {
                 await CommitmentService.updateCommitment(commitmentId, {
                   status: newStatus as any,

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -29,7 +29,7 @@ import { SessionNotesCompact } from './session-notes-compact'
 import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
 import TranscriptViewer from './transcript-viewer'
-import { VideoPlayer } from '@/components/sessions/video-player'
+// import { VideoPlayer } from '@/components/sessions/video-player'
 
 interface TranscriptEntry {
   id: string
@@ -83,10 +83,10 @@ export function SessionOverviewTab({
   clientId,
   transcript,
   isViewer = false,
-  videoUrl,
+  videoUrl: _videoUrl,
   onViewAnalysis,
   onRefreshCommitments,
-  onRefreshVideoUrl,
+  onRefreshVideoUrl: _onRefreshVideoUrl,
   isGroupSession = false,
   selectedClientId = null,
   clientAnalyses,
@@ -253,14 +253,14 @@ export function SessionOverviewTab({
         </Card>
       )}
 
-      {/* Session Recording */}
-      {videoUrl && onRefreshVideoUrl && !isViewer && (
+      {/* Session Recording — hidden for now */}
+      {/* {videoUrl && onRefreshVideoUrl && !isViewer && (
         <VideoPlayer
           videoUrl={videoUrl}
           sessionId={sessionId}
           onRefresh={onRefreshVideoUrl}
         />
-      )}
+      )} */}
 
       {/* Commitments and Wins */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/components/client-portal/active-sessions-card.tsx
+++ b/src/components/client-portal/active-sessions-card.tsx
@@ -6,13 +6,13 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Radio, Clock } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/date-utils'
+import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 
 interface ActiveSession {
   session_id: string
@@ -26,14 +26,24 @@ interface ActiveSession {
 export function ActiveSessionsCard() {
   const [activeSessions, setActiveSessions] = useState<ActiveSession[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const router = useRouter()
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [])
+
   const fetchActiveSessions = useCallback(async () => {
+    // Check token validity client-side before making the request
+    if (!isTokenValid()) {
+      stopPolling()
+      return
+    }
+
     try {
       const token = localStorage.getItem('auth_token')
-      if (!token) return
-
       const apiUrl =
         process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
       const headers: Record<string, string> = {
@@ -49,10 +59,8 @@ export function ActiveSessionsCard() {
       })
 
       if (response.status === 401) {
-        // Token expired — stop polling and redirect to login
-        if (intervalRef.current) clearInterval(intervalRef.current)
-        localStorage.removeItem('auth_token')
-        router.push('/login')
+        stopPolling()
+        handleAuthExpired()
         return
       }
 
@@ -65,7 +73,7 @@ export function ActiveSessionsCard() {
     } finally {
       setIsLoading(false)
     }
-  }, [router])
+  }, [stopPolling])
 
   useEffect(() => {
     fetchActiveSessions()

--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -84,6 +84,7 @@ import { useTargets } from '@/hooks/queries/use-targets'
 import { useSprints } from '@/hooks/queries/use-sprints'
 import { toast } from 'sonner'
 import { Progress } from '@/components/ui/progress'
+import { useConfetti } from '@/hooks/use-confetti'
 
 export interface GuestContext {
   meetingToken: string
@@ -1110,6 +1111,7 @@ function MilestonesSection({
   const addMilestone = useAddMilestone(commitmentId)
   const updateMilestone = useUpdateMilestone(commitmentId)
   const deleteMilestone = useDeleteMilestone(commitmentId)
+  const { fireConfetti } = useConfetti()
 
   const milestones = commitment.milestones || []
   const completedCount = milestones.filter(m => m.status === 'completed').length
@@ -1122,11 +1124,16 @@ function MilestonesSection({
   }
 
   const toggleMilestoneStatus = (milestone: Milestone) => {
+    // Don't toggle temp milestones that haven't been saved yet
+    if (milestone.id.startsWith('temp-')) return
     const newStatus = milestone.status === 'completed' ? 'pending' : 'completed'
     updateMilestone.mutate({
       milestoneId: milestone.id,
       data: { status: newStatus },
     })
+    if (newStatus === 'completed') {
+      fireConfetti({ intensity: 'subtle' })
+    }
   }
 
   return (

--- a/src/components/sprints/sprint-kanban-board.tsx
+++ b/src/components/sprints/sprint-kanban-board.tsx
@@ -6,6 +6,7 @@ import { CommitmentService } from '@/services/commitment-service'
 import { queryKeys } from '@/lib/query-client'
 import { toast } from 'sonner'
 import type { CommitmentStatus } from '@/types/commitment'
+import { useConfetti } from '@/hooks/use-confetti'
 
 interface SprintKanbanBoardProps {
   commitments: any[]
@@ -29,6 +30,7 @@ export function SprintKanbanBoard({
   onDelete,
 }: SprintKanbanBoardProps) {
   const queryClient = useQueryClient()
+  const { fireConfetti } = useConfetti()
 
   const handleDrop = async (commitmentId: string, newStatus: string) => {
     const statusLabels: Record<string, string> = {
@@ -51,6 +53,9 @@ export function SprintKanbanBoard({
     })
 
     toast.success(`Moved to ${statusLabels[newStatus]}`)
+    if (newStatus === 'completed') {
+      fireConfetti({ intensity: 'medium' })
+    }
 
     try {
       await CommitmentService.updateCommitment(commitmentId, {

--- a/src/hooks/use-confetti.ts
+++ b/src/hooks/use-confetti.ts
@@ -1,0 +1,40 @@
+import confetti from 'canvas-confetti'
+import { useCallback } from 'react'
+
+/**
+ * Subtle confetti burst for task completion celebrations.
+ */
+export function useConfetti() {
+  const fireConfetti = useCallback(
+    (options?: { intensity?: 'subtle' | 'medium' }) => {
+      const intensity = options?.intensity ?? 'subtle'
+
+      if (intensity === 'medium') {
+        // For moving a task to "Done" column
+        confetti({
+          particleCount: 60,
+          spread: 55,
+          origin: { y: 0.65 },
+          colors: ['#10b981', '#34d399', '#6ee7b7', '#a7f3d0', '#3b82f6'],
+          ticks: 120,
+          gravity: 1.2,
+          scalar: 0.9,
+        })
+      } else {
+        // For subtask checkbox — quick small pop
+        confetti({
+          particleCount: 25,
+          spread: 40,
+          origin: { y: 0.7 },
+          colors: ['#10b981', '#34d399', '#6ee7b7'],
+          ticks: 80,
+          gravity: 1.5,
+          scalar: 0.7,
+        })
+      }
+    },
+    [],
+  )
+
+  return { fireConfetti }
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -11,14 +11,28 @@ export class ApiClient {
       const contentType = response.headers.get('content-type')
       if (contentType && contentType.includes('application/json')) {
         const errorData = await response.json()
-        errorMessage = errorData.detail || errorData.message || errorMessage
+        const detail = errorData.detail
+        if (typeof detail === 'string') {
+          errorMessage = detail
+        } else if (Array.isArray(detail)) {
+          errorMessage = detail.map((d: any) => d.msg || String(d)).join('; ')
+        } else {
+          errorMessage = errorData.message || errorMessage
+        }
       } else {
         const errorText = await response.text()
         // Try to parse as JSON if it looks like JSON
         if (errorText.startsWith('{')) {
           try {
             const errorData = JSON.parse(errorText)
-            errorMessage = errorData.detail || errorData.message || errorText
+            const det = errorData.detail
+            if (typeof det === 'string') {
+              errorMessage = det
+            } else if (Array.isArray(det)) {
+              errorMessage = det.map((d: any) => d.msg || String(d)).join('; ')
+            } else {
+              errorMessage = errorData.message || errorText
+            }
           } catch {
             errorMessage = errorText || errorMessage
           }

--- a/src/lib/axios-config.ts
+++ b/src/lib/axios-config.ts
@@ -1,5 +1,42 @@
 import axios from 'axios'
 
+/**
+ * Check if the stored JWT token is present and not expired.
+ * Used by both axios interceptor and raw fetch() callers to avoid
+ * sending requests with expired tokens (which generate 401 noise).
+ */
+export function isTokenValid(): boolean {
+  if (typeof window === 'undefined') return false
+  const token =
+    localStorage.getItem('auth_token') ||
+    localStorage.getItem('client_auth_token')
+  if (!token) return false
+  try {
+    const payload = token.split('.')[1]
+    const decoded = JSON.parse(atob(payload))
+    return decoded.exp > Date.now() / 1000
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Clear all auth data and redirect to login.
+ * Shared between axios interceptor and raw fetch() callers.
+ */
+export function handleAuthExpired() {
+  if (typeof window === 'undefined') return
+  localStorage.removeItem('auth_token')
+  localStorage.removeItem('user_roles')
+  localStorage.removeItem('client_access')
+  localStorage.removeItem('user_email')
+  localStorage.removeItem('user_full_name')
+  localStorage.removeItem('user_client_id')
+  localStorage.removeItem('client_auth_token')
+  localStorage.removeItem('client_user_data')
+  window.location.href = '/auth'
+}
+
 // Create axios instance with default config
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1',
@@ -51,22 +88,7 @@ axiosInstance.interceptors.response.use(
   response => response,
   error => {
     if (error.response?.status === 401) {
-      // NEW: Clear ALL auth data (including legacy keys)
-      localStorage.removeItem('auth_token')
-      localStorage.removeItem('user_roles')
-      localStorage.removeItem('client_access')
-      localStorage.removeItem('user_email')
-      localStorage.removeItem('user_full_name')
-      localStorage.removeItem('user_client_id')
-
-      // Also clear legacy keys
-      localStorage.removeItem('client_auth_token')
-      localStorage.removeItem('client_user_data')
-
-      // Redirect to login page
-      if (typeof window !== 'undefined') {
-        window.location.href = '/auth'
-      }
+      handleAuthExpired()
     }
     return Promise.reject(error)
   },


### PR DESCRIPTION
## Summary
- **401 fix**: Added `isTokenValid()` and `handleAuthExpired()` shared utils. Client portal pages now check JWT expiry client-side before making API calls, eliminating ~90+ daily 401 errors in Grafana
- **Confetti**: Subtle confetti celebrations on kanban task completion and subtask checkbox
- **Hide video**: Temporarily hidden video player section on session details page

## Test plan
- [ ] Verify client portal redirects to /auth when token expires (no more silent 401s)
- [ ] Verify active-sessions polling stops when token expires
- [ ] Confetti fires on kanban Done column drop and subtask check
- [ ] Video section not visible on session detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)