### PR TITLE
Add pre-session questionnaire and session scheduling UI

### DIFF
--- a/src/app/clients/[clientId]/components/client-modals.tsx
+++ b/src/app/clients/[clientId]/components/client-modals.tsx
@@ -6,6 +6,7 @@ import { TargetFormModal } from '@/components/sprints/target-form-modal'
 import { EndSprintModal } from './end-sprint-modal'
 import { CommitmentCreatePanel } from '@/components/commitments/commitment-create-panel'
 import { StartSessionModal } from './start-session-modal'
+import { ScheduleSessionModal } from '@/components/sessions/schedule-session-modal'
 import { GoalFormModal } from '@/components/goals/goal-form-modal'
 import { UnifiedCreationModal } from './unified-creation-modal'
 import { useCommitments } from '@/hooks/queries/use-commitments'
@@ -26,6 +27,8 @@ interface ClientModalsProps {
   setIsSprintModalOpen: (open: boolean) => void
   isStartSessionModalOpen: boolean
   setIsStartSessionModalOpen: (open: boolean) => void
+  isScheduleSessionModalOpen: boolean
+  setIsScheduleSessionModalOpen: (open: boolean) => void
   isGoalModalOpen: boolean
   setIsGoalModalOpen: (open: boolean) => void
   isOutcomeModalOpen: boolean
@@ -60,6 +63,8 @@ export function ClientModals({
   setIsSprintModalOpen,
   isStartSessionModalOpen,
   setIsStartSessionModalOpen,
+  isScheduleSessionModalOpen,
+  setIsScheduleSessionModalOpen,
   isGoalModalOpen,
   setIsGoalModalOpen,
   isOutcomeModalOpen,
@@ -164,6 +169,12 @@ export function ClientModals({
         onClose={() => setIsStartSessionModalOpen(false)}
         clientId={client.id}
         clientName={client.name}
+      />
+
+      <ScheduleSessionModal
+        isOpen={isScheduleSessionModalOpen}
+        onClose={() => setIsScheduleSessionModalOpen(false)}
+        preselectedClientId={client.id}
       />
 
       <GoalFormModal

--- a/src/app/clients/[clientId]/hooks/use-client-modals.ts
+++ b/src/app/clients/[clientId]/hooks/use-client-modals.ts
@@ -7,6 +7,8 @@ export function useClientModals() {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
   const [isSprintModalOpen, setIsSprintModalOpen] = useState(false)
   const [isStartSessionModalOpen, setIsStartSessionModalOpen] = useState(false)
+  const [isScheduleSessionModalOpen, setIsScheduleSessionModalOpen] =
+    useState(false)
   const [isGoalModalOpen, setIsGoalModalOpen] = useState(false)
   const [isOutcomeModalOpen, setIsOutcomeModalOpen] = useState(false)
   const [isUnifiedCreateModalOpen, setIsUnifiedCreateModalOpen] =
@@ -32,6 +34,8 @@ export function useClientModals() {
     setIsSprintModalOpen,
     isStartSessionModalOpen,
     setIsStartSessionModalOpen,
+    isScheduleSessionModalOpen,
+    setIsScheduleSessionModalOpen,
     isGoalModalOpen,
     setIsGoalModalOpen,
     isOutcomeModalOpen,

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -35,6 +35,7 @@ import {
   Loader2,
   Trash2,
   Mic,
+  CalendarClock,
   Target,
   Trophy,
   BookOpen,
@@ -423,6 +424,16 @@ export default function ClientDetailPage({
                           <Mic className="h-4 w-4 mr-2" />
                           Start Live Session
                         </Button>
+                        <Button
+                          onClick={() =>
+                            modalState.setIsScheduleSessionModalOpen(true)
+                          }
+                          variant="outline"
+                          className="border-gray-300 dark:border-gray-600"
+                        >
+                          <CalendarClock className="h-4 w-4 mr-2" />
+                          Schedule Session
+                        </Button>
                       </div>
                     )}
                   </div>
@@ -543,6 +554,10 @@ export default function ClientDetailPage({
           setIsSprintModalOpen={modalState.setIsSprintModalOpen}
           isStartSessionModalOpen={modalState.isStartSessionModalOpen}
           setIsStartSessionModalOpen={modalState.setIsStartSessionModalOpen}
+          isScheduleSessionModalOpen={modalState.isScheduleSessionModalOpen}
+          setIsScheduleSessionModalOpen={
+            modalState.setIsScheduleSessionModalOpen
+          }
           isGoalModalOpen={modalState.isGoalModalOpen}
           setIsGoalModalOpen={modalState.setIsGoalModalOpen}
           isOutcomeModalOpen={modalState.isOutcomeModalOpen}

--- a/src/app/meeting/[botId]/components/meeting-panels.tsx
+++ b/src/app/meeting/[botId]/components/meeting-panels.tsx
@@ -50,6 +50,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { MeetingResourcesPanel } from './meeting-resources-panel'
+import { PreSessionResponsesCompact } from '@/components/meeting/pre-session-responses-compact'
 import { useResources } from '@/hooks/queries/use-resources'
 import { useShareResource } from '@/hooks/mutations/use-resource-mutations'
 import { CATEGORY_COLORS } from '@/types/resource'
@@ -75,7 +76,7 @@ interface MeetingPanelsProps {
   isMeetingEnded?: boolean
 }
 
-type SidebarTab = 'transcript' | 'context' | 'resources'
+type SidebarTab = 'transcript' | 'context' | 'resources' | 'questionnaire'
 
 export default function MeetingPanels({
   transcript,
@@ -504,6 +505,18 @@ export default function MeetingPanels({
                 <BookOpen className="h-3.5 w-3.5" />
                 Resources
               </button>
+              <button
+                onClick={() => setSidebarTab('questionnaire')}
+                className={cn(
+                  'flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 flex items-center justify-center gap-1.5',
+                  sidebarTab === 'questionnaire'
+                    ? 'text-gray-900 dark:text-white border-gray-900 dark:border-white'
+                    : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300',
+                )}
+              >
+                <ClipboardList className="h-3.5 w-3.5" />
+                Q&A
+              </button>
             </div>
           </div>
 
@@ -514,6 +527,11 @@ export default function MeetingPanels({
                 transcript={recentTranscript}
                 mode="sidebar"
                 autoScroll={true}
+              />
+            ) : sidebarTab === 'questionnaire' ? (
+              <PreSessionResponsesCompact
+                sessionId={sessionId}
+                clientId={commitmentClientId || clientId}
               />
             ) : sidebarTab === 'resources' ? (
               <MeetingResourcesPanel

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,8 +16,17 @@ import StartRecording from './components/start-recording'
 import { AttentionNeeded } from './components/attention-needed'
 import ClientModal from '@/components/clients/client-modal'
 import { ManualSessionModal } from '@/components/sessions/manual-session-modal'
+import { ScheduleSessionModal } from '@/components/sessions/schedule-session-modal'
 import { StartStandaloneGroupSessionModal } from '@/components/group-session/start-standalone-group-session-modal'
-import { Eye, Plus, PlayCircle, FileText, Users } from 'lucide-react'
+import { UpcomingSessions } from '@/components/dashboard/upcoming-sessions'
+import {
+  Eye,
+  Plus,
+  PlayCircle,
+  FileText,
+  Users,
+  CalendarClock,
+} from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -31,6 +40,8 @@ export default function CoachDashboard() {
   const [isManualSessionModalOpen, setIsManualSessionModalOpen] =
     useState(false)
   const [isGroupSessionModalOpen, setIsGroupSessionModalOpen] = useState(false)
+  const [isScheduleSessionModalOpen, setIsScheduleSessionModalOpen] =
+    useState(false)
 
   // Get first name for personalized greeting
   const firstName = user?.full_name?.split(' ')[0] || 'there'
@@ -298,6 +309,9 @@ export default function CoachDashboard() {
           {/* Live Session Banner */}
           <LiveSessionBanner sessions={activeSessions} />
 
+          {/* Upcoming Scheduled Sessions */}
+          {canCreateMeeting && <UpcomingSessions />}
+
           {/* Top Section: Clients (2/3) and Start Session (1/3) */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6 lg:items-stretch">
             {/* Left: Clients (2/3 width) */}
@@ -332,6 +346,15 @@ export default function CoachDashboard() {
                       >
                         <Users className="h-4 w-4 mr-2" />
                         Start Group Session
+                      </Button>
+                      <Button
+                        onClick={() => setIsScheduleSessionModalOpen(true)}
+                        variant="outline"
+                        size="sm"
+                        className="w-full border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+                      >
+                        <CalendarClock className="h-4 w-4 mr-2" />
+                        Schedule Session
                       </Button>
                       <Button
                         onClick={() => setIsManualSessionModalOpen(true)}
@@ -376,6 +399,12 @@ export default function CoachDashboard() {
         <ManualSessionModal
           isOpen={isManualSessionModalOpen}
           onClose={() => setIsManualSessionModalOpen(false)}
+        />
+
+        {/* Schedule Session Modal */}
+        <ScheduleSessionModal
+          isOpen={isScheduleSessionModalOpen}
+          onClose={() => setIsScheduleSessionModalOpen(false)}
         />
 
         {/* Group Session Modal */}

--- a/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { format } from 'date-fns'
+import { CheckCircle2 } from 'lucide-react'
+import Image from 'next/image'
+
+interface QuestionnaireCompleteProps {
+  clientName: string
+  coachName: string
+  scheduledFor: string | null
+}
+
+export function QuestionnaireComplete({
+  clientName,
+  coachName,
+  scheduledFor,
+}: QuestionnaireCompleteProps) {
+  const [showCheck, setShowCheck] = useState(false)
+  const [showText, setShowText] = useState(false)
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setShowCheck(true), 200)
+    const t2 = setTimeout(() => setShowText(true), 600)
+    return () => {
+      clearTimeout(t1)
+      clearTimeout(t2)
+    }
+  }, [])
+
+  const dateInfo = scheduledFor
+    ? format(new Date(scheduledFor), "EEEE, MMMM d 'at' h:mm a")
+    : null
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 via-white to-gray-100">
+      {/* Logo */}
+      <div className="pt-8 px-6 flex justify-center">
+        <Image
+          src="/novus-global-logo.webp"
+          alt="Novus Global"
+          width={120}
+          height={40}
+          className="opacity-80"
+          priority
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="text-center max-w-lg">
+          {/* Animated Checkmark */}
+          <div
+            className={`transition-all duration-500 ease-out ${
+              showCheck ? 'opacity-100 scale-100' : 'opacity-0 scale-75'
+            }`}
+          >
+            <div className="w-20 h-20 bg-gray-900 rounded-full flex items-center justify-center mx-auto mb-8">
+              <CheckCircle2 className="h-10 w-10 text-white" />
+            </div>
+          </div>
+
+          {/* Text */}
+          <div
+            className={`transition-all duration-500 ease-out delay-200 ${
+              showText ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+            }`}
+          >
+            <h1 className="text-3xl font-light text-gray-900 mb-4">
+              Thank you, {clientName}!
+            </h1>
+            <p className="text-gray-500 text-lg leading-relaxed mb-6">
+              Your responses have been shared with {coachName}.
+              {dateInfo && (
+                <>
+                  <br />
+                  <span className="text-gray-400">See you on {dateInfo}.</span>
+                </>
+              )}
+            </p>
+            <p className="text-sm text-gray-300">You can close this tab now.</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="pb-6 text-center">
+        <p className="text-xs text-gray-300">Powered by Novus Global</p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import { ArrowLeft, ArrowRight, Check, Loader2 } from 'lucide-react'
+import Image from 'next/image'
+import { toast } from 'sonner'
+import { QuestionnaireService } from '@/services/questionnaire-service'
+import type {
+  QuestionItem,
+  QuestionnaireAnswerItem,
+} from '@/types/questionnaire'
+
+interface QuestionnaireFlowProps {
+  token: string
+  questions: QuestionItem[]
+  existingAnswers: QuestionnaireAnswerItem[]
+  clientName: string
+  coachName: string
+  onComplete: () => void
+}
+
+function getStorageKey(token: string) {
+  return `questionnaire_answers_${token}`
+}
+
+function loadFromStorage(token: string): Record<number, string> {
+  try {
+    const raw = localStorage.getItem(getStorageKey(token))
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveToStorage(token: string, answers: Record<number, string>) {
+  try {
+    localStorage.setItem(getStorageKey(token), JSON.stringify(answers))
+  } catch {
+    // Storage full or unavailable — continue without persistence
+  }
+}
+
+function clearStorage(token: string) {
+  try {
+    localStorage.removeItem(getStorageKey(token))
+  } catch {
+    // Ignore
+  }
+}
+
+export function QuestionnaireFlow({
+  token,
+  questions,
+  existingAnswers,
+  onComplete,
+}: QuestionnaireFlowProps) {
+  const [answers, setAnswers] = useState<Record<number, string>>(() => {
+    // Priority: localStorage > existingAnswers from API
+    const stored = loadFromStorage(token)
+    if (Object.keys(stored).length > 0) return stored
+
+    const initial: Record<number, string> = {}
+    existingAnswers.forEach(a => {
+      initial[a.question_index] = a.answer
+    })
+    return initial
+  })
+  const [currentIndex, setCurrentIndex] = useState(() => {
+    // Resume at the first unanswered question
+    const stored = loadFromStorage(token)
+    const answeredKeys =
+      Object.keys(stored).length > 0
+        ? stored
+        : existingAnswers.reduce<Record<number, string>>((acc, a) => {
+            acc[a.question_index] = a.answer
+            return acc
+          }, {})
+
+    for (let i = 0; i < questions.length; i++) {
+      if (!answeredKeys[i] || !String(answeredKeys[i]).trim()) return i
+    }
+    // All answered — go to last question so user can review/submit
+    return Object.keys(answeredKeys).length > 0 ? questions.length - 1 : 0
+  })
+  const [direction, setDirection] = useState<'forward' | 'backward'>('forward')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isAnimating, setIsAnimating] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const currentQuestion = questions[currentIndex]
+  const currentAnswer = answers[currentIndex] || ''
+  const isFirst = currentIndex === 0
+  const isLast = currentIndex === questions.length - 1
+  const progress = ((currentIndex + 1) / questions.length) * 100
+
+  // Auto-focus textarea
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      textareaRef.current?.focus()
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [currentIndex])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${Math.max(120, textarea.scrollHeight)}px`
+    }
+  }, [currentAnswer])
+
+  const updateAnswer = (value: string) => {
+    const updated = { ...answers, [currentIndex]: value }
+    setAnswers(updated)
+    saveToStorage(token, updated)
+  }
+
+  const goNext = async () => {
+    if (isAnimating) return
+
+    if (isLast) {
+      // Submit all answers in one API call
+      setIsSubmitting(true)
+      try {
+        const allAnswers = questions
+          .map(q => ({
+            question_index: q.index,
+            answer: (answers[q.index] || '').trim(),
+          }))
+          .filter(a => a.answer.length > 0)
+
+        await QuestionnaireService.submitAll(token, allAnswers)
+        clearStorage(token)
+        onComplete()
+      } catch {
+        toast.error('Failed to submit. Please try again.')
+        setIsSubmitting(false)
+      }
+      return
+    }
+
+    // Instant navigation — no API call
+    setDirection('forward')
+    setIsAnimating(true)
+    setTimeout(() => {
+      setCurrentIndex(prev => prev + 1)
+      setIsAnimating(false)
+    }, 300)
+  }
+
+  const goBack = () => {
+    if (isFirst || isAnimating) return
+
+    setDirection('backward')
+    setIsAnimating(true)
+    setTimeout(() => {
+      setCurrentIndex(prev => prev - 1)
+      setIsAnimating(false)
+    }, 300)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      goNext()
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 via-white to-gray-100">
+      {/* Progress Bar */}
+      <div className="fixed top-0 left-0 right-0 z-50">
+        <div className="h-1 bg-gray-100">
+          <div
+            className="h-full bg-gray-900 transition-all duration-500 ease-out"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Header with Novus Logo */}
+      <div className="pt-8 px-6 flex flex-col items-center gap-3">
+        <Image
+          src="/novus-global-logo.webp"
+          alt="Novus Global"
+          width={120}
+          height={40}
+          className="opacity-80"
+          priority
+        />
+        <p className="text-xs uppercase tracking-widest text-gray-400 font-medium">
+          Pre-Session Questionnaire
+        </p>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex-1 flex items-center justify-center px-6 py-12">
+        <div className="w-full max-w-2xl">
+          {/* Question (counter + text + input all animate together) */}
+          <div
+            className={`transition-all duration-300 ease-out ${
+              isAnimating
+                ? direction === 'forward'
+                  ? '-translate-y-4 opacity-0'
+                  : 'translate-y-4 opacity-0'
+                : 'translate-y-0 opacity-100'
+            }`}
+          >
+            {/* Question Counter */}
+            <div className="mb-8">
+              <span className="text-sm text-gray-400 font-medium">
+                {currentIndex + 1}{' '}
+                <span className="text-gray-300">/ {questions.length}</span>
+              </span>
+            </div>
+
+            <h2 className="text-2xl sm:text-3xl font-light text-gray-900 leading-relaxed mb-8">
+              {currentQuestion?.text}
+            </h2>
+
+            {/* Answer Input */}
+            <textarea
+              ref={textareaRef}
+              value={currentAnswer}
+              onChange={e => updateAnswer(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isSubmitting}
+              placeholder="Type your answer here..."
+              className="w-full bg-transparent border-0 border-b-2 border-gray-200 focus:border-gray-900 text-lg text-gray-800 placeholder-gray-300 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
+              rows={3}
+            />
+          </div>
+
+          {/* Navigation */}
+          <div className="flex items-center justify-between mt-12">
+            <button
+              onClick={goBack}
+              disabled={isFirst || isAnimating}
+              className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-all ${
+                isFirst
+                  ? 'text-gray-300 cursor-not-allowed'
+                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+              }`}
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </button>
+
+            <button
+              onClick={goNext}
+              disabled={!currentAnswer.trim() || isAnimating || isSubmitting}
+              className={`flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded-lg transition-all ${
+                currentAnswer.trim()
+                  ? 'bg-gray-900 text-white hover:bg-gray-800 shadow-sm'
+                  : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              <span
+                className={isSubmitting ? 'flex items-center gap-2' : 'hidden'}
+              >
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Submitting...
+              </span>
+              <span
+                className={
+                  !isSubmitting && isLast ? 'flex items-center gap-2' : 'hidden'
+                }
+              >
+                Complete
+                <Check className="h-4 w-4" />
+              </span>
+              <span
+                className={
+                  !isSubmitting && !isLast
+                    ? 'flex items-center gap-2'
+                    : 'hidden'
+                }
+              >
+                Next
+                <ArrowRight className="h-4 w-4" />
+              </span>
+            </button>
+          </div>
+
+          {/* Keyboard hint */}
+          <p className="text-center text-xs text-gray-300 mt-8">
+            Press{' '}
+            <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
+              ⌘
+            </kbd>{' '}
+            +{' '}
+            <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
+              Enter
+            </kbd>{' '}
+            to continue
+          </p>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="pb-6 text-center">
+        <p className="text-xs text-gray-300">Powered by Novus Global</p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/questionnaire/[token]/layout.tsx
+++ b/src/app/questionnaire/[token]/layout.tsx
@@ -1,0 +1,27 @@
+/**
+ * Questionnaire Layout
+ * Simple layout for the public questionnaire page (no authentication required)
+ */
+
+import { Toaster } from 'sonner'
+import { ThemeProvider } from '@/components/providers/theme-provider'
+
+export default function QuestionnaireLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="light"
+      enableSystem={false}
+      storageKey="questionnaire-theme"
+    >
+      <div className="min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-100">
+        {children}
+        <Toaster position="top-center" richColors />
+      </div>
+    </ThemeProvider>
+  )
+}

--- a/src/app/questionnaire/[token]/page.tsx
+++ b/src/app/questionnaire/[token]/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { Loader2, AlertCircle } from 'lucide-react'
+import { QuestionnaireService } from '@/services/questionnaire-service'
+import type { QuestionnaireValidation } from '@/types/questionnaire'
+import { QuestionnaireFlow } from './components/questionnaire-flow'
+import { QuestionnaireComplete } from './components/questionnaire-complete'
+
+type PageState = 'loading' | 'error' | 'active' | 'complete'
+
+export default function QuestionnairePage() {
+  const params = useParams()
+  const token = params.token as string
+
+  const [state, setState] = useState<PageState>('loading')
+  const [data, setData] = useState<QuestionnaireValidation | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    const validate = async () => {
+      try {
+        const result = await QuestionnaireService.validateToken(token)
+        setData(result)
+        setState('active')
+      } catch {
+        setErrorMessage(
+          'This questionnaire link is invalid or has expired. Please contact your coach for a new link.',
+        )
+        setState('error')
+      }
+    }
+    validate()
+  }, [token])
+
+  if (state === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="h-8 w-8 animate-spin text-gray-400 mx-auto mb-4" />
+          <p className="text-gray-500 text-sm">Loading questionnaire...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="text-center max-w-md">
+          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-6">
+            <AlertCircle className="h-8 w-8 text-gray-400" />
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900 mb-3">
+            Questionnaire Unavailable
+          </h1>
+          <p className="text-gray-500 leading-relaxed">{errorMessage}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'complete' && data) {
+    return (
+      <QuestionnaireComplete
+        clientName={data.client_name}
+        coachName={data.coach_name}
+        scheduledFor={data.scheduled_for}
+      />
+    )
+  }
+
+  if (state === 'active' && data) {
+    return (
+      <QuestionnaireFlow
+        token={token}
+        questions={data.questions}
+        existingAnswers={data.existing_answers}
+        clientName={data.client_name}
+        coachName={data.coach_name}
+        onComplete={() => setState('complete')}
+      />
+    )
+  }
+
+  return null
+}

--- a/src/app/sessions/[sessionId]/components/pre-session-responses.tsx
+++ b/src/app/sessions/[sessionId]/components/pre-session-responses.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { ClipboardList, CheckCircle2, Clock } from 'lucide-react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { useQuestionnaireResponses } from '@/hooks/queries/use-questionnaire'
+import { format } from 'date-fns'
+
+interface PreSessionResponsesProps {
+  sessionId: string
+  clientId?: string
+}
+
+export function PreSessionResponses({
+  sessionId,
+  clientId,
+}: PreSessionResponsesProps) {
+  const { data: responses, isLoading } = useQuestionnaireResponses(
+    sessionId,
+    clientId,
+  )
+
+  if (isLoading || !responses || responses.length === 0) return null
+
+  const response = responses[0]
+  const isCompleted = response.status === 'completed'
+
+  return (
+    <Card className="border-app-border shadow-sm">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ClipboardList className="h-4 w-4 text-app-secondary" />
+            <h3 className="text-sm font-semibold text-app-primary">
+              Pre-Session Questionnaire
+            </h3>
+          </div>
+          {isCompleted ? (
+            <Badge
+              variant="secondary"
+              className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-xs"
+            >
+              <CheckCircle2 className="h-3 w-3 mr-1" />
+              Completed
+              {response.completed_at &&
+                ` ${format(new Date(response.completed_at), 'MMM d')}`}
+            </Badge>
+          ) : (
+            <Badge
+              variant="secondary"
+              className="bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800 text-xs"
+            >
+              <Clock className="h-3 w-3 mr-1" />
+              In Progress
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="space-y-4">
+          {response.responses.map((qa, idx) => (
+            <div key={idx}>
+              <p className="text-xs font-medium text-app-secondary uppercase tracking-wider mb-1.5">
+                {qa.question_text}
+              </p>
+              <p className="text-sm text-app-primary leading-relaxed pl-0">
+                {qa.answer}
+              </p>
+              {idx < response.responses.length - 1 && (
+                <div className="border-b border-app-border mt-4" />
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -28,6 +28,7 @@ import { GroupAggregatedCommitments } from './group-aggregated-commitments'
 import { SessionNotesCompact } from './session-notes-compact'
 import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
+import { PreSessionResponses } from './pre-session-responses'
 import TranscriptViewer from './transcript-viewer'
 // import { VideoPlayer } from '@/components/sessions/video-player'
 
@@ -137,6 +138,9 @@ export function SessionOverviewTab({
 
   return (
     <div className="space-y-6">
+      {/* Pre-Session Questionnaire Responses */}
+      <PreSessionResponses sessionId={sessionId} clientId={clientId} />
+
       {/* Per-Client Analysis Pending State */}
       {isGroupSession && selectedClientId && !clientAnalysis && (
         <Card className="border-dashed border-2 border-app-border">

--- a/src/app/sessions/[sessionId]/components/start-bot-card.tsx
+++ b/src/app/sessions/[sessionId]/components/start-bot-card.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { format } from 'date-fns'
+import {
+  Play,
+  Link2,
+  CalendarClock,
+  Upload,
+  Loader2,
+  Bot,
+  Send,
+} from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useStartSessionBot } from '@/hooks/mutations/use-questionnaire-mutations'
+import { useSendQuestionnaire } from '@/hooks/mutations/use-questionnaire-mutations'
+import { useQuestionnaireResponses } from '@/hooks/queries/use-questionnaire'
+import { toast } from '@/hooks/use-toast'
+
+interface StartBotCardProps {
+  sessionId: string
+  clientId?: string
+  clientName?: string
+  scheduledFor?: string | null
+  meetingUrl?: string | null
+  questionnaireSent?: boolean
+  onShowUploader: () => void
+}
+
+export function StartBotCard({
+  sessionId,
+  clientId,
+  clientName,
+  scheduledFor,
+  meetingUrl: initialMeetingUrl,
+  questionnaireSent,
+  onShowUploader,
+}: StartBotCardProps) {
+  const router = useRouter()
+  const startBot = useStartSessionBot()
+  const sendQuestionnaire = useSendQuestionnaire()
+  const { data: responses } = useQuestionnaireResponses(sessionId)
+  const [meetingUrl, setMeetingUrl] = useState(initialMeetingUrl || '')
+  const [botName, setBotName] = useState('Coach Sidekick')
+
+  const hasResponses =
+    responses && responses.length > 0 && responses[0].responses.length > 0
+  const showSendButton = !hasResponses && clientId
+
+  const handleStartBot = async () => {
+    if (!meetingUrl.trim()) {
+      toast({
+        title: 'Meeting URL required',
+        description: 'Please enter a meeting URL to start the bot.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    try {
+      const result = await startBot.mutateAsync({
+        sessionId,
+        meetingUrl: meetingUrl.trim(),
+        botName: botName || undefined,
+      })
+
+      toast({
+        title: 'Bot started',
+        description: 'Redirecting to the live meeting page...',
+      })
+
+      setTimeout(() => {
+        router.push(`/meeting/${result.id}`)
+      }, 500)
+    } catch {
+      // Error handled by mutation hook
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-4">
+      {/* Session Info */}
+      <Card className="border-app-border shadow-sm">
+        <CardContent className="p-8 text-center">
+          <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-2xl flex items-center justify-center mx-auto mb-6">
+            <Bot className="h-8 w-8 text-gray-500" />
+          </div>
+
+          <h2 className="text-xl font-semibold text-app-primary mb-2">
+            Ready to Start
+          </h2>
+
+          {clientName && (
+            <p className="text-app-secondary mb-1">
+              Session with{' '}
+              <span className="font-medium text-app-primary">{clientName}</span>
+            </p>
+          )}
+
+          {scheduledFor && (
+            <div className="flex items-center justify-center gap-1.5 text-sm text-app-secondary mb-6">
+              <CalendarClock className="h-4 w-4" />
+              {format(new Date(scheduledFor), "EEEE, MMMM d 'at' h:mm a")}
+            </div>
+          )}
+
+          {/* Send Questionnaire */}
+          {showSendButton && (
+            <div className="mt-6">
+              <Button
+                variant="outline"
+                onClick={() =>
+                  sendQuestionnaire.mutate({
+                    sessionId,
+                    clientId: clientId!,
+                  })
+                }
+                disabled={sendQuestionnaire.isPending}
+                className="border-gray-300 dark:border-gray-600"
+              >
+                {sendQuestionnaire.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4 mr-2" />
+                    {questionnaireSent
+                      ? 'Resend Questionnaire'
+                      : 'Send Pre-Session Questionnaire'}
+                  </>
+                )}
+              </Button>
+            </div>
+          )}
+
+          {/* Meeting URL */}
+          <div className="text-left space-y-4 mt-6">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">
+                Meeting URL <span className="text-red-500">*</span>
+              </Label>
+              <div className="relative">
+                <Link2 className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Input
+                  value={meetingUrl}
+                  onChange={e => setMeetingUrl(e.target.value)}
+                  placeholder="https://zoom.us/j/... or https://meet.google.com/..."
+                  className="pl-10"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">
+                Bot Name{' '}
+                <span className="text-muted-foreground font-normal">
+                  (Optional)
+                </span>
+              </Label>
+              <Input
+                value={botName}
+                onChange={e => setBotName(e.target.value)}
+                placeholder="Coach Sidekick"
+              />
+            </div>
+          </div>
+
+          {/* Start Button */}
+          <Button
+            onClick={handleStartBot}
+            disabled={!meetingUrl.trim() || startBot.isPending}
+            size="lg"
+            className="w-full mt-6 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 h-12 text-base"
+          >
+            {startBot.isPending ? (
+              <>
+                <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+                Starting Bot...
+              </>
+            ) : (
+              <>
+                <Play className="h-5 w-5 mr-2" />
+                Start Bot & Join Meeting
+              </>
+            )}
+          </Button>
+
+          {/* Upload alternative */}
+          <div className="mt-4 pt-4 border-t border-app-border">
+            <button
+              onClick={onShowUploader}
+              className="text-sm text-app-secondary hover:text-app-primary transition-colors flex items-center justify-center gap-1.5 mx-auto"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              Or upload a past recording instead
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -35,6 +35,8 @@ import {
   type FullAnalysisResponse,
 } from '@/services/analysis-service'
 import { SessionService } from '@/services/session-service'
+import { StartBotCard } from './components/start-bot-card'
+import { PreSessionResponses } from './components/pre-session-responses'
 import { CommitmentCreatePanel } from '@/components/commitments/commitment-create-panel'
 import { CommitmentDetailPanel } from '@/components/commitments/commitment-detail-panel'
 import { toast } from '@/hooks/use-toast'
@@ -166,6 +168,8 @@ export default function SessionDetailsPage({
   // UI state
   const [showQuickNote, setShowQuickNote] = useState(false)
   const [activeTab, setActiveTab] = useState('overview')
+  const [showUploaderForScheduled, setShowUploaderForScheduled] =
+    useState(false)
 
   // Auto-trigger analysis
   React.useEffect(() => {
@@ -446,7 +450,15 @@ export default function SessionDetailsPage({
       meeting_summary.total_transcript_entries > 0)
   const isPendingUpload = session.status === 'pending_upload'
   const isProcessing = session.transcription_status === 'processing'
-  const needsUpload = (isPendingUpload || !transcriptsExist) && !isProcessing
+  // A session is "scheduled" (show StartBotCard) if:
+  // - status is explicitly "scheduled", OR
+  // - it was originally scheduled (has scheduled_for) and has no transcripts yet
+  //   (covers the case where a previous bot was kicked/failed)
+  const isScheduled =
+    session.status === 'scheduled' ||
+    (session.scheduled_for && !transcriptsExist && !isProcessing)
+  const needsUpload =
+    (isPendingUpload || !transcriptsExist) && !isProcessing && !isScheduled
 
   return (
     <ProtectedRoute loadingMessage="Loading session details...">
@@ -490,8 +502,52 @@ export default function SessionDetailsPage({
 
           {/* Main Content */}
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            {/* Upload Required State */}
-            {needsUpload && !isViewer ? (
+            {/* Scheduled Session State */}
+            {isScheduled && !showUploaderForScheduled ? (
+              <div className="space-y-6">
+                {/* Pre-Session Responses */}
+                <PreSessionResponses
+                  sessionId={session.id}
+                  clientId={clientId}
+                />
+
+                {/* Quick Note */}
+                {!isViewer && <QuickNote sessionId={session.id} />}
+
+                {/* Start Bot Card */}
+                {!isViewer && (
+                  <StartBotCard
+                    sessionId={session.id}
+                    clientId={clientId}
+                    clientName={session.client_name || session.client?.name}
+                    scheduledFor={session.scheduled_for}
+                    meetingUrl={session.meeting_url}
+                    questionnaireSent={session.questionnaire_sent}
+                    onShowUploader={() => setShowUploaderForScheduled(true)}
+                  />
+                )}
+              </div>
+            ) : isScheduled && showUploaderForScheduled ? (
+              <div className="max-w-2xl mx-auto space-y-4">
+                <button
+                  onClick={() => setShowUploaderForScheduled(false)}
+                  className="text-sm text-app-secondary hover:text-app-primary transition-colors mb-2"
+                >
+                  &larr; Back to session
+                </button>
+                <MediaUploader
+                  sessionId={session.id}
+                  sessionTitle={session.title}
+                  onUploadComplete={() => {
+                    queryClient.invalidateQueries({
+                      queryKey: queryKeys.sessions.detail(
+                        resolvedParams.sessionId,
+                      ),
+                    })
+                  }}
+                />
+              </div>
+            ) : needsUpload && !isViewer ? (
               <div className="max-w-2xl mx-auto">
                 <MediaUploader
                   sessionId={session.id}

--- a/src/components/dashboard/upcoming-sessions.tsx
+++ b/src/components/dashboard/upcoming-sessions.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { format, formatDistanceToNow, isPast } from 'date-fns'
+import {
+  CalendarClock,
+  Play,
+  Send,
+  CheckCircle2,
+  Clock,
+  Mail,
+} from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { useUpcomingSessions } from '@/hooks/queries/use-questionnaire'
+import { useSendQuestionnaire } from '@/hooks/mutations/use-questionnaire-mutations'
+
+export function UpcomingSessions() {
+  const router = useRouter()
+  const { data: sessions, isLoading } = useUpcomingSessions()
+  const sendQuestionnaire = useSendQuestionnaire()
+
+  if (isLoading || !sessions || sessions.length === 0) return null
+
+  return (
+    <Card className="border-gray-200 dark:border-gray-700 mb-6">
+      <CardHeader className="border-b border-gray-200 dark:border-gray-700 pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <CalendarClock className="h-4 w-4 text-gray-500" />
+            <CardTitle className="text-base font-semibold">
+              Upcoming Sessions
+            </CardTitle>
+            <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5">
+              {sessions.length}
+            </Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-0 divide-y divide-gray-100 dark:divide-gray-800">
+        {sessions.map(session => {
+          const scheduledDate = session.scheduled_for
+            ? new Date(session.scheduled_for)
+            : null
+          const isOverdue = scheduledDate ? isPast(scheduledDate) : false
+
+          return (
+            <div
+              key={session.id}
+              className="flex items-center justify-between px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
+              onClick={() => router.push(`/sessions/${session.id}`)}
+            >
+              {/* Left: Client + Time */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    {session.client_name || 'Unknown Client'}
+                  </span>
+                  {session.title && (
+                    <span className="text-xs text-gray-500 dark:text-gray-400 truncate hidden sm:inline">
+                      {session.title}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  <Clock className="h-3 w-3 text-gray-400" />
+                  <span
+                    className={`text-xs ${isOverdue ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'}`}
+                  >
+                    {scheduledDate
+                      ? `${format(scheduledDate, 'MMM d, h:mm a')} (${formatDistanceToNow(scheduledDate, { addSuffix: true })})`
+                      : 'No date set'}
+                  </span>
+                </div>
+              </div>
+
+              {/* Center: Questionnaire Status */}
+              <div className="flex items-center gap-2 mx-4">
+                {session.questionnaire_completed ? (
+                  <Badge
+                    variant="secondary"
+                    className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800"
+                  >
+                    <CheckCircle2 className="h-3 w-3 mr-1" />
+                    Answered
+                  </Badge>
+                ) : session.questionnaire_sent ? (
+                  <Badge
+                    variant="secondary"
+                    className="bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800"
+                  >
+                    <Mail className="h-3 w-3 mr-1" />
+                    Sent
+                  </Badge>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs text-gray-500 hover:text-gray-700"
+                    onClick={e => {
+                      e.stopPropagation()
+                      if (session.client_id) {
+                        sendQuestionnaire.mutate({
+                          sessionId: session.id,
+                          clientId: session.client_id,
+                        })
+                      }
+                    }}
+                    disabled={sendQuestionnaire.isPending}
+                  >
+                    <Send className="h-3 w-3 mr-1" />
+                    Send Q&A
+                  </Button>
+                )}
+              </div>
+
+              {/* Right: View Button */}
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 text-xs shrink-0"
+                onClick={e => {
+                  e.stopPropagation()
+                  router.push(`/sessions/${session.id}`)
+                }}
+              >
+                <Play className="h-3 w-3 mr-1" />
+                Open
+              </Button>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/meeting/pre-session-responses-compact.tsx
+++ b/src/components/meeting/pre-session-responses-compact.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import { ClipboardList, ChevronDown, ChevronUp } from 'lucide-react'
+import { useQuestionnaireResponses } from '@/hooks/queries/use-questionnaire'
+
+interface PreSessionResponsesCompactProps {
+  sessionId: string | undefined
+  clientId: string | undefined
+}
+
+export function PreSessionResponsesCompact({
+  sessionId,
+  clientId,
+}: PreSessionResponsesCompactProps) {
+  const { data: responses, isLoading } = useQuestionnaireResponses(
+    sessionId,
+    clientId,
+  )
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-3">
+        {[0, 1, 2].map(i => (
+          <div key={i} className="animate-pulse space-y-1.5">
+            <div className="h-2.5 bg-gray-200 dark:bg-gray-600 rounded w-3/4" />
+            <div className="h-2.5 bg-gray-200 dark:bg-gray-600 rounded w-1/2" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (!responses || responses.length === 0) {
+    return (
+      <div className="p-6 text-center">
+        <div className="w-10 h-10 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center mx-auto mb-3">
+          <ClipboardList className="h-5 w-5 text-gray-400" />
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          No pre-session responses for this session
+        </p>
+      </div>
+    )
+  }
+
+  const response = responses[0]
+
+  return (
+    <div className="p-3 space-y-2.5 overflow-y-auto h-full">
+      {response.responses.map((qa, idx) => {
+        const isExpanded = expandedIndex === idx
+        const isLong = qa.answer.length > 120
+        const displayAnswer =
+          isLong && !isExpanded ? qa.answer.slice(0, 120) + '...' : qa.answer
+
+        // Shorten question for compact display
+        const shortQuestion =
+          qa.question_text.length > 60
+            ? qa.question_text.slice(0, 60) + '...'
+            : qa.question_text
+
+        return (
+          <div
+            key={idx}
+            className="p-2.5 rounded-lg bg-gray-50 dark:bg-gray-700/50"
+          >
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">
+              {shortQuestion}
+            </p>
+            <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed">
+              {displayAnswer}
+            </p>
+            {isLong && (
+              <button
+                onClick={() => setExpandedIndex(isExpanded ? null : idx)}
+                className="flex items-center gap-0.5 text-[10px] text-gray-400 hover:text-gray-600 mt-1 transition-colors"
+              >
+                {isExpanded ? (
+                  <>
+                    Show less <ChevronUp className="h-2.5 w-2.5" />
+                  </>
+                ) : (
+                  <>
+                    Show more <ChevronDown className="h-2.5 w-2.5" />
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/sessions/schedule-session-modal.tsx
+++ b/src/components/sessions/schedule-session-modal.tsx
@@ -1,0 +1,387 @@
+'use client'
+
+import React, { useState, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  format,
+  addDays,
+  isToday,
+  isTomorrow,
+  startOfDay,
+  isSameDay,
+} from 'date-fns'
+import { CalendarIcon, Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Calendar } from '@/components/ui/calendar'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+import { useClientsSimple } from '@/hooks/queries/use-clients'
+import { useScheduleSession } from '@/hooks/mutations/use-questionnaire-mutations'
+
+interface ScheduleSessionModalProps {
+  isOpen: boolean
+  onClose: () => void
+  preselectedClientId?: string
+}
+
+// Quick-pick date options
+function getQuickDates() {
+  const today = startOfDay(new Date())
+  return [
+    { label: 'Today', date: today },
+    { label: 'Tomorrow', date: addDays(today, 1) },
+    { label: format(addDays(today, 2), 'EEE, MMM d'), date: addDays(today, 2) },
+    { label: format(addDays(today, 3), 'EEE, MMM d'), date: addDays(today, 3) },
+    {
+      label: `Next ${format(addDays(today, 7), 'EEEE')}`,
+      date: addDays(today, 7),
+    },
+  ]
+}
+
+function formatDateLabel(date: Date | undefined) {
+  if (!date) return 'Pick a date'
+  if (isToday(date)) return `Today, ${format(date, 'MMM d')}`
+  if (isTomorrow(date)) return `Tomorrow, ${format(date, 'MMM d')}`
+  return format(date, 'EEE, MMM d, yyyy')
+}
+
+const HOURS = Array.from({ length: 12 }, (_, i) => i + 1)
+const MINUTES = ['00', '15', '30', '45']
+
+export function ScheduleSessionModal({
+  isOpen,
+  onClose,
+  preselectedClientId,
+}: ScheduleSessionModalProps) {
+  const router = useRouter()
+  const { data: clientsData, isLoading: loadingClients } = useClientsSimple()
+  const clients = clientsData?.clients || []
+  const scheduleSession = useScheduleSession()
+
+  const [clientId, setClientId] = useState(preselectedClientId || '')
+  const [sessionDate, setSessionDate] = useState<Date | undefined>(undefined)
+  const [hour, setHour] = useState('10')
+  const [minute, setMinute] = useState('00')
+  const [period, setPeriod] = useState<'AM' | 'PM'>('AM')
+  const [title, setTitle] = useState('')
+  const [meetingUrl, setMeetingUrl] = useState('')
+  const [sendQuestionnaire, setSendQuestionnaire] = useState(true)
+  const [calendarOpen, setCalendarOpen] = useState(false)
+
+  const quickDates = useMemo(() => getQuickDates(), [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!clientId || !sessionDate) return
+
+    // Convert 12h to 24h
+    let h = parseInt(hour)
+    if (period === 'AM' && h === 12) h = 0
+    if (period === 'PM' && h !== 12) h += 12
+
+    const scheduledFor = new Date(sessionDate)
+    scheduledFor.setHours(h, parseInt(minute), 0, 0)
+
+    const result = await scheduleSession.mutateAsync({
+      client_id: clientId,
+      scheduled_for: scheduledFor.toISOString(),
+      title: title || undefined,
+      meeting_url: meetingUrl || undefined,
+      send_questionnaire: sendQuestionnaire,
+    })
+
+    onClose()
+    router.push(`/sessions/${result.id}`)
+  }
+
+  const handleClose = () => {
+    setClientId(preselectedClientId || '')
+    setSessionDate(undefined)
+    setHour('10')
+    setMinute('00')
+    setPeriod('AM')
+    setTitle('')
+    setMeetingUrl('')
+    setSendQuestionnaire(true)
+    onClose()
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="text-xl">Schedule Session</DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            Schedule an upcoming session and send a pre-session questionnaire to
+            your client
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-5 mt-4">
+          {/* Client Selection */}
+          {!preselectedClientId && (
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">
+                Client <span className="text-red-500">*</span>
+              </Label>
+              {loadingClients ? (
+                <div className="flex items-center justify-center p-3 border rounded-md">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                </div>
+              ) : (
+                <Select value={clientId} onValueChange={setClientId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a client" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {clients.map(client => (
+                      <SelectItem key={client.id} value={client.id}>
+                        {client.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+          )}
+
+          {/* Date Selection */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              Date <span className="text-red-500">*</span>
+            </Label>
+
+            {/* Quick date pills */}
+            <div className="flex flex-wrap gap-1.5">
+              {quickDates.map(qd => (
+                <button
+                  key={qd.label}
+                  type="button"
+                  onClick={() => setSessionDate(qd.date)}
+                  className={cn(
+                    'px-3 py-1.5 text-xs font-medium rounded-full border transition-all',
+                    sessionDate && isSameDay(sessionDate, qd.date)
+                      ? 'bg-gray-900 text-white border-gray-900 dark:bg-white dark:text-gray-900 dark:border-white'
+                      : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400 hover:text-gray-900 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700 dark:hover:border-gray-500',
+                  )}
+                >
+                  {qd.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Calendar picker */}
+            <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className={cn(
+                    'w-full justify-start text-left font-normal',
+                    !sessionDate && 'text-muted-foreground',
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {formatDateLabel(sessionDate)}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={sessionDate}
+                  onSelect={date => {
+                    setSessionDate(date)
+                    setCalendarOpen(false)
+                  }}
+                  disabled={date => date < startOfDay(new Date())}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          {/* Time Selection */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Time</Label>
+            <div className="flex items-center gap-2">
+              {/* Hour */}
+              <Select value={hour} onValueChange={setHour}>
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <ScrollArea className="h-[200px]">
+                    {HOURS.map(h => (
+                      <SelectItem key={h} value={String(h)}>
+                        {String(h).padStart(2, '0')}
+                      </SelectItem>
+                    ))}
+                  </ScrollArea>
+                </SelectContent>
+              </Select>
+
+              <span className="text-lg font-medium text-muted-foreground">
+                :
+              </span>
+
+              {/* Minute */}
+              <Select value={minute} onValueChange={setMinute}>
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MINUTES.map(m => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* AM/PM toggle */}
+              <div className="flex rounded-lg border border-input overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setPeriod('AM')}
+                  className={cn(
+                    'px-3 py-2 text-sm font-medium transition-colors',
+                    period === 'AM'
+                      ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                      : 'bg-white text-gray-500 hover:text-gray-900 dark:bg-gray-800 dark:text-gray-400',
+                  )}
+                >
+                  AM
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPeriod('PM')}
+                  className={cn(
+                    'px-3 py-2 text-sm font-medium transition-colors',
+                    period === 'PM'
+                      ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                      : 'bg-white text-gray-500 hover:text-gray-900 dark:bg-gray-800 dark:text-gray-400',
+                  )}
+                >
+                  PM
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Title */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              Title{' '}
+              <span className="text-muted-foreground font-normal">
+                (Optional)
+              </span>
+            </Label>
+            <Input
+              placeholder="e.g., Weekly Check-in"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+            />
+          </div>
+
+          {/* Meeting URL */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              Meeting URL{' '}
+              <span className="text-muted-foreground font-normal">
+                (Optional)
+              </span>
+            </Label>
+            <Input
+              placeholder="https://zoom.us/j/..."
+              value={meetingUrl}
+              onChange={e => setMeetingUrl(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              You can add this later before starting the session
+            </p>
+          </div>
+
+          {/* Send Questionnaire */}
+          <div className="flex items-center space-x-3 p-3 rounded-lg bg-muted/50">
+            <Checkbox
+              id="send-questionnaire"
+              checked={sendQuestionnaire}
+              onCheckedChange={checked =>
+                setSendQuestionnaire(checked as boolean)
+              }
+            />
+            <div>
+              <Label
+                htmlFor="send-questionnaire"
+                className="text-sm font-medium cursor-pointer"
+              >
+                Send pre-session questionnaire
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Client will receive 5 reflection questions via email
+              </p>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-4 border-t">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={scheduleSession.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                scheduleSession.isPending ||
+                !clientId ||
+                !sessionDate ||
+                loadingClients
+              }
+              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+            >
+              {scheduleSession.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Scheduling...
+                </>
+              ) : (
+                <>
+                  <CalendarIcon className="w-4 h-4 mr-2" />
+                  Schedule Session
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/hooks/mutations/use-questionnaire-mutations.ts
+++ b/src/hooks/mutations/use-questionnaire-mutations.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { QuestionnaireService } from '@/services/questionnaire-service'
+import { questionnaireKeys } from '@/hooks/queries/use-questionnaire'
+import { queryKeys } from '@/lib/query-client'
+import { toast } from 'sonner'
+import type { ScheduleSessionRequest } from '@/types/questionnaire'
+
+export function useScheduleSession() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: ScheduleSessionRequest) =>
+      QuestionnaireService.scheduleSession(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: questionnaireKeys.upcoming })
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all })
+      toast.success('Session scheduled successfully')
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to schedule session')
+    },
+  })
+}
+
+export function useSendQuestionnaire() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      clientId,
+    }: {
+      sessionId: string
+      clientId: string
+    }) => QuestionnaireService.sendQuestionnaire(sessionId, clientId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: questionnaireKeys.upcoming })
+      toast.success('Questionnaire sent successfully')
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to send questionnaire')
+    },
+  })
+}
+
+export function useStartSessionBot() {
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      meetingUrl,
+      botName,
+    }: {
+      sessionId: string
+      meetingUrl: string
+      botName?: string
+    }) => QuestionnaireService.startBot(sessionId, meetingUrl, botName),
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to start bot')
+    },
+  })
+}

--- a/src/hooks/queries/use-questionnaire.ts
+++ b/src/hooks/queries/use-questionnaire.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+import { QuestionnaireService } from '@/services/questionnaire-service'
+import type {
+  ScheduledSession,
+  QuestionnaireResponseView,
+} from '@/types/questionnaire'
+
+export const questionnaireKeys = {
+  upcoming: ['questionnaire', 'upcoming'] as const,
+  responses: (sessionId: string, clientId?: string) =>
+    ['questionnaire', 'responses', sessionId, clientId] as const,
+}
+
+export function useUpcomingSessions() {
+  return useQuery<ScheduledSession[]>({
+    queryKey: questionnaireKeys.upcoming,
+    queryFn: () => QuestionnaireService.getUpcomingSessions(),
+    staleTime: 30 * 1000, // 30 seconds
+  })
+}
+
+export function useQuestionnaireResponses(
+  sessionId: string | undefined,
+  clientId?: string,
+) {
+  return useQuery<QuestionnaireResponseView[]>({
+    queryKey: questionnaireKeys.responses(sessionId || '', clientId),
+    queryFn: () => QuestionnaireService.getResponses(sessionId!, clientId),
+    enabled: !!sessionId,
+    staleTime: 60 * 1000, // 1 minute
+  })
+}

--- a/src/services/questionnaire-service.ts
+++ b/src/services/questionnaire-service.ts
@@ -1,0 +1,113 @@
+import { ApiClient } from '@/lib/api-client'
+import type {
+  ScheduleSessionRequest,
+  ScheduledSession,
+  QuestionnaireValidation,
+  QuestionnaireResponseView,
+  QuestionnaireTokenResponse,
+  StartBotResponse,
+} from '@/types/questionnaire'
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://coach-sidekick-backend-production.up.railway.app/api/v1'
+
+export class QuestionnaireService {
+  // ---- Authenticated (coach) ----
+
+  static async scheduleSession(
+    data: ScheduleSessionRequest,
+  ): Promise<ScheduledSession> {
+    return ApiClient.post(`${BACKEND_URL}/questionnaire/schedule`, data)
+  }
+
+  static async getUpcomingSessions(): Promise<ScheduledSession[]> {
+    return ApiClient.get(`${BACKEND_URL}/questionnaire/upcoming`)
+  }
+
+  static async sendQuestionnaire(
+    sessionId: string,
+    clientId: string,
+  ): Promise<QuestionnaireTokenResponse> {
+    return ApiClient.post(`${BACKEND_URL}/questionnaire/send`, {
+      session_id: sessionId,
+      client_id: clientId,
+    })
+  }
+
+  static async getResponses(
+    sessionId: string,
+    clientId?: string,
+  ): Promise<QuestionnaireResponseView[]> {
+    const params = clientId ? `?client_id=${clientId}` : ''
+    return ApiClient.get(
+      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/responses${params}`,
+    )
+  }
+
+  static async startBot(
+    sessionId: string,
+    meetingUrl: string,
+    botName?: string,
+  ): Promise<StartBotResponse> {
+    return ApiClient.post(
+      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/start-bot`,
+      { meeting_url: meetingUrl, bot_name: botName },
+    )
+  }
+
+  // ---- Public (no auth, raw fetch) ----
+
+  static async validateToken(token: string): Promise<QuestionnaireValidation> {
+    const res = await fetch(`${BACKEND_URL}/questionnaire/public/${token}`)
+    if (!res.ok) {
+      throw new Error('Questionnaire not found or expired')
+    }
+    return res.json()
+  }
+
+  static async saveAnswer(
+    token: string,
+    questionIndex: number,
+    answer: string,
+  ): Promise<void> {
+    const res = await fetch(
+      `${BACKEND_URL}/questionnaire/public/${token}/answer`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question_index: questionIndex, answer }),
+      },
+    )
+    if (!res.ok) {
+      throw new Error('Failed to save answer')
+    }
+  }
+
+  static async submitAll(
+    token: string,
+    answers: { question_index: number; answer: string }[],
+  ): Promise<void> {
+    const res = await fetch(
+      `${BACKEND_URL}/questionnaire/public/${token}/submit`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answers }),
+      },
+    )
+    if (!res.ok) {
+      throw new Error('Failed to submit questionnaire')
+    }
+  }
+
+  static async completeQuestionnaire(token: string): Promise<void> {
+    const res = await fetch(
+      `${BACKEND_URL}/questionnaire/public/${token}/complete`,
+      { method: 'POST' },
+    )
+    if (!res.ok) {
+      throw new Error('Failed to complete questionnaire')
+    }
+  }
+}

--- a/src/types/questionnaire.ts
+++ b/src/types/questionnaire.ts
@@ -1,0 +1,71 @@
+export interface ScheduleSessionRequest {
+  client_id: string
+  scheduled_for: string // ISO datetime
+  title?: string
+  meeting_url?: string
+  send_questionnaire?: boolean
+}
+
+export interface ScheduledSession {
+  id: string
+  coach_id: string
+  client_id: string | null
+  client_name: string | null
+  title: string | null
+  meeting_url: string | null
+  status: string
+  scheduled_for: string | null
+  questionnaire_sent: boolean
+  questionnaire_completed: boolean
+  created_at: string
+}
+
+export interface QuestionnaireValidation {
+  valid: boolean
+  client_name: string
+  coach_name: string
+  session_title: string | null
+  scheduled_for: string | null
+  questions: QuestionItem[]
+  existing_answers: QuestionnaireAnswerItem[]
+}
+
+export interface QuestionItem {
+  index: number
+  text: string
+}
+
+export interface QuestionnaireAnswerItem {
+  question_index: number
+  answer: string
+}
+
+export interface QuestionnaireResponseView {
+  client_id: string
+  client_name: string
+  responses: QuestionAnswerPair[]
+  status: string
+  completed_at: string | null
+}
+
+export interface QuestionAnswerPair {
+  question_index: number
+  question_text: string
+  answer: string
+}
+
+export interface QuestionnaireTokenResponse {
+  token: string
+  questionnaire_url: string
+  expires_at: string
+}
+
+export interface StartBotRequest {
+  meeting_url: string
+  bot_name?: string
+}
+
+export interface StartBotResponse {
+  id: string
+  session_id: string
+}


### PR DESCRIPTION
## Summary
- Schedule session modal with quick-pick date pills, calendar popover, and AM/PM time selector
- Typeform-style public questionnaire page with localStorage answer persistence and batch API submit
- Upcoming sessions dashboard section with questionnaire status badges
- Pre-session responses card on session detail page and Q&A sidebar tab on live meeting page
- Start-bot card for launching Recall.ai bot from scheduled sessions with retry support
- Novus Global branding on questionnaire pages
- Schedule Session button on client detail page

## Test plan
- [ ] Schedule a session from dashboard and client detail page
- [ ] Complete questionnaire flow end-to-end (all 5 questions, submit)
- [ ] Verify localStorage persistence on page refresh mid-questionnaire
- [ ] Verify pre-session responses display on session detail and live meeting Q&A tab
- [ ] Start bot from scheduled session and verify redirect to meeting page

🤖 Generated with [Claude Code](https://claude.com/claude-code)