### PR TITLE
Improve upcoming sessions UI and schedule modal

### DIFF
--- a/src/app/clients/[clientId]/components/client-upcoming-sessions.tsx
+++ b/src/app/clients/[clientId]/components/client-upcoming-sessions.tsx
@@ -30,9 +30,15 @@ import {
 } from '@/hooks/mutations/use-questionnaire-mutations'
 import { useUpdateSession } from '@/hooks/mutations/use-session-mutations'
 
-export function UpcomingSessions() {
+interface ClientUpcomingSessionsProps {
+  clientId: string
+}
+
+export function ClientUpcomingSessions({
+  clientId,
+}: ClientUpcomingSessionsProps) {
   const router = useRouter()
-  const { data: sessions, isLoading } = useUpcomingSessions()
+  const { data: sessions, isLoading } = useUpcomingSessions(clientId)
   const sendQuestionnaire = useSendQuestionnaire()
   const reschedule = useRescheduleSession()
   const updateSession = useUpdateSession()
@@ -115,14 +121,10 @@ export function UpcomingSessions() {
                 ) : (
                   <button
                     onClick={() => startEditingTitle(session)}
-                    className="text-sm font-medium text-gray-900 dark:text-white truncate block text-left hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                    className="text-sm font-medium text-gray-900 dark:text-white truncate block text-left group/title hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     title="Click to edit title"
                   >
-                    {session.client_name && session.title
-                      ? session.title
-                      : session.client_name ||
-                        session.title ||
-                        'Scheduled Session'}
+                    {session.title || 'Scheduled Session'}
                     <Pencil className="h-2.5 w-2.5 ml-1.5 inline opacity-0 group-hover:opacity-40 transition-opacity" />
                   </button>
                 )}

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -55,6 +55,7 @@ import {
 import { ClientService } from '@/services/client-service'
 import { ClientWinsTimeline } from '@/components/wins/client-wins-timeline'
 import { ClientResourcesTab } from './components/client-resources-tab'
+import { ClientUpcomingSessions } from './components/client-upcoming-sessions'
 
 export default function ClientDetailPage({
   params,
@@ -368,6 +369,9 @@ export default function ClientDetailPage({
               <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 {/* Live Session Banner */}
                 <LiveSessionBanner sessions={clientActiveSessions} />
+
+                {/* Upcoming Scheduled Sessions */}
+                <ClientUpcomingSessions clientId={client.id} />
 
                 <Tabs
                   value={activeTab}

--- a/src/components/meeting/pre-session-responses-compact.tsx
+++ b/src/components/meeting/pre-session-responses-compact.tsx
@@ -1,8 +1,15 @@
 'use client'
 
 import { useState } from 'react'
-import { ClipboardList, ChevronDown, ChevronUp } from 'lucide-react'
+import {
+  ClipboardList,
+  ChevronDown,
+  ChevronUp,
+  Send,
+  Loader2,
+} from 'lucide-react'
 import { useQuestionnaireResponses } from '@/hooks/queries/use-questionnaire'
+import { useSendQuestionnaire } from '@/hooks/mutations/use-questionnaire-mutations'
 
 interface PreSessionResponsesCompactProps {
   sessionId: string | undefined
@@ -17,6 +24,7 @@ export function PreSessionResponsesCompact({
     sessionId,
     clientId,
   )
+  const sendQuestionnaire = useSendQuestionnaire()
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
 
   if (isLoading) {
@@ -38,9 +46,33 @@ export function PreSessionResponsesCompact({
         <div className="w-10 h-10 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center mx-auto mb-3">
           <ClipboardList className="h-5 w-5 text-gray-400" />
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
           No pre-session responses for this session
         </p>
+        {sessionId && clientId && (
+          <button
+            onClick={() =>
+              sendQuestionnaire.mutate({
+                sessionId,
+                clientId,
+              })
+            }
+            disabled={sendQuestionnaire.isPending}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 disabled:opacity-50 transition-colors"
+          >
+            {sendQuestionnaire.isPending ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Sending...
+              </>
+            ) : (
+              <>
+                <Send className="h-3 w-3" />
+                Send Questionnaire
+              </>
+            )}
+          </button>
+        )}
       </div>
     )
   }

--- a/src/components/sessions/schedule-session-modal.tsx
+++ b/src/components/sessions/schedule-session-modal.tsx
@@ -87,11 +87,25 @@ export function ScheduleSessionModal({
   const [minute, setMinute] = useState('00')
   const [period, setPeriod] = useState<'AM' | 'PM'>('AM')
   const [title, setTitle] = useState('')
+  const [titleManuallySet, setTitleManuallySet] = useState(false)
   const [meetingUrl, setMeetingUrl] = useState('')
   const [sendQuestionnaire, setSendQuestionnaire] = useState(true)
   const [calendarOpen, setCalendarOpen] = useState(false)
 
   const quickDates = useMemo(() => getQuickDates(), [])
+
+  // Auto-populate title when client or date changes (unless manually edited)
+  const selectedClient = clients.find(c => c.id === clientId)
+  React.useEffect(() => {
+    if (titleManuallySet) return
+    if (selectedClient && sessionDate) {
+      setTitle(
+        `${selectedClient.name} - ${format(sessionDate, 'MMMM d, yyyy')}`,
+      )
+    } else {
+      setTitle('')
+    }
+  }, [clientId, sessionDate, selectedClient, titleManuallySet])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -125,6 +139,7 @@ export function ScheduleSessionModal({
     setMinute('00')
     setPeriod('AM')
     setTitle('')
+    setTitleManuallySet(false)
     setMeetingUrl('')
     setSendQuestionnaire(true)
     onClose()
@@ -303,7 +318,10 @@ export function ScheduleSessionModal({
             <Input
               placeholder="e.g., Weekly Check-in"
               value={title}
-              onChange={e => setTitle(e.target.value)}
+              onChange={e => {
+                setTitle(e.target.value)
+                setTitleManuallySet(true)
+              }}
             />
           </div>
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-2 shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-2 rounded-xl border py-2 shadow-sm',
         className,
       )}
       {...props}

--- a/src/hooks/mutations/use-questionnaire-mutations.ts
+++ b/src/hooks/mutations/use-questionnaire-mutations.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { QuestionnaireService } from '@/services/questionnaire-service'
-import { questionnaireKeys } from '@/hooks/queries/use-questionnaire'
 import { queryKeys } from '@/lib/query-client'
 import { toast } from 'sonner'
 import type { ScheduleSessionRequest } from '@/types/questionnaire'
@@ -12,7 +11,11 @@ export function useScheduleSession() {
     mutationFn: (data: ScheduleSessionRequest) =>
       QuestionnaireService.scheduleSession(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: questionnaireKeys.upcoming })
+      queryClient.invalidateQueries({
+        predicate: query =>
+          query.queryKey[0] === 'questionnaire' &&
+          query.queryKey[1] === 'upcoming',
+      })
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all })
       toast.success('Session scheduled successfully')
     },
@@ -34,11 +37,41 @@ export function useSendQuestionnaire() {
       clientId: string
     }) => QuestionnaireService.sendQuestionnaire(sessionId, clientId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: questionnaireKeys.upcoming })
+      queryClient.invalidateQueries({
+        predicate: query =>
+          query.queryKey[0] === 'questionnaire' &&
+          query.queryKey[1] === 'upcoming',
+      })
       toast.success('Questionnaire sent successfully')
     },
     onError: (error: Error) => {
       toast.error(error.message || 'Failed to send questionnaire')
+    },
+  })
+}
+
+export function useRescheduleSession() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      scheduledFor,
+    }: {
+      sessionId: string
+      scheduledFor: string
+    }) => QuestionnaireService.rescheduleSession(sessionId, scheduledFor),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: query =>
+          query.queryKey[0] === 'questionnaire' &&
+          query.queryKey[1] === 'upcoming',
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all })
+      toast.success('Session rescheduled')
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to reschedule session')
     },
   })
 }

--- a/src/hooks/queries/use-questionnaire.ts
+++ b/src/hooks/queries/use-questionnaire.ts
@@ -6,15 +6,16 @@ import type {
 } from '@/types/questionnaire'
 
 export const questionnaireKeys = {
-  upcoming: ['questionnaire', 'upcoming'] as const,
+  upcoming: (clientId?: string) =>
+    ['questionnaire', 'upcoming', clientId] as const,
   responses: (sessionId: string, clientId?: string) =>
     ['questionnaire', 'responses', sessionId, clientId] as const,
 }
 
-export function useUpcomingSessions() {
+export function useUpcomingSessions(clientId?: string) {
   return useQuery<ScheduledSession[]>({
-    queryKey: questionnaireKeys.upcoming,
-    queryFn: () => QuestionnaireService.getUpcomingSessions(),
+    queryKey: questionnaireKeys.upcoming(clientId),
+    queryFn: () => QuestionnaireService.getUpcomingSessions(clientId),
     staleTime: 30 * 1000, // 30 seconds
   })
 }

--- a/src/services/questionnaire-service.ts
+++ b/src/services/questionnaire-service.ts
@@ -21,8 +21,21 @@ export class QuestionnaireService {
     return ApiClient.post(`${BACKEND_URL}/questionnaire/schedule`, data)
   }
 
-  static async getUpcomingSessions(): Promise<ScheduledSession[]> {
-    return ApiClient.get(`${BACKEND_URL}/questionnaire/upcoming`)
+  static async getUpcomingSessions(
+    clientId?: string,
+  ): Promise<ScheduledSession[]> {
+    const params = clientId ? `?client_id=${clientId}` : ''
+    return ApiClient.get(`${BACKEND_URL}/questionnaire/upcoming${params}`)
+  }
+
+  static async rescheduleSession(
+    sessionId: string,
+    scheduledFor: string,
+  ): Promise<{ id: string; scheduled_for: string }> {
+    return ApiClient.patch(
+      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/reschedule`,
+      { scheduled_for: scheduledFor },
+    )
   }
 
   static async sendQuestionnaire(


### PR DESCRIPTION
## Summary
- Redesigned upcoming sessions as compact rows with inline title editing, date reschedule, and resend questionnaire
- Same design on both dashboard and client detail pages
- Schedule modal auto-populates title as "{Client} - {Date}"
- Send questionnaire button in meeting page Q&A tab empty state
- Client-scoped upcoming sessions component on client detail page

## Test plan
- [ ] Verify compact upcoming sessions UI on dashboard and client page
- [ ] Click title to edit inline, save on blur/Enter
- [ ] Click date to reschedule via calendar popover
- [ ] Resend questionnaire via rotate icon next to "Sent" badge
- [ ] Schedule modal auto-fills title when client + date selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)