### PR TITLE
Improve meeting page responsiveness

### DIFF
--- a/src/app/meeting/[botId]/components/meeting-panels.tsx
+++ b/src/app/meeting/[botId]/components/meeting-panels.tsx
@@ -93,6 +93,7 @@ export default function MeetingPanels({
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('transcript')
   const [aiSuggestionsOpen, setAiSuggestionsOpen] = useState(true)
   const [resourcesOpen, setResourcesOpen] = useState(false)
+  const [commitmentsOpen, setCommitmentsOpen] = useState(true)
   const [sharingResourceId, setSharingResourceId] = useState<string | null>(
     null,
   )
@@ -228,19 +229,104 @@ export default function MeetingPanels({
         </Button>
       </div>
 
-      {/* Collapsible AI Suggestions Panel */}
+      {/* Collapsible AI Suggestions Panel + Resources */}
       <div
         className={cn(
           'flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ease-in-out overflow-hidden',
-          aiSuggestionsOpen ? 'w-80 lg:w-96' : 'w-0',
+          aiSuggestionsOpen ? 'w-72 xl:w-80 2xl:w-96' : 'w-0',
         )}
       >
-        <div className="w-80 lg:w-96 h-full">
-          <CoachingPanel
-            botId={botId}
-            className="h-full shadow-sm"
-            simplified={true}
-          />
+        <div className="w-72 xl:w-80 2xl:w-96 h-full flex flex-col">
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <CoachingPanel
+              botId={botId}
+              className="h-full shadow-sm"
+              simplified={true}
+            />
+          </div>
+
+          {/* Resources section below AI suggestions */}
+          {allResources.length > 0 && (
+            <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 overflow-hidden">
+              <button
+                onClick={() => setResourcesOpen(!resourcesOpen)}
+                className="w-full flex items-center justify-between px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+              >
+                <div className="flex items-center gap-2">
+                  <BookOpen className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                  <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                    Resources
+                  </span>
+                  <Badge
+                    variant="secondary"
+                    className="text-[10px] px-1 py-0 h-4"
+                  >
+                    {allResources.length}
+                  </Badge>
+                </div>
+                {resourcesOpen ? (
+                  <ChevronUp className="h-3 w-3 text-gray-400" />
+                ) : (
+                  <ChevronDown className="h-3 w-3 text-gray-400" />
+                )}
+              </button>
+
+              {resourcesOpen && (
+                <div className="px-3 pb-2 max-h-[180px] overflow-y-auto space-y-0.5">
+                  {allResources.map(resource => {
+                    const Icon =
+                      RESOURCE_CATEGORY_ICONS[resource.category] || FileText
+                    const colors =
+                      CATEGORY_COLORS[resource.category as ResourceCategory] ||
+                      CATEGORY_COLORS.general
+                    const alreadyShared = isResourceSharedWithClient(resource)
+                    const isSharing = sharingResourceId === resource.id
+                    const targetClientId = commitmentClientId || clientId
+
+                    return (
+                      <div
+                        key={resource.id}
+                        className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                      >
+                        <div className={`p-1 rounded ${colors.bg} shrink-0`}>
+                          <Icon className={`h-3 w-3 ${colors.text}`} />
+                        </div>
+                        <p className="flex-1 min-w-0 text-[11px] font-medium text-gray-900 dark:text-white truncate">
+                          {resource.title}
+                        </p>
+                        {targetClientId &&
+                          (alreadyShared ? (
+                            <div className="shrink-0 flex items-center gap-0.5 text-green-600 dark:text-green-400">
+                              <Check className="h-2.5 w-2.5" />
+                              <span className="text-[9px] font-medium">
+                                Shared
+                              </span>
+                            </div>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-5 text-[9px] px-1.5 shrink-0"
+                              onClick={() => handleQuickShare(resource.id)}
+                              disabled={isSharing}
+                            >
+                              {isSharing ? (
+                                <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                              ) : (
+                                <>
+                                  <Share2 className="h-2.5 w-2.5 mr-0.5" />
+                                  Share
+                                </>
+                              )}
+                            </Button>
+                          ))}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -258,9 +344,9 @@ export default function MeetingPanels({
           </div>
         )}
 
-        <div className="flex-1 grid grid-cols-1 lg:grid-cols-8 gap-4 min-h-0 overflow-hidden">
-          {/* Left Column - Notes + Resources (5/8) */}
-          <div className="lg:col-span-5 h-full overflow-hidden flex flex-col">
+        <div className="flex-1 grid grid-cols-1 lg:grid-cols-12 gap-4 min-h-0 overflow-hidden">
+          {/* Left Column - Notes + Resources (7/12 ≈ 58%) */}
+          <div className="lg:col-span-7 xl:col-span-8 h-full overflow-hidden flex flex-col">
             <div className="flex-1 min-h-0 overflow-hidden">
               {sessionId ? (
                 <QuickNote
@@ -289,140 +375,82 @@ export default function MeetingPanels({
                 </Card>
               )}
             </div>
-
-            {/* Collapsible Resources Section */}
-            {allResources.length > 0 && (
-              <div className="flex-shrink-0 bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-xl mt-2 overflow-hidden">
-                <button
-                  onClick={() => setResourcesOpen(!resourcesOpen)}
-                  className="w-full flex items-center justify-between px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-                >
-                  <div className="flex items-center gap-2">
-                    <BookOpen className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-                    <span className="text-sm font-semibold text-gray-900 dark:text-white">
-                      Resources
-                    </span>
-                    <Badge
-                      variant="secondary"
-                      className="text-xs px-1.5 py-0 h-5"
-                    >
-                      {allResources.length}
-                    </Badge>
-                  </div>
-                  {resourcesOpen ? (
-                    <ChevronUp className="h-3.5 w-3.5 text-gray-400" />
-                  ) : (
-                    <ChevronDown className="h-3.5 w-3.5 text-gray-400" />
-                  )}
-                </button>
-
-                {resourcesOpen && (
-                  <div className="px-3 pb-3 max-h-[200px] overflow-y-auto space-y-1">
-                    {allResources.map(resource => {
-                      const Icon =
-                        RESOURCE_CATEGORY_ICONS[resource.category] || FileText
-                      const colors =
-                        CATEGORY_COLORS[
-                          resource.category as ResourceCategory
-                        ] || CATEGORY_COLORS.general
-                      const alreadyShared = isResourceSharedWithClient(resource)
-                      const isSharing = sharingResourceId === resource.id
-                      const targetClientId = commitmentClientId || clientId
-
-                      return (
-                        <div
-                          key={resource.id}
-                          className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                        >
-                          <div
-                            className={`p-1.5 rounded ${colors.bg} shrink-0`}
-                          >
-                            <Icon className={`h-3.5 w-3.5 ${colors.text}`} />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-xs font-medium text-gray-900 dark:text-white truncate">
-                              {resource.title}
-                            </p>
-                          </div>
-                          {targetClientId &&
-                            (alreadyShared ? (
-                              <div className="shrink-0 flex items-center gap-1 text-green-600 dark:text-green-400">
-                                <Check className="h-3 w-3" />
-                                <span className="text-[10px] font-medium">
-                                  Shared
-                                </span>
-                              </div>
-                            ) : (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-6 text-[10px] px-2 shrink-0"
-                                onClick={() => handleQuickShare(resource.id)}
-                                disabled={isSharing}
-                              >
-                                {isSharing ? (
-                                  <Loader2 className="h-3 w-3 animate-spin" />
-                                ) : (
-                                  <>
-                                    <Share2 className="h-3 w-3 mr-1" />
-                                    Share
-                                  </>
-                                )}
-                              </Button>
-                            ))}
-                        </div>
-                      )
-                    })}
-                  </div>
-                )}
-              </div>
-            )}
           </div>
 
-          {/* Right Column - Commitments (3/8) */}
-          <div className="lg:col-span-3 h-full overflow-hidden flex flex-col gap-2">
-            {commitmentSessionId && commitmentClientId ? (
-              <QuickCommitment
-                sessionId={commitmentSessionId}
-                clientId={commitmentClientId}
-              />
-            ) : sessionId && !commitmentClientId ? (
-              <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-amber-100 dark:border-amber-900/50 h-full">
-                <CardContent className="p-4">
-                  <div className="flex items-start gap-3">
-                    <div className="p-2 bg-amber-50 dark:bg-amber-900/30 rounded-lg">
-                      <Target className="h-4 w-4 text-amber-500 dark:text-amber-400" />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                        Commitments
-                      </h4>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                        No client selected
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ) : (
-              <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 h-full">
-                <CardContent className="p-4">
-                  <div className="flex items-start gap-3">
-                    <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                      <Target className="h-4 w-4 text-gray-400" />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                        Commitments
-                      </h4>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                        Session loading...
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+          {/* Right Column - Commitments (collapsible) */}
+          <div
+            className={cn(
+              'overflow-hidden flex flex-col',
+              commitmentsOpen
+                ? 'lg:col-span-5 xl:col-span-4 h-full'
+                : 'lg:col-span-5 xl:col-span-4',
             )}
+          >
+            <button
+              onClick={() => setCommitmentsOpen(!commitmentsOpen)}
+              className="flex items-center justify-between px-3 py-2 bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-t-xl flex-shrink-0 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors lg:hidden"
+            >
+              <div className="flex items-center gap-2">
+                <Target className="h-3.5 w-3.5 text-gray-500" />
+                <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                  Commitments
+                </span>
+              </div>
+              {commitmentsOpen ? (
+                <ChevronUp className="h-3 w-3 text-gray-400" />
+              ) : (
+                <ChevronDown className="h-3 w-3 text-gray-400" />
+              )}
+            </button>
+            <div
+              className={cn(
+                'flex-1 min-h-0 overflow-hidden flex flex-col gap-2',
+                !commitmentsOpen && 'hidden lg:flex',
+              )}
+            >
+              {commitmentSessionId && commitmentClientId ? (
+                <QuickCommitment
+                  sessionId={commitmentSessionId}
+                  clientId={commitmentClientId}
+                />
+              ) : sessionId && !commitmentClientId ? (
+                <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-amber-100 dark:border-amber-900/50 h-full">
+                  <CardContent className="p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 bg-amber-50 dark:bg-amber-900/30 rounded-lg">
+                        <Target className="h-4 w-4 text-amber-500 dark:text-amber-400" />
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Commitments
+                        </h4>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          No client selected
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ) : (
+                <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 h-full">
+                  <CardContent className="p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
+                        <Target className="h-4 w-4 text-gray-400" />
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Commitments
+                        </h4>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          Session loading...
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -457,10 +485,10 @@ export default function MeetingPanels({
       <div
         className={cn(
           'flex-shrink-0 border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ease-in-out overflow-hidden',
-          sidebarOpen ? 'w-80' : 'w-0',
+          sidebarOpen ? 'w-72 xl:w-80' : 'w-0',
         )}
       >
-        <div className="w-80 h-full flex flex-col">
+        <div className="w-72 xl:w-80 h-full flex flex-col">
           {/* Sidebar Tabs */}
           <div className="flex-shrink-0 border-b border-gray-100 dark:border-gray-700">
             <div className="flex">

--- a/src/components/session-notes/quick-note.tsx
+++ b/src/components/session-notes/quick-note.tsx
@@ -22,6 +22,8 @@ import {
   Trash2,
   X,
   FileText,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react'
 import {
   useCreateNote,
@@ -61,6 +63,7 @@ export function QuickNote({
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null)
   const [editContent, setEditContent] = useState('')
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const [notesListOpen, setNotesListOpen] = useState(true)
 
   const createNote = useCreateNote(sessionId, clientId)
   const updateNote = useUpdateNote(sessionId, clientId)
@@ -195,8 +198,8 @@ export function QuickNote({
         </div>
       </div>
 
-      {/* Editor - 50% height */}
-      <div className="h-1/2 p-4 flex flex-col min-h-0">
+      {/* Editor - takes priority space */}
+      <div className="flex-[3] p-4 flex flex-col min-h-0">
         <div className="flex-1 min-h-0">
           <RichTextEditor
             content={content}
@@ -224,155 +227,169 @@ export function QuickNote({
         </div>
       </div>
 
-      {/* Session Notes List - 50% height */}
+      {/* Session Notes List - collapsible */}
       {sortedNotes.length > 0 && (
-        <div className="h-1/2 border-t border-gray-100 dark:border-gray-700 flex flex-col min-h-0">
-          <div className="px-4 py-2 bg-gray-50 dark:bg-gray-700/50 flex items-center justify-between flex-shrink-0">
+        <div
+          className={`${notesListOpen ? 'flex-[2]' : 'flex-shrink-0'} min-h-0 border-t border-gray-100 dark:border-gray-700 flex flex-col`}
+        >
+          <button
+            onClick={() => setNotesListOpen(!notesListOpen)}
+            className="px-4 py-2 bg-gray-50 dark:bg-gray-700/50 flex items-center justify-between flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors w-full"
+          >
             <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
               Session Notes
             </span>
-            <Badge variant="secondary" className="text-xs">
-              {sortedNotes.length}
-            </Badge>
-          </div>
-          <div className="flex-1 overflow-y-auto">
-            {sortedNotes.map(note => (
-              <div
-                key={note.id}
-                className="px-4 py-3 border-b border-gray-50 dark:border-gray-700 last:border-b-0 hover:bg-gray-50/50 dark:hover:bg-gray-700/50"
-              >
-                {editingNoteId === note.id ? (
-                  // Edit mode
-                  <div className="space-y-2">
-                    <RichTextEditor
-                      content={editContent}
-                      onChange={setEditContent}
-                      minHeight="80px"
-                    />
-                    <div className="flex items-center justify-end gap-2">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={handleCancelEdit}
-                        className="h-7 text-xs"
-                      >
-                        <X className="h-3 w-3 mr-1" />
-                        Cancel
-                      </Button>
-                      <Button
-                        size="sm"
-                        onClick={() => handleSaveEdit(note.id)}
-                        disabled={
-                          !hasContent(editContent) || updateNote.isPending
-                        }
-                        className="h-7 text-xs bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
-                      >
-                        {updateNote.isPending ? (
-                          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                        ) : (
-                          <Check className="h-3 w-3 mr-1" />
-                        )}
-                        Save
-                      </Button>
-                    </div>
-                  </div>
-                ) : (
-                  // View mode
-                  <div>
-                    <div className="flex items-start justify-between gap-2">
-                      <div
-                        className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3 flex-1 prose prose-sm dark:prose-invert max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0.5"
-                        dangerouslySetInnerHTML={{ __html: note.content }}
+            <div className="flex items-center gap-1.5">
+              <Badge variant="secondary" className="text-xs">
+                {sortedNotes.length}
+              </Badge>
+              {notesListOpen ? (
+                <ChevronUp className="h-3 w-3 text-gray-400" />
+              ) : (
+                <ChevronDown className="h-3 w-3 text-gray-400" />
+              )}
+            </div>
+          </button>
+          {notesListOpen && (
+            <div className="flex-1 overflow-y-auto">
+              {sortedNotes.map(note => (
+                <div
+                  key={note.id}
+                  className="px-4 py-3 border-b border-gray-50 dark:border-gray-700 last:border-b-0 hover:bg-gray-50/50 dark:hover:bg-gray-700/50"
+                >
+                  {editingNoteId === note.id ? (
+                    // Edit mode
+                    <div className="space-y-2">
+                      <RichTextEditor
+                        content={editContent}
+                        onChange={setEditContent}
+                        minHeight="80px"
                       />
-                      <div className="flex items-center gap-1 flex-shrink-0">
-                        <button
-                          onClick={() => handleStartEdit(note)}
-                          className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-                          title="Edit note"
+                      <div className="flex items-center justify-end gap-2">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={handleCancelEdit}
+                          className="h-7 text-xs"
                         >
-                          <Pencil className="h-3.5 w-3.5" />
-                        </button>
-                        <Popover
-                          open={deleteConfirmId === note.id}
-                          onOpenChange={open =>
-                            setDeleteConfirmId(open ? note.id : null)
+                          <X className="h-3 w-3 mr-1" />
+                          Cancel
+                        </Button>
+                        <Button
+                          size="sm"
+                          onClick={() => handleSaveEdit(note.id)}
+                          disabled={
+                            !hasContent(editContent) || updateNote.isPending
                           }
+                          className="h-7 text-xs bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
                         >
-                          <PopoverTrigger asChild>
-                            <button
-                              className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded"
-                              title="Delete note"
-                            >
-                              <Trash2 className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent
-                            className="w-auto p-3 dark:bg-gray-800 dark:border-gray-700"
-                            align="end"
-                          >
-                            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-                              Delete this note?
-                            </p>
-                            <div className="flex items-center gap-2">
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                onClick={() => setDeleteConfirmId(null)}
-                                className="h-7 text-xs"
-                              >
-                                Cancel
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="destructive"
-                                onClick={() => handleDelete(note.id)}
-                                disabled={deleteNote.isPending}
-                                className="h-7 text-xs"
-                              >
-                                {deleteNote.isPending ? (
-                                  <Loader2 className="h-3 w-3 animate-spin" />
-                                ) : (
-                                  'Delete'
-                                )}
-                              </Button>
-                            </div>
-                          </PopoverContent>
-                        </Popover>
+                          {updateNote.isPending ? (
+                            <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                          ) : (
+                            <Check className="h-3 w-3 mr-1" />
+                          )}
+                          Save
+                        </Button>
                       </div>
                     </div>
-                    <div className="flex items-center gap-2 mt-1.5">
-                      <Badge
-                        variant="outline"
-                        className={`text-xs px-1.5 py-0 h-5 ${
-                          note.note_type === 'coach_private'
-                            ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700'
-                            : 'border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30'
-                        }`}
-                      >
-                        {note.note_type === 'coach_private' ? (
-                          <Lock className="h-2.5 w-2.5 mr-1" />
-                        ) : (
-                          <Users className="h-2.5 w-2.5 mr-1" />
-                        )}
-                        {note.note_type === 'coach_private'
-                          ? 'Private'
-                          : 'Shared'}
-                      </Badge>
-                      <span className="text-xs text-gray-400">
-                        {formatRelativeTime(note.created_at)}
-                      </span>
+                  ) : (
+                    // View mode
+                    <div>
+                      <div className="flex items-start justify-between gap-2">
+                        <div
+                          className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3 flex-1 prose prose-sm dark:prose-invert max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0.5"
+                          dangerouslySetInnerHTML={{ __html: note.content }}
+                        />
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <button
+                            onClick={() => handleStartEdit(note)}
+                            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                            title="Edit note"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <Popover
+                            open={deleteConfirmId === note.id}
+                            onOpenChange={open =>
+                              setDeleteConfirmId(open ? note.id : null)
+                            }
+                          >
+                            <PopoverTrigger asChild>
+                              <button
+                                className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded"
+                                title="Delete note"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                              className="w-auto p-3 dark:bg-gray-800 dark:border-gray-700"
+                              align="end"
+                            >
+                              <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
+                                Delete this note?
+                              </p>
+                              <div className="flex items-center gap-2">
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() => setDeleteConfirmId(null)}
+                                  className="h-7 text-xs"
+                                >
+                                  Cancel
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="destructive"
+                                  onClick={() => handleDelete(note.id)}
+                                  disabled={deleteNote.isPending}
+                                  className="h-7 text-xs"
+                                >
+                                  {deleteNote.isPending ? (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                  ) : (
+                                    'Delete'
+                                  )}
+                                </Button>
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 mt-1.5">
+                        <Badge
+                          variant="outline"
+                          className={`text-xs px-1.5 py-0 h-5 ${
+                            note.note_type === 'coach_private'
+                              ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700'
+                              : 'border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                          }`}
+                        >
+                          {note.note_type === 'coach_private' ? (
+                            <Lock className="h-2.5 w-2.5 mr-1" />
+                          ) : (
+                            <Users className="h-2.5 w-2.5 mr-1" />
+                          )}
+                          {note.note_type === 'coach_private'
+                            ? 'Private'
+                            : 'Shared'}
+                        </Badge>
+                        <span className="text-xs text-gray-400">
+                          {formatRelativeTime(note.created_at)}
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
-      {/* Empty state for notes (only show after loading) - 50% height */}
+      {/* Empty state for notes (only show after loading) */}
       {!notesLoading && sortedNotes.length === 0 && (
-        <div className="h-1/2 border-t border-gray-100 dark:border-gray-700 px-4 py-4 flex items-center justify-center">
+        <div className="flex-shrink-0 border-t border-gray-100 dark:border-gray-700 px-4 py-3 flex items-center justify-center">
           <div className="text-center">
             <FileText className="h-6 w-6 text-gray-300 dark:text-gray-600 mx-auto mb-1" />
             <p className="text-xs text-gray-400">No notes captured yet</p>


### PR DESCRIPTION
## Summary
- Notes editor gets priority space (60%) over notes list (40%) via flex ratios
- Notes list is collapsible — click header to toggle, editor gets full height when collapsed
- Resources section moved below AI suggestions in left panel
- Commitments section collapsible on mobile screens (below lg breakpoint)
- Side panels narrower on smaller screens (w-72 base → w-80 at xl)
- Grid split adjusted for better note-taking space

## Test plan
- [ ] Open live meeting page — notes editor should be larger than notes list
- [ ] Click "Session Notes" header to collapse/expand the notes list
- [ ] Verify resources appear below AI Coach suggestions panel
- [ ] On narrow viewport, verify commitments collapse toggle appears
- [ ] Verify side panels are slightly narrower, giving more space to center

🤖 Generated with [Claude Code](https://claude.com/claude-code)