### PR TITLE
UI polish: full-width meeting, kanban fix, notes improvements

### DIFF
--- a/src/app/clients/[clientId]/components/client-profile-section.tsx
+++ b/src/app/clients/[clientId]/components/client-profile-section.tsx
@@ -346,7 +346,7 @@ export function ClientProfileSection({
               <div className="flex items-center gap-2 mt-3 p-2 bg-primary/5 rounded-lg">
                 <Target className="h-4 w-4 text-primary" />
                 <span className="text-sm text-gray-700 dark:text-gray-300">
-                  <strong>{activeGoals}</strong> active goal
+                  <strong>{activeGoals}</strong> active vision
                   {activeGoals !== 1 ? 's' : ''}
                 </span>
               </div>

--- a/src/app/meeting/[botId]/components/meeting-header.tsx
+++ b/src/app/meeting/[botId]/components/meeting-header.tsx
@@ -54,7 +54,7 @@ export default function MeetingHeader({
 
   return (
     <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
-      <div className="max-w-7xl mx-auto px-4 py-3">
+      <div className="w-full px-4 py-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Button

--- a/src/app/meeting/[botId]/page.tsx
+++ b/src/app/meeting/[botId]/page.tsx
@@ -146,7 +146,7 @@ export default function MeetingPage() {
         />
       </div>
       <div className="flex-1 flex flex-col overflow-hidden">
-        <div className="flex-1 flex flex-col max-w-[1600px] w-full mx-auto px-4 py-3 overflow-hidden">
+        <div className="flex-1 flex flex-col w-full px-4 py-3 overflow-hidden">
           <div className="flex-1 overflow-hidden">
             <MeetingPanels
               transcript={transcript}

--- a/src/app/sessions/[sessionId]/components/session-notes-compact.tsx
+++ b/src/app/sessions/[sessionId]/components/session-notes-compact.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import {
   Dialog,
@@ -12,10 +11,20 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { StickyNote, FileText, Loader2, Plus } from 'lucide-react'
+import {
+  StickyNote,
+  FileText,
+  Loader2,
+  Plus,
+  Lock,
+  Users,
+  Copy,
+  Check,
+} from 'lucide-react'
 import { SessionNotesService } from '@/services/session-notes-service'
 import { SessionNote } from '@/types/session-note'
 import { formatRelativeTime } from '@/lib/date-utils'
+import { htmlToPlainText } from '@/components/ui/rich-text-editor'
 import { toast } from 'sonner'
 
 interface SessionNotesCompactProps {
@@ -33,9 +42,12 @@ export function SessionNotesCompact({
   const [loading, setLoading] = useState(true)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [expandedNoteId, setExpandedNoteId] = useState<string | null>(null)
-  const [newTitle, setNewTitle] = useState('')
   const [newContent, setNewContent] = useState('')
+  const [newNoteType, setNewNoteType] = useState<'coach_private' | 'shared'>(
+    'coach_private',
+  )
   const [isCreating, setIsCreating] = useState(false)
+  const [copiedNoteId, setCopiedNoteId] = useState<string | null>(null)
 
   useEffect(() => {
     fetchNotes()
@@ -62,15 +74,15 @@ export function SessionNotesCompact({
     setIsCreating(true)
     try {
       await SessionNotesService.createNote(sessionId, {
-        title: newTitle.trim() || null,
+        title: `Note - ${new Date().toLocaleTimeString()}`,
         content: newContent.trim(),
-        note_type: 'coach_private',
+        note_type: newNoteType,
         ...(clientId ? { client_id: clientId } : {}),
       })
       toast.success('Note added')
       setShowCreateDialog(false)
-      setNewTitle('')
       setNewContent('')
+      setNewNoteType('coach_private')
       fetchNotes()
     } catch (error) {
       console.error('Failed to create note:', error)
@@ -142,12 +154,16 @@ export function SessionNotesCompact({
             {notes.map(note => (
               <div
                 key={note.id}
-                className="p-3 bg-app-surface rounded-lg border border-app-border hover:border-app-border transition-colors cursor-pointer"
-                onClick={() =>
-                  setExpandedNoteId(expandedNoteId === note.id ? null : note.id)
-                }
+                className="p-3 bg-app-surface rounded-lg border border-app-border hover:border-app-border transition-colors"
               >
-                <div className="flex items-start justify-between gap-2 mb-1">
+                <div
+                  className="flex items-start justify-between gap-2 mb-1 cursor-pointer"
+                  onClick={() =>
+                    setExpandedNoteId(
+                      expandedNoteId === note.id ? null : note.id,
+                    )
+                  }
+                >
                   <h4
                     className={`font-medium text-sm text-app-primary ${expandedNoteId === note.id ? '' : 'line-clamp-1'}`}
                   >
@@ -169,14 +185,34 @@ export function SessionNotesCompact({
 
                 {note.content && (
                   <div
-                    className={`text-sm text-app-secondary ${expandedNoteId === note.id ? '' : 'line-clamp-2'} mb-2 prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0`}
+                    className={`text-sm text-app-secondary ${expandedNoteId === note.id ? '' : 'line-clamp-2'} mb-2 prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0 select-text`}
                     dangerouslySetInnerHTML={{ __html: note.content }}
                   />
                 )}
 
-                <p className="text-xs text-app-secondary">
-                  {formatRelativeTime(note.created_at)}
-                </p>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-app-secondary">
+                    {formatRelativeTime(note.created_at)}
+                  </p>
+                  <button
+                    onClick={() => {
+                      const text = note.content
+                        ? htmlToPlainText(note.content)
+                        : ''
+                      navigator.clipboard.writeText(text)
+                      setCopiedNoteId(note.id)
+                      setTimeout(() => setCopiedNoteId(null), 2000)
+                    }}
+                    className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+                    title="Copy note"
+                  >
+                    {copiedNoteId === note.id ? (
+                      <Check className="h-3.5 w-3.5 text-green-500" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
               </div>
             ))}
           </div>
@@ -189,8 +225,8 @@ export function SessionNotesCompact({
         onOpenChange={open => {
           if (!open) {
             setShowCreateDialog(false)
-            setNewTitle('')
             setNewContent('')
+            setNewNoteType('coach_private')
           }
         }}
       >
@@ -201,13 +237,34 @@ export function SessionNotesCompact({
           <div className="space-y-4 py-4">
             <div>
               <label className="text-sm font-medium text-app-primary mb-1.5 block">
-                Title
+                Visibility
               </label>
-              <Input
-                value={newTitle}
-                onChange={e => setNewTitle(e.target.value)}
-                placeholder="Note title (optional)"
-              />
+              <div className="flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700 rounded-md p-0.5 w-fit">
+                <button
+                  type="button"
+                  onClick={() => setNewNoteType('coach_private')}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+                    newNoteType === 'coach_private'
+                      ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  }`}
+                >
+                  <Lock className="h-3.5 w-3.5" />
+                  Private
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setNewNoteType('shared')}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+                    newNoteType === 'shared'
+                      ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  }`}
+                >
+                  <Users className="h-3.5 w-3.5" />
+                  Shared
+                </button>
+              </div>
             </div>
             <div>
               <label className="text-sm font-medium text-app-primary mb-1.5 block">
@@ -226,8 +283,8 @@ export function SessionNotesCompact({
               variant="outline"
               onClick={() => {
                 setShowCreateDialog(false)
-                setNewTitle('')
                 setNewContent('')
+                setNewNoteType('coach_private')
               }}
             >
               Cancel

--- a/src/components/commitments/commitment-kanban-board.tsx
+++ b/src/components/commitments/commitment-kanban-board.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 import { CommitmentKanbanCard } from '@/components/commitments/commitment-kanban-card'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Circle, PlayCircle, CheckCircle2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Commitment } from '@/types/commitment'
@@ -71,9 +70,12 @@ function KanbanColumn({
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 flex flex-col h-full">
+    <Card className="border-gray-200 dark:border-gray-700 flex flex-col h-full min-h-0 overflow-hidden">
       <CardHeader
-        className={cn('py-3 pt-4 -mt-2 rounded-t-xl border-b', headerBgColor)}
+        className={cn(
+          'py-3 pt-4 -mt-2 rounded-t-xl border-b flex-shrink-0',
+          headerBgColor,
+        )}
       >
         <CardTitle className="text-sm font-semibold flex items-center gap-2">
           <div className={iconColor}>{icon}</div>
@@ -83,39 +85,37 @@ function KanbanColumn({
           </span>
         </CardTitle>
       </CardHeader>
-      <CardContent
+      <div
         className={cn(
-          'p-0 flex-1 transition-colors min-h-0',
+          'p-0 flex-1 transition-colors min-h-0 overflow-y-auto',
           isDragOver && 'bg-primary/5',
         )}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        <ScrollArea className="h-full">
-          <div className="p-3 space-y-3">
-            {commitments.length > 0 ? (
-              commitments.map(commitment => (
-                <CommitmentKanbanCard
-                  key={commitment.id}
-                  commitment={commitment}
-                  targets={targets}
-                  outcomeMap={outcomeMap}
-                  onClick={() => onCommitmentClick?.(commitment)}
-                  onEdit={onEdit ? () => onEdit(commitment) : undefined}
-                  onDelete={onDelete ? () => onDelete(commitment) : undefined}
-                />
-              ))
-            ) : (
-              <div className="text-center py-8 px-4">
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  {emptyMessage}
-                </p>
-              </div>
-            )}
-          </div>
-        </ScrollArea>
-      </CardContent>
+        <div className="p-3 space-y-3">
+          {commitments.length > 0 ? (
+            commitments.map(commitment => (
+              <CommitmentKanbanCard
+                key={commitment.id}
+                commitment={commitment}
+                targets={targets}
+                outcomeMap={outcomeMap}
+                onClick={() => onCommitmentClick?.(commitment)}
+                onEdit={onEdit ? () => onEdit(commitment) : undefined}
+                onDelete={onDelete ? () => onDelete(commitment) : undefined}
+              />
+            ))
+          ) : (
+            <div className="text-center py-8 px-4">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {emptyMessage}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
     </Card>
   )
 }
@@ -140,7 +140,7 @@ export function CommitmentKanbanBoard({
   const doneCommitments = commitments.filter(c => c.status === 'completed')
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 h-[500px]">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 h-[600px] max-h-[70vh]">
       <KanbanColumn
         title="To Do"
         icon={<Circle className="h-4 w-4" />}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-2 rounded-xl border py-2 shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-2 rounded-xl border py-2 shadow-sm pb-4',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Remove max-width constraints on live meeting page for full-width layout
- Fix commitments kanban columns overflowing on client detail page
- Add Private/Shared toggle to Add Note dialog, remove title field
- Add copy button on note cards for quick copying
- Rename "active goal" to "active vision" on client profile

## Test plan
- [ ] Meeting page spans full screen width
- [ ] Kanban columns scroll instead of overflowing
- [ ] Add Note dialog shows visibility toggle, no title field
- [ ] Copy button on notes works correctly
- [ ] Client profile shows "active vision" label