### PR TITLE
Add coach notes, re-enable analysis tab

### DIFF
--- a/src/app/sessions/[sessionId]/components/session-header.tsx
+++ b/src/app/sessions/[sessionId]/components/session-header.tsx
@@ -36,6 +36,7 @@ interface SessionHeaderProps {
     session_type?: string
     title?: string | null
     summary?: string | null
+    coach_notes?: string | null
     client_id?: string | null
     is_group_session?: boolean
     participant_client_ids?: string[]

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -628,14 +628,13 @@ export default function SessionDetailsPage({
                         <LayoutGrid className="h-4 w-4 mr-2" />
                         Overview
                       </TabsTrigger>
-                      {/* Analysis tab hidden temporarily during Meta Performance migration */}
-                      {/* <TabsTrigger
+                      <TabsTrigger
                         value="analysis"
                         className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-800 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
                       >
                         <Brain className="h-4 w-4 mr-2" />
                         Analysis
-                      </TabsTrigger> */}
+                      </TabsTrigger>
                     </TabsList>
                   </Tabs>
 

--- a/src/components/sessions/edit-session-modal.tsx
+++ b/src/components/sessions/edit-session-modal.tsx
@@ -20,6 +20,7 @@ interface Session {
   id: string
   title?: string | null
   summary?: string | null
+  coach_notes?: string | null
 }
 
 interface EditSessionModalProps {
@@ -38,7 +39,7 @@ export function EditSessionModal({
   const updateSession = useUpdateSession()
   const [formData, setFormData] = useState({
     title: '',
-    summary: '',
+    coach_notes: '',
   })
 
   // Populate form when modal opens with session data
@@ -46,7 +47,7 @@ export function EditSessionModal({
     if (open && session) {
       setFormData({
         title: session.title || '',
-        summary: session.summary || '',
+        coach_notes: session.coach_notes || '',
       })
     }
   }, [open, session])
@@ -61,7 +62,7 @@ export function EditSessionModal({
         sessionId: session.id,
         data: {
           title: formData.title.trim() || undefined,
-          summary: formData.summary.trim() || undefined,
+          coach_notes: formData.coach_notes.trim() || undefined,
         },
       })
 
@@ -85,7 +86,7 @@ export function EditSessionModal({
         <DialogHeader>
           <DialogTitle>Edit Session</DialogTitle>
           <DialogDescription>
-            Update the session title and summary
+            Update the session title and notes
           </DialogDescription>
         </DialogHeader>
 
@@ -105,13 +106,13 @@ export function EditSessionModal({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="summary">Summary</Label>
+              <Label htmlFor="coach_notes">Note</Label>
               <Textarea
-                id="summary"
-                placeholder="Brief summary of the session..."
-                value={formData.summary}
+                id="coach_notes"
+                placeholder="Add your notes about this session..."
+                value={formData.coach_notes}
                 onChange={e =>
-                  setFormData({ ...formData, summary: e.target.value })
+                  setFormData({ ...formData, coach_notes: e.target.value })
                 }
                 rows={4}
                 disabled={updateSession.isPending}

--- a/src/components/sessions/session-card.tsx
+++ b/src/components/sessions/session-card.tsx
@@ -364,6 +364,7 @@ export function SessionCard({
             id: session.id,
             title: session.title,
             summary: session.summary,
+            coach_notes: (session as any).coach_notes,
           }}
           onSuccess={() => {
             // Trigger callback if title was updated

--- a/src/services/live-meeting-service.ts
+++ b/src/services/live-meeting-service.ts
@@ -276,7 +276,8 @@ export class LiveMeetingService {
       headers: getGuestHeaders(guestToken),
     })
 
-    return handleResponse<ClientNote[]>(response)
+    const result = await handleResponse<{ data: ClientNote[] }>(response)
+    return result.data
   }
 
   /**

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -17,6 +17,7 @@ export interface SessionUpdateDto {
   status?: string
   ended_at?: string
   summary?: string
+  coach_notes?: string
   key_topics?: string[]
   action_items?: string[]
   session_metadata?: Record<string, any>


### PR DESCRIPTION
## Summary
- Switch edit session modal from editing AI summary to coach_notes (personal notes)
- Re-enable the Analysis tab on session detail page (was hidden during Meta Performance migration)
- Fix live-meeting guest notes response parsing (unwrap `.data` from response)
- Add coach_notes to session types and service DTOs

## Test plan
- [ ] Edit a session → "Note" field saves and persists as coach_notes
- [ ] Analysis tab visible and functional on session detail page
- [ ] Guest notes load correctly on live meeting page

🤖 Generated with [Claude Code](https://claude.com/claude-code)