### PR TITLE
Add missing analysis fields to FullAnalysisResponse type

### DIFF
--- a/src/services/analysis-service.ts
+++ b/src/services/analysis-service.ts
@@ -113,6 +113,11 @@ export interface FullAnalysisResponse {
       engagement: string
     }
     suggestions: string[]
+    score_justifications?: Record<string, string>
+    overall_assessment?: string
+    key_strengths?: string[]
+    areas_for_growth?: string[]
+    breakthrough_moments?: string[]
     analysis_version: string
     processing_time_ms: number
   } | null


### PR DESCRIPTION
## Summary
- Added `score_justifications`, `overall_assessment`, `key_strengths`, `areas_for_growth`, `breakthrough_moments` to `FullAnalysisResponse.coaching` type
- Matches backend fix that now returns these fields