### PR TITLE
Trainee role parity + client/session UI polish

### DIFF
--- a/src/app/admin/access/components/coach-delegation-view.tsx
+++ b/src/app/admin/access/components/coach-delegation-view.tsx
@@ -26,6 +26,7 @@ import {
   useAssignCoachToAdmin,
   useRemoveCoachFromAdmin,
 } from '@/hooks/mutations/use-admin-coach-access-mutations'
+import { isCoachRole } from '@/lib/roles'
 import {
   UserCheck,
   Link2,
@@ -65,7 +66,7 @@ export default function CoachDelegationView({
 
   // Separate users by role with memoization
   const { coaches, admins } = useMemo(() => {
-    const coaches = users.filter(u => u.roles.includes('coach'))
+    const coaches = users.filter(u => isCoachRole(u.roles))
     const admins = users.filter(
       u => u.roles.includes('admin') || u.roles.includes('super_admin'),
     )

--- a/src/app/admin/access/components/hierarchy-view.tsx
+++ b/src/app/admin/access/components/hierarchy-view.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react'
 import { ClientAccessMatrix, User as UserType } from '@/services/admin-service'
 import { useRouter } from 'next/navigation'
+import { isCoachRole } from '@/lib/roles'
 
 interface HierarchyNode {
   type: 'admin' | 'coach' | 'client'
@@ -80,7 +81,7 @@ export default function HierarchyView({
       const admins = usersList.filter(
         u => u.roles.includes('admin') || u.roles.includes('super_admin'),
       )
-      const coaches = usersList.filter(u => u.roles.includes('coach'))
+      const coaches = usersList.filter(u => isCoachRole(u.roles))
 
       // Build admin -> coach -> client hierarchy
       admins.forEach(admin => {

--- a/src/app/admin/access/page.tsx
+++ b/src/app/admin/access/page.tsx
@@ -12,6 +12,7 @@ import HierarchyView from './components/hierarchy-view'
 import CoachDelegationView from './components/coach-delegation-view'
 import ClientAccessView from './components/client-access-view'
 import ListView from './components/list-view'
+import { isCoachRole } from '@/lib/roles'
 
 export default function UnifiedAccessManagementPage() {
   const [activeTab, setActiveTab] = useState('hierarchy')
@@ -40,7 +41,7 @@ export default function UnifiedAccessManagementPage() {
   const stats = useMemo(() => {
     if (isInitialLoading) return null
 
-    const coaches = users.filter(u => u.roles.includes('coach'))
+    const coaches = users.filter(u => isCoachRole(u.roles))
     const admins = users.filter(
       u => u.roles.includes('admin') || u.roles.includes('super_admin'),
     )

--- a/src/app/admin/clients/import/page.tsx
+++ b/src/app/admin/clients/import/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { CSVImportRow } from '@/types/admin-client'
 import { useAdminUsers } from '@/hooks/queries/use-admin-users'
 import { useImportClients } from '@/hooks/mutations/use-admin-client-mutations'
+import { isCoachRole } from '@/lib/roles'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -67,7 +68,7 @@ export default function ImportClientsPage() {
   const { data: users = [] } = useAdminUsers({ limit: 100 })
   const coaches = users.filter(
     u =>
-      u.roles.includes('coach') ||
+      isCoachRole(u.roles) ||
       u.roles.includes('admin') ||
       u.roles.includes('super_admin'),
   )

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -73,6 +73,7 @@ import { useQuery } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-client'
 import axiosInstance from '@/lib/axios-config'
 import { formatDate } from '@/lib/date-utils'
+import { isCoachRole } from '@/lib/roles'
 
 interface Program {
   id: string
@@ -121,7 +122,7 @@ export default function AdminClientsPage() {
   const { data: users = [] } = useAdminUsers({ limit: 100 })
   const coaches = users.filter(
     u =>
-      u.roles.includes('coach') ||
+      isCoachRole(u.roles) ||
       u.roles.includes('admin') ||
       u.roles.includes('super_admin'),
   )

--- a/src/app/admin/coach-access/page.tsx
+++ b/src/app/admin/coach-access/page.tsx
@@ -7,6 +7,7 @@ import {
   useAssignCoachToAdmin,
   useRemoveCoachFromAdmin,
 } from '@/hooks/mutations/use-admin-coach-access-mutations'
+import { isCoachRole } from '@/lib/roles'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -64,7 +65,7 @@ export default function CoachAccessPage() {
 
   // Separate users by role with memoization
   const { coaches, admins } = useMemo(() => {
-    const coaches = users.filter(u => u.roles.includes('coach'))
+    const coaches = users.filter(u => isCoachRole(u.roles))
     const admins = users.filter(
       u => u.roles.includes('admin') || u.roles.includes('super_admin'),
     )

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -121,6 +121,7 @@ export default function AdminDashboard() {
       super_admin: 0,
       admin: 0,
       coach: 0,
+      trainee: 0,
       viewer: 0,
     }
 
@@ -236,7 +237,7 @@ export default function AdminDashboard() {
         />
         <StatCard
           title="Active Coaches"
-          value={stats.roleDistribution.coach}
+          value={stats.roleDistribution.coach + stats.roleDistribution.trainee}
           description="Coaching users"
           icon={
             <TrendingUp className="h-5 w-5 text-purple-600 dark:text-purple-400" />
@@ -285,9 +286,11 @@ export default function AdminDashboard() {
                               ? 'bg-blue-500'
                               : role === 'coach'
                                 ? 'bg-green-500'
-                                : role === 'viewer'
-                                  ? 'bg-gray-500'
-                                  : ''
+                                : role === 'trainee'
+                                  ? 'bg-emerald-400'
+                                  : role === 'viewer'
+                                    ? 'bg-gray-500'
+                                    : ''
                         }`}
                       />
                       <span className="text-sm font-medium text-gray-700 dark:text-gray-300 capitalize">

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -69,6 +69,7 @@ import {
   Send,
 } from 'lucide-react'
 import { CoachInvitationModal } from '@/components/admin/coach-invitation-modal'
+import { isCoachRole } from '@/lib/roles'
 import { formatDate } from '@/lib/date-utils'
 
 export default function UsersPage() {
@@ -286,7 +287,7 @@ export default function UsersPage() {
       admins: users.filter(
         u => u.roles.includes('admin') || u.roles.includes('super_admin'),
       ).length,
-      coaches: users.filter(u => u.roles.includes('coach')).length,
+      coaches: users.filter(u => isCoachRole(u.roles)).length,
     }),
     [users],
   )
@@ -643,7 +644,7 @@ export default function UsersPage() {
                                 <LockKeyhole className="h-4 w-4 mr-2" />
                                 Client Access
                               </DropdownMenuItem>
-                              {user.roles.includes('coach') && (
+                              {isCoachRole(user.roles) && (
                                 <DropdownMenuItem
                                   onClick={() => {
                                     sessionStorage.setItem(
@@ -917,6 +918,8 @@ export default function UsersPage() {
                         'Full system access and control'}
                       {role === 'admin' && 'User and client management'}
                       {role === 'coach' && 'Access to coaching sessions'}
+                      {role === 'trainee' &&
+                        'Coach in training — full coach access; AI suggestions hidden during live meetings'}
                       {role === 'viewer' && 'Read-only access'}
                     </p>
                   </div>
@@ -927,6 +930,7 @@ export default function UsersPage() {
                   )}
                   {role === 'admin' && <Shield className="h-3 w-3 mr-1" />}
                   {role === 'coach' && <UserCheck className="h-3 w-3 mr-1" />}
+                  {role === 'trainee' && <UserCheck className="h-3 w-3 mr-1" />}
                   {role === 'viewer' && <Eye className="h-3 w-3 mr-1" />}
                   {formatRoleName(role)}
                 </Badge>

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -13,7 +13,7 @@ export default function AuthPage() {
   useEffect(() => {
     if (isAuthenticated && !loading) {
       const hasAdmin = roles.some(r => ['admin', 'super_admin'].includes(r))
-      const hasCoach = roles.includes('coach')
+      const hasCoach = roles.includes('coach') || roles.includes('trainee')
       const hasClient = roles.includes('client')
       const isClientOnly = roles.length === 1 && hasClient
 

--- a/src/app/clients/[clientId]/components/empty-state-welcome.tsx
+++ b/src/app/clients/[clientId]/components/empty-state-welcome.tsx
@@ -1,10 +1,17 @@
 'use client'
 
-import { Mic, FileText, Target, ChevronRight } from 'lucide-react'
+import {
+  Mic,
+  FileText,
+  Target,
+  CalendarClock,
+  ChevronRight,
+} from 'lucide-react'
 
 interface EmptyStateWelcomeProps {
   client: any
   onStartSession: () => void
+  onScheduleSession: () => void
   onAddPastSession: () => void
   onSetGoals: () => void
 }
@@ -12,6 +19,7 @@ interface EmptyStateWelcomeProps {
 export function EmptyStateWelcome({
   client,
   onStartSession,
+  onScheduleSession,
   onAddPastSession,
   onSetGoals,
 }: EmptyStateWelcomeProps) {
@@ -55,6 +63,26 @@ export function EmptyStateWelcome({
         <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-3">
           Or choose another option
         </p>
+
+        <button
+          onClick={onScheduleSession}
+          className="w-full group flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all"
+        >
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+              <CalendarClock className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            </div>
+            <div className="text-left">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-white">
+                Schedule Session
+              </h4>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Book a future session and send a questionnaire
+              </p>
+            </div>
+          </div>
+          <ChevronRight className="h-4 w-4 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
+        </button>
 
         <button
           onClick={onAddPastSession}

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -357,6 +357,9 @@ export default function ClientDetailPage({
                 onStartSession={() =>
                   modalState.setIsStartSessionModalOpen(true)
                 }
+                onScheduleSession={() =>
+                  modalState.setIsScheduleSessionModalOpen(true)
+                }
                 onAddPastSession={() =>
                   modalState.setIsManualSessionModalOpen(true)
                 }

--- a/src/app/components/recent-clients.tsx
+++ b/src/app/components/recent-clients.tsx
@@ -43,7 +43,11 @@ export default function RecentClients({
     )
   }
 
-  if (clients.length === 0) {
+  // Show empty state when the coach has no owned clients. Users who only
+  // see clients via ClientAccess (assigned clients or their own client-portal
+  // profile) also land here, because the dashboard "My Clients" card is
+  // scoped to clients they own.
+  if (myClients.length === 0) {
     return (
       <Card className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
         <CardHeader className="border-b border-gray-200 dark:border-gray-700 pb-4">

--- a/src/app/meeting/[botId]/components/meeting-header.tsx
+++ b/src/app/meeting/[botId]/components/meeting-header.tsx
@@ -8,19 +8,11 @@ import { BotStatus } from '@/components/meeting/bot-status'
 import { WebSocketStatus } from '@/components/meeting/websocket-status'
 import { ClientMeetingLink } from '@/components/meeting/client-meeting-link'
 import { Bot } from '@/types/meeting'
-import {
-  ArrowLeft,
-  ExternalLink,
-  Users,
-  MessageSquare,
-  Moon,
-  Sun,
-} from 'lucide-react'
+import { ArrowLeft, ExternalLink, Moon, Sun } from 'lucide-react'
 import { GroupSessionBadge } from '@/components/group-session/group-session-badge'
 
 interface MeetingHeaderProps {
   bot: Bot | null
-  transcriptLength: number
   isStoppingBot: boolean
   sessionId?: string | null
   clientId?: string | null
@@ -32,7 +24,6 @@ interface MeetingHeaderProps {
 
 export default function MeetingHeader({
   bot,
-  transcriptLength,
   isStoppingBot,
   sessionId,
   clientId,
@@ -91,19 +82,6 @@ export default function MeetingHeader({
 
           {bot && (
             <div className="flex items-center gap-3">
-              <div className="hidden sm:flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
-                <div className="flex items-center gap-1">
-                  <Users className="h-4 w-4" />
-                  <span className="capitalize">
-                    {bot.platform || 'Unknown'}
-                  </span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <MessageSquare className="h-4 w-4" />
-                  <span>{transcriptLength} entries</span>
-                </div>
-              </div>
-
               {/* Client Meeting Link - inline with actions */}
               {sessionId && (
                 <>

--- a/src/app/meeting/[botId]/components/meeting-panels.tsx
+++ b/src/app/meeting/[botId]/components/meeting-panels.tsx
@@ -53,6 +53,7 @@ import { MeetingResourcesPanel } from './meeting-resources-panel'
 import { PreSessionResponsesCompact } from '@/components/meeting/pre-session-responses-compact'
 import { useResources } from '@/hooks/queries/use-resources'
 import { useShareResource } from '@/hooks/mutations/use-resource-mutations'
+import { useAuth } from '@/contexts/auth-context'
 import { CATEGORY_COLORS } from '@/types/resource'
 import type { ResourceCategory } from '@/types/resource'
 
@@ -86,6 +87,8 @@ export default function MeetingPanels({
   isGroupSession,
   isMeetingEnded,
 }: MeetingPanelsProps) {
+  const { hasRole } = useAuth()
+  const isTrainee = hasRole('trainee')
   const [fullContext, setFullContext] = useState<any>(null)
   const [patterns, setPatterns] = useState<any[]>([])
   const [contextLoading, setContextLoading] = useState(true)
@@ -207,128 +210,136 @@ export default function MeetingPanels({
 
   return (
     <div className="h-full flex overflow-hidden">
-      {/* AI Suggestions Toggle Button */}
-      <div className="flex-shrink-0 flex items-start pt-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setAiSuggestionsOpen(!aiSuggestionsOpen)}
-          className={cn(
-            'h-auto py-3 px-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-r-lg rounded-l-none border-l-0',
-            aiSuggestionsOpen && 'bg-gray-100 dark:bg-gray-700',
-          )}
-        >
-          <div className="flex flex-col items-center gap-2">
-            {aiSuggestionsOpen ? (
-              <PanelLeftClose className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-            ) : (
-              <PanelLeftOpen className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-            )}
-            <Sparkles className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-          </div>
-        </Button>
-      </div>
-
-      {/* Collapsible AI Suggestions Panel + Resources */}
-      <div
-        className={cn(
-          'flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ease-in-out overflow-hidden',
-          aiSuggestionsOpen ? 'w-72 xl:w-80 2xl:w-96' : 'w-0',
-        )}
-      >
-        <div className="w-72 xl:w-80 2xl:w-96 h-full flex flex-col">
-          <div className="flex-1 min-h-0 overflow-hidden">
-            <CoachingPanel
-              botId={botId}
-              className="h-full shadow-sm"
-              simplified={true}
-            />
-          </div>
-
-          {/* Resources section below AI suggestions */}
-          {allResources.length > 0 && (
-            <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 overflow-hidden">
-              <button
-                onClick={() => setResourcesOpen(!resourcesOpen)}
-                className="w-full flex items-center justify-between px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-              >
-                <div className="flex items-center gap-2">
-                  <BookOpen className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
-                  <span className="text-xs font-semibold text-gray-900 dark:text-white">
-                    Resources
-                  </span>
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] px-1 py-0 h-4"
-                  >
-                    {allResources.length}
-                  </Badge>
-                </div>
-                {resourcesOpen ? (
-                  <ChevronUp className="h-3 w-3 text-gray-400" />
+      {!isTrainee && (
+        <>
+          {/* AI Suggestions Toggle Button */}
+          <div className="flex-shrink-0 flex items-start pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAiSuggestionsOpen(!aiSuggestionsOpen)}
+              className={cn(
+                'h-auto py-3 px-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-r-lg rounded-l-none border-l-0',
+                aiSuggestionsOpen && 'bg-gray-100 dark:bg-gray-700',
+              )}
+            >
+              <div className="flex flex-col items-center gap-2">
+                {aiSuggestionsOpen ? (
+                  <PanelLeftClose className="h-4 w-4 text-gray-600 dark:text-gray-400" />
                 ) : (
-                  <ChevronDown className="h-3 w-3 text-gray-400" />
+                  <PanelLeftOpen className="h-4 w-4 text-gray-600 dark:text-gray-400" />
                 )}
-              </button>
+                <Sparkles className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+              </div>
+            </Button>
+          </div>
 
-              {resourcesOpen && (
-                <div className="px-3 pb-2 max-h-[180px] overflow-y-auto space-y-0.5">
-                  {allResources.map(resource => {
-                    const Icon =
-                      RESOURCE_CATEGORY_ICONS[resource.category] || FileText
-                    const colors =
-                      CATEGORY_COLORS[resource.category as ResourceCategory] ||
-                      CATEGORY_COLORS.general
-                    const alreadyShared = isResourceSharedWithClient(resource)
-                    const isSharing = sharingResourceId === resource.id
-                    const targetClientId = commitmentClientId || clientId
+          {/* Collapsible AI Suggestions Panel + Resources */}
+          <div
+            className={cn(
+              'flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ease-in-out overflow-hidden',
+              aiSuggestionsOpen ? 'w-72 xl:w-80 2xl:w-96' : 'w-0',
+            )}
+          >
+            <div className="w-72 xl:w-80 2xl:w-96 h-full flex flex-col">
+              <div className="flex-1 min-h-0 overflow-hidden">
+                <CoachingPanel
+                  botId={botId}
+                  className="h-full shadow-sm"
+                  simplified={true}
+                />
+              </div>
 
-                    return (
-                      <div
-                        key={resource.id}
-                        className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              {/* Resources section below AI suggestions */}
+              {allResources.length > 0 && (
+                <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 overflow-hidden">
+                  <button
+                    onClick={() => setResourcesOpen(!resourcesOpen)}
+                    className="w-full flex items-center justify-between px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      <BookOpen className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                      <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                        Resources
+                      </span>
+                      <Badge
+                        variant="secondary"
+                        className="text-[10px] px-1 py-0 h-4"
                       >
-                        <div className={`p-1 rounded ${colors.bg} shrink-0`}>
-                          <Icon className={`h-3 w-3 ${colors.text}`} />
-                        </div>
-                        <p className="flex-1 min-w-0 text-[11px] font-medium text-gray-900 dark:text-white truncate">
-                          {resource.title}
-                        </p>
-                        {targetClientId &&
-                          (alreadyShared ? (
-                            <div className="shrink-0 flex items-center gap-0.5 text-green-600 dark:text-green-400">
-                              <Check className="h-2.5 w-2.5" />
-                              <span className="text-[9px] font-medium">
-                                Shared
-                              </span>
-                            </div>
-                          ) : (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              className="h-5 text-[9px] px-1.5 shrink-0"
-                              onClick={() => handleQuickShare(resource.id)}
-                              disabled={isSharing}
+                        {allResources.length}
+                      </Badge>
+                    </div>
+                    {resourcesOpen ? (
+                      <ChevronUp className="h-3 w-3 text-gray-400" />
+                    ) : (
+                      <ChevronDown className="h-3 w-3 text-gray-400" />
+                    )}
+                  </button>
+
+                  {resourcesOpen && (
+                    <div className="px-3 pb-2 max-h-[180px] overflow-y-auto space-y-0.5">
+                      {allResources.map(resource => {
+                        const Icon =
+                          RESOURCE_CATEGORY_ICONS[resource.category] || FileText
+                        const colors =
+                          CATEGORY_COLORS[
+                            resource.category as ResourceCategory
+                          ] || CATEGORY_COLORS.general
+                        const alreadyShared =
+                          isResourceSharedWithClient(resource)
+                        const isSharing = sharingResourceId === resource.id
+                        const targetClientId = commitmentClientId || clientId
+
+                        return (
+                          <div
+                            key={resource.id}
+                            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                          >
+                            <div
+                              className={`p-1 rounded ${colors.bg} shrink-0`}
                             >
-                              {isSharing ? (
-                                <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                              <Icon className={`h-3 w-3 ${colors.text}`} />
+                            </div>
+                            <p className="flex-1 min-w-0 text-[11px] font-medium text-gray-900 dark:text-white truncate">
+                              {resource.title}
+                            </p>
+                            {targetClientId &&
+                              (alreadyShared ? (
+                                <div className="shrink-0 flex items-center gap-0.5 text-green-600 dark:text-green-400">
+                                  <Check className="h-2.5 w-2.5" />
+                                  <span className="text-[9px] font-medium">
+                                    Shared
+                                  </span>
+                                </div>
                               ) : (
-                                <>
-                                  <Share2 className="h-2.5 w-2.5 mr-0.5" />
-                                  Share
-                                </>
-                              )}
-                            </Button>
-                          ))}
-                      </div>
-                    )
-                  })}
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-5 text-[9px] px-1.5 shrink-0"
+                                  onClick={() => handleQuickShare(resource.id)}
+                                  disabled={isSharing}
+                                >
+                                  {isSharing ? (
+                                    <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                                  ) : (
+                                    <>
+                                      <Share2 className="h-2.5 w-2.5 mr-0.5" />
+                                      Share
+                                    </>
+                                  )}
+                                </Button>
+                              ))}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
                 </div>
               )}
             </div>
-          )}
-        </div>
-      </div>
+          </div>
+        </>
+      )}
 
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col min-h-0 overflow-hidden p-1">

--- a/src/app/meeting/[botId]/page.tsx
+++ b/src/app/meeting/[botId]/page.tsx
@@ -135,7 +135,6 @@ export default function MeetingPage() {
       <div className="flex-shrink-0 z-10">
         <MeetingHeader
           bot={bot}
-          transcriptLength={transcript.length}
           isStoppingBot={isStoppingBot}
           sessionId={sessionId}
           clientId={clientId}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,9 +124,13 @@ export default function CoachDashboard() {
     }
   }
 
-  // Determine if this is a new coach (no clients and no sessions)
+  // Determine if this is a new coach (no owned clients and no sessions).
+  // We count only owned clients — a user may see assigned or self-portal
+  // clients via ClientAccess, but "new coach" guidance is about getting
+  // started with your own clients.
+  const ownedClientsCount = clients.filter(c => c.is_my_client !== false).length
   const isNewCoach =
-    !clientsLoading && clients.length === 0 && totalSessions === 0
+    !clientsLoading && ownedClientsCount === 0 && totalSessions === 0
 
   // Show empty state with guidance for new coaches
   if (isNewCoach && canCreateMeeting) {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -460,7 +460,9 @@ export default function ProfilePage() {
                 </div>
 
                 {/* Show client access for coaches and viewers */}
-                {(hasRole('coach') || hasRole('viewer')) &&
+                {(hasRole('coach') ||
+                  hasRole('trainee') ||
+                  hasRole('viewer')) &&
                   profile?.client_access &&
                   profile.client_access.length > 0 && (
                     <div className="border-t pt-4">

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/services/analysis-service'
 import { SessionService } from '@/services/session-service'
 import { StartBotCard } from './components/start-bot-card'
+import { AnalysisPrintView } from './components/analysis-print-view'
 import { PreSessionResponses } from './components/pre-session-responses'
 import { CommitmentCreatePanel } from '@/components/commitments/commitment-create-panel'
 import { CommitmentDetailPanel } from '@/components/commitments/commitment-detail-panel'
@@ -511,9 +512,6 @@ export default function SessionDetailsPage({
                   clientId={clientId}
                 />
 
-                {/* Quick Note */}
-                {!isViewer && <QuickNote sessionId={session.id} />}
-
                 {/* Start Bot Card */}
                 {!isViewer && (
                   <StartBotCard
@@ -526,6 +524,9 @@ export default function SessionDetailsPage({
                     onShowUploader={() => setShowUploaderForScheduled(true)}
                   />
                 )}
+
+                {/* Quick Note */}
+                {!isViewer && <QuickNote sessionId={session.id} />}
               </div>
             ) : isScheduled && showUploaderForScheduled ? (
               <div className="max-w-2xl mx-auto space-y-4">
@@ -805,7 +806,33 @@ export default function SessionDetailsPage({
                           }
                         />
 
-                        {/* Detailed Analysis */}
+                        {/* Print Button + Detailed Analysis */}
+                        <div className="flex justify-end">
+                          <AnalysisPrintView
+                            insights={analysisData.insights || undefined}
+                            coaching={
+                              analysisData.coaching
+                                ? {
+                                    ...analysisData.coaching,
+                                    session_id: analysisData.session_id,
+                                    timestamp: analysisData.timestamp,
+                                  }
+                                : undefined
+                            }
+                            sessionTitle={
+                              session.title ||
+                              `Session ${formatDate(session.started_at || session.created_at)}`
+                            }
+                            clientName={
+                              session.client_name || session.client?.name
+                            }
+                            coachName={session.coach_name}
+                            sessionDate={
+                              session.started_at || session.created_at
+                            }
+                          />
+                        </div>
+
                         <SessionAnalysisMerged
                           insights={analysisData.insights || undefined}
                           coaching={

--- a/src/components/auth/coach-route.tsx
+++ b/src/components/auth/coach-route.tsx
@@ -21,7 +21,7 @@ export function CoachRoute({ children }: CoachRouteProps) {
       } else {
         // Check if user has coach, admin, super_admin, or viewer role
         const hasCoachAccess = roles.some(role =>
-          ['coach', 'admin', 'super_admin', 'viewer'].includes(role),
+          ['coach', 'trainee', 'admin', 'super_admin', 'viewer'].includes(role),
         )
 
         if (!hasCoachAccess) {
@@ -47,7 +47,7 @@ export function CoachRoute({ children }: CoachRouteProps) {
 
   // Check if user has coach access
   const hasCoachAccess = roles.some(role =>
-    ['coach', 'admin', 'super_admin', 'viewer'].includes(role),
+    ['coach', 'trainee', 'admin', 'super_admin', 'viewer'].includes(role),
   )
 
   if (!hasCoachAccess) {

--- a/src/components/auth/role-switcher.tsx
+++ b/src/components/auth/role-switcher.tsx
@@ -41,7 +41,7 @@ export function RoleSwitcher() {
     })
   }
 
-  if (hasRole('coach')) {
+  if (hasRole('coach') || hasRole('trainee')) {
     roleViews.push({
       role: 'coach',
       label: 'Coach Dashboard',

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -202,7 +202,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     checkRoles.some(role => roles.includes(role))
   const isAdmin = () => hasAnyRole(['super_admin', 'admin'])
   const isSuperAdmin = () => hasRole('super_admin')
-  const isCoach = () => hasRole('coach')
+  const isCoach = () => hasRole('coach') || hasRole('trainee')
   const isViewer = () => hasRole('viewer')
   const isClient = () => hasRole('client') // NEW
 

--- a/src/contexts/permission-context.tsx
+++ b/src/contexts/permission-context.tsx
@@ -166,7 +166,7 @@ export function PermissionProvider({
       effectivePermissions = ROLE_PERMISSIONS.super_admin
     } else if (hasRole('admin')) {
       effectivePermissions = ROLE_PERMISSIONS.admin
-    } else if (hasRole('coach')) {
+    } else if (hasRole('coach') || hasRole('trainee')) {
       effectivePermissions = ROLE_PERMISSIONS.coach
     } else if (hasRole('viewer')) {
       effectivePermissions = ROLE_PERMISSIONS.viewer
@@ -200,7 +200,7 @@ export function PermissionProvider({
           // This would need to be checked against actual data
           return true // For now, assume admin has access
         }
-        if (hasRole('coach')) {
+        if (hasRole('coach') || hasRole('trainee')) {
           // Coach needs to own the client
           // This would need to be checked against actual data
           return true // For now, assume coach has access
@@ -220,7 +220,7 @@ export function PermissionProvider({
       if (!permissions.client.edit) return false
 
       // Additional checks for specific client could go here
-      if (clientId && hasRole('coach')) {
+      if (clientId && (hasRole('coach') || hasRole('trainee'))) {
         // Coach can only edit their own clients
         // This would need to be checked against actual data
         return true
@@ -233,7 +233,7 @@ export function PermissionProvider({
       if (!permissions.client.delete) return false
 
       // Additional checks for specific client could go here
-      if (clientId && hasRole('coach')) {
+      if (clientId && (hasRole('coach') || hasRole('trainee'))) {
         // Coach can only delete their own clients
         // This would need to be checked against actual data
         return true
@@ -275,7 +275,10 @@ export function PermissionProvider({
     },
 
     isViewerOnly: () => {
-      return hasRole('viewer') && !hasAnyRole(['super_admin', 'admin', 'coach'])
+      return (
+        hasRole('viewer') &&
+        !hasAnyRole(['super_admin', 'admin', 'coach', 'trainee'])
+      )
     },
 
     isViewer: () => {
@@ -283,7 +286,7 @@ export function PermissionProvider({
     },
 
     isCoach: () => {
-      return hasRole('coach')
+      return hasRole('coach') || hasRole('trainee')
     },
 
     isAdmin: () => {

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,15 @@
+/**
+ * Role helpers.
+ *
+ * The `trainee` role is a self-sufficient, coach-equivalent role — trainees
+ * should appear and behave like coaches in admin UIs (dropdowns, stats,
+ * delegation pickers, impersonation, etc.). Only the AI suggestions path
+ * is explicitly suppressed for trainees during live meetings.
+ *
+ * Use `isCoachRole()` for any admin-side filter that asks "is this user a
+ * coach?" so we don't drift back to raw `roles.includes('coach')` checks.
+ */
+export const isCoachRole = (roles: string[] | undefined | null): boolean => {
+  if (!roles) return false
+  return roles.includes('coach') || roles.includes('trainee')
+}

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -293,7 +293,7 @@ class AuthService {
   }
 
   isCoach(): boolean {
-    return this.hasRole('coach')
+    return this.hasRole('coach') || this.hasRole('trainee')
   }
 
   isViewer(): boolean {


### PR DESCRIPTION
## Summary
- Full trainee-as-coach parity across admin UIs (stats, pickers, delegation, View-as-Coach, role description) via new `isCoachRole()` helper
- Trainees now hit the getting-started dashboard when they have no owned clients (was blank left column)
- Client detail empty state gains a **Schedule Session** option
- Scheduled session page shows **Ready to Start** above Notes
- AI Suggestions panel hidden for trainees in live meetings
- Meeting header declutter (drop inline platform/entries counter)

## Test plan
- [ ] As super_admin: open `/admin/users` — "Coaches" stat includes trainees, View-as-Coach appears on trainee rows, Manage Roles shows Trainee description
- [ ] As super_admin: `/admin/clients` bulk-assign, `/admin/clients/import`, `/admin/coach-access`, `/admin/access`, `/admin/dashboard` — trainees appear everywhere coaches do
- [ ] As a trainee with no owned clients: dashboard shows the welcome/getting-started screen
- [ ] As a trainee: join live meeting — AI Suggestions panel hidden
- [ ] Any coach: open a client with no sessions — see Schedule Session button; it opens the modal with the client preselected
- [ ] Any coach: open a scheduled session — Ready to Start card is above Notes