### PR TITLE
Add View Client Portal button for coaches (flagged off)

### DIFF
--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -57,12 +57,16 @@ import { ClientWinsTimeline } from '@/components/wins/client-wins-timeline'
 import { ClientResourcesTab } from './components/client-resources-tab'
 import { ClientUpcomingSessions } from './components/client-upcoming-sessions'
 
+// Feature flag: hides the "View Client Portal" button while the feature is gated off.
+// Backend already authorizes coaches with client access — flip to true to expose the UI.
+const SHOW_VIEW_AS_CLIENT = false
+
 export default function ClientDetailPage({
   params,
 }: {
   params: Promise<{ clientId: string }>
 }) {
-  const { userId, isSuperAdmin } = useAuth()
+  const { userId, hasClientAccess } = useAuth()
   const permissions = usePermissions()
   const isViewer = permissions.isViewer()
   const router = useRouter()
@@ -332,7 +336,8 @@ export default function ClientDetailPage({
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Clients
               </Button>
-              {isSuperAdmin() && client && (
+              {/* View Client Portal hidden for now — backend authorizes it, flip SHOW_VIEW_AS_CLIENT to enable. */}
+              {SHOW_VIEW_AS_CLIENT && client && hasClientAccess(client.id) && (
                 <Button
                   variant="outline"
                   size="sm"


### PR DESCRIPTION
## Summary

- Switches the "View Client Portal" button on `/clients/[clientId]` from `isSuperAdmin()` to `hasClientAccess(client.id)` so coaches/admins can use it for their own clients.
- Gates the button behind a local `SHOW_VIEW_AS_CLIENT = false` flag — UI stays hidden for now, flip to `true` to expose.
- Backend authorization (coach/trainee via `ClientAccess`) already shipped in ainovusdev/coach-sidekick-backend#20.

## Test plan

- [ ] Super admin still sees no button while flag is off (expected)
- [ ] No role change causes the button to appear while flag is off
- [ ] When flag is flipped on: super_admin, admin, coach, trainee all see the button on `/clients/[clientId]` for accessible clients
- [ ] Clicking routes to `/client-portal/dashboard`, amber banner shows "Viewing portal as: {name}", Exit Preview returns to client detail page