### PR TITLE
Show session recording on session detail page

### DIFF
--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -30,7 +30,7 @@ import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
 import { PreSessionResponses } from './pre-session-responses'
 import TranscriptViewer from './transcript-viewer'
-// import { VideoPlayer } from '@/components/sessions/video-player'
+import { VideoPlayer } from '@/components/sessions/video-player'
 
 interface TranscriptEntry {
   id: string
@@ -257,14 +257,14 @@ export function SessionOverviewTab({
         </Card>
       )}
 
-      {/* Session Recording — hidden for now */}
-      {/* {videoUrl && onRefreshVideoUrl && !isViewer && (
+      {/* Session Recording */}
+      {videoUrl && onRefreshVideoUrl && !isViewer && (
         <VideoPlayer
           videoUrl={videoUrl}
           sessionId={sessionId}
           onRefresh={onRefreshVideoUrl}
         />
-      )} */}
+      )}
 
       {/* Commitments and Wins */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- Uncommented the `VideoPlayer` component on the session overview tab
- All plumbing (webhook → S3 transfer → `session_metadata.video_url` → session detail API → refresh handler + props) was already built; only the render was hidden
- Keeps the existing `!isViewer` gate so clients don't see the recording in the client portal

## Test plan
- [ ] Open a completed session with a recording as coach — player renders with controls
- [ ] Refresh the presigned URL via the button — new URL fetched, player reloads
- [ ] Open as client (client portal) — no player shown
- [ ] Session without a recording (e.g. past-session upload, no bot) — no player shown (component gated on `videoUrl` truthiness)