### PR TITLE
Hide session recording UI

### DIFF
--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -30,7 +30,7 @@ import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
 import { PreSessionResponses } from './pre-session-responses'
 import TranscriptViewer from './transcript-viewer'
-import { VideoPlayer } from '@/components/sessions/video-player'
+// import { VideoPlayer } from '@/components/sessions/video-player'
 
 interface TranscriptEntry {
   id: string
@@ -84,10 +84,10 @@ export function SessionOverviewTab({
   clientId,
   transcript,
   isViewer = false,
-  videoUrl,
+  videoUrl: _videoUrl,
   onViewAnalysis,
   onRefreshCommitments,
-  onRefreshVideoUrl,
+  onRefreshVideoUrl: _onRefreshVideoUrl,
   isGroupSession = false,
   selectedClientId = null,
   clientAnalyses,
@@ -257,14 +257,14 @@ export function SessionOverviewTab({
         </Card>
       )}
 
-      {/* Session Recording */}
-      {videoUrl && onRefreshVideoUrl && !isViewer && (
+      {/* Session Recording — hidden for now */}
+      {/* {videoUrl && onRefreshVideoUrl && !isViewer && (
         <VideoPlayer
           videoUrl={videoUrl}
           sessionId={sessionId}
           onRefresh={onRefreshVideoUrl}
         />
-      )}
+      )} */}
 
       {/* Commitments and Wins */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- Re-commented the `<VideoPlayer>` import + JSX on the session overview tab
- Backend pipeline (S3 transfer, `video_url` on `session_metadata`, refresh endpoint) stays intact
- Restored underscore aliases on `videoUrl` / `onRefreshVideoUrl` params so unused-var lint passes

## Test plan
- [x] `pnpm build` passes locally
- [ ] Session detail page renders without a video player