### PR TITLE
Coach session evaluations, review-page polish, nav cleanup

### DIFF
--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -57,10 +57,6 @@ import { ClientWinsTimeline } from '@/components/wins/client-wins-timeline'
 import { ClientResourcesTab } from './components/client-resources-tab'
 import { ClientUpcomingSessions } from './components/client-upcoming-sessions'
 
-// Feature flag: hides the "View Client Portal" button while the feature is gated off.
-// Backend already authorizes coaches with client access — flip to true to expose the UI.
-const SHOW_VIEW_AS_CLIENT = false
-
 export default function ClientDetailPage({
   params,
 }: {
@@ -336,8 +332,7 @@ export default function ClientDetailPage({
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Clients
               </Button>
-              {/* View Client Portal hidden for now — backend authorizes it, flip SHOW_VIEW_AS_CLIENT to enable. */}
-              {SHOW_VIEW_AS_CLIENT && client && hasClientAccess(client.id) && (
+              {client && hasClientAccess(client.id) && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -40,7 +40,6 @@ import {
   Trophy,
   BookOpen,
   XCircle,
-  Eye,
 } from 'lucide-react'
 import {
   AlertDialog,
@@ -62,7 +61,7 @@ export default function ClientDetailPage({
 }: {
   params: Promise<{ clientId: string }>
 }) {
-  const { userId, hasClientAccess } = useAuth()
+  const { userId } = useAuth()
   const permissions = usePermissions()
   const isViewer = permissions.isViewer()
   const router = useRouter()
@@ -332,20 +331,6 @@ export default function ClientDetailPage({
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Clients
               </Button>
-              {client && hasClientAccess(client.id) && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    sessionStorage.setItem('view_as_client_id', client.id)
-                    sessionStorage.setItem('view_as_client_name', client.name)
-                    router.push('/client-portal/dashboard')
-                  }}
-                >
-                  <Eye className="h-4 w-4 mr-2" />
-                  View Client Portal
-                </Button>
-              )}
             </div>
           </div>
 

--- a/src/app/components/recent-sessions-to-review.tsx
+++ b/src/app/components/recent-sessions-to-review.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowRight, Users } from 'lucide-react'
+import { useSessions } from '@/hooks/queries/use-sessions'
+import { SharedSessionRow } from '@/components/sessions/shared-session-row'
+
+/**
+ * Surfaces the 3 most recently shared-with-me sessions on the homepage so a
+ * coach lands and sees what's waiting for their review. Renders nothing when
+ * there's nothing to review — no empty state, no loading skeleton, just
+ * absent — so the dashboard doesn't carry dead real estate for coaches who
+ * never receive shares.
+ */
+export function RecentSessionsToReview() {
+  const router = useRouter()
+  const { data, isLoading, error } = useSessions(
+    { scope: 'shared', per_page: 3 },
+    { staleTime: 60 * 1000 },
+  )
+
+  // Hide the section entirely on first load, errors, or empty results — the
+  // homepage shouldn't carry real estate for a feature the user isn't using.
+  if (isLoading || error) return null
+  const sessions = data?.sessions ?? []
+  if (sessions.length === 0) return null
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            Recent sessions to review
+          </h2>
+        </div>
+        <Link
+          href="/sessions/shared"
+          className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700"
+        >
+          View all
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      <div className="space-y-3">
+        {sessions.map((s: any) => (
+          <SharedSessionRow
+            key={s.id}
+            session={s}
+            onOpen={id => router.push(`/sessions/${id}/review`)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { useDashboardData } from './hooks/use-dashboard-data'
 import { useSessions } from '@/hooks/queries/use-sessions'
 import RecentClients from './components/recent-clients'
 import RecentSessions from './components/recent-sessions'
+import { RecentSessionsToReview } from './components/recent-sessions-to-review'
 import LiveSessionBanner from './components/live-session-banner'
 import StartRecording from './components/start-recording'
 import { AttentionNeeded } from './components/attention-needed'
@@ -378,6 +379,9 @@ export default function CoachDashboard() {
 
           {/* Attention Needed Alerts */}
           <AttentionNeeded clients={clients} />
+
+          {/* Sessions other coaches have shared for review (hidden when none) */}
+          <RecentSessionsToReview />
 
           {/* Bottom Section: Recent Sessions (Full Width) */}
           <RecentSessions

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -257,14 +257,6 @@ export function SessionOverviewTab({
         </Card>
       )}
 
-      {videoUrl && onRefreshVideoUrl && !isViewer && (
-        <VideoPlayer
-          videoUrl={videoUrl}
-          sessionId={sessionId}
-          onRefresh={onRefreshVideoUrl}
-        />
-      )}
-
       {/* Commitments and Wins */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {!isViewer &&
@@ -522,6 +514,15 @@ export function SessionOverviewTab({
             </CardContent>
           </Card>
         )}
+
+      {/* Session Recording */}
+      {videoUrl && onRefreshVideoUrl && !isViewer && (
+        <VideoPlayer
+          videoUrl={videoUrl}
+          sessionId={sessionId}
+          onRefresh={onRefreshVideoUrl}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -30,7 +30,7 @@ import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
 import { PreSessionResponses } from './pre-session-responses'
 import TranscriptViewer from './transcript-viewer'
-// import { VideoPlayer } from '@/components/sessions/video-player'
+import { VideoPlayer } from '@/components/sessions/video-player'
 
 interface TranscriptEntry {
   id: string
@@ -84,10 +84,10 @@ export function SessionOverviewTab({
   clientId,
   transcript,
   isViewer = false,
-  videoUrl: _videoUrl,
+  videoUrl,
   onViewAnalysis,
   onRefreshCommitments,
-  onRefreshVideoUrl: _onRefreshVideoUrl,
+  onRefreshVideoUrl,
   isGroupSession = false,
   selectedClientId = null,
   clientAnalyses,
@@ -257,14 +257,13 @@ export function SessionOverviewTab({
         </Card>
       )}
 
-      {/* Session Recording — hidden for now */}
-      {/* {videoUrl && onRefreshVideoUrl && !isViewer && (
+      {videoUrl && onRefreshVideoUrl && !isViewer && (
         <VideoPlayer
           videoUrl={videoUrl}
           sessionId={sessionId}
           onRefresh={onRefreshVideoUrl}
         />
-      )} */}
+      )}
 
       {/* Commitments and Wins */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -30,7 +30,6 @@ import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
 import { PreSessionResponses } from './pre-session-responses'
 import TranscriptViewer from './transcript-viewer'
-import { VideoPlayer } from '@/components/sessions/video-player'
 
 interface TranscriptEntry {
   id: string
@@ -63,10 +62,8 @@ interface SessionOverviewTabProps {
   clientId?: string
   transcript?: TranscriptEntry[]
   isViewer?: boolean
-  videoUrl?: string | null
   onViewAnalysis: () => void
   onRefreshCommitments?: () => void
-  onRefreshVideoUrl?: () => Promise<void>
   isGroupSession?: boolean
   selectedClientId?: string | null
   clientAnalyses?: Record<string, ClientAnalysis>
@@ -84,10 +81,8 @@ export function SessionOverviewTab({
   clientId,
   transcript,
   isViewer = false,
-  videoUrl,
   onViewAnalysis,
   onRefreshCommitments,
-  onRefreshVideoUrl,
   isGroupSession = false,
   selectedClientId = null,
   clientAnalyses,
@@ -515,14 +510,7 @@ export function SessionOverviewTab({
           </Card>
         )}
 
-      {/* Session Recording */}
-      {videoUrl && onRefreshVideoUrl && !isViewer && (
-        <VideoPlayer
-          videoUrl={videoUrl}
-          sessionId={sessionId}
-          onRefresh={onRefreshVideoUrl}
-        />
-      )}
+      {/* Recording lives in its own "Recording" tab on the page; not rendered here. */}
     </div>
   )
 }

--- a/src/app/sessions/[sessionId]/hooks/use-session-data.ts
+++ b/src/app/sessions/[sessionId]/hooks/use-session-data.ts
@@ -45,10 +45,15 @@ interface SessionDetails {
     title?: string | null
     transcription_status?: string
     transcription_progress?: number
+    started_at?: string | null
+    ended_at?: string | null
     created_at: string
     updated_at: string
     metadata: any
     client_id?: string
+    coach_id?: string | null
+    video_url?: string | null
+    video_unavailable?: boolean
     client?: {
       id: string
       name: string

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -30,6 +30,8 @@ import { SessionHeroCard } from './components/session-hero-card'
 import { SessionOverviewTab } from './components/session-overview-tab'
 import { SessionAnalysisMerged } from './components/session-analysis-merged'
 import { VideoReviewPanel } from '@/components/sessions/video-review-panel'
+import { EvaluationsList } from '@/components/sessions/evaluations-list'
+import { useCoachEvaluations } from '@/hooks/queries/use-coach-evaluations'
 import { useAuth } from '@/contexts/auth-context'
 import { isPresignedUrlExpired } from '@/lib/presigned-url'
 import { GroupParticipantBar } from './components/group-participant-bar'
@@ -84,9 +86,13 @@ export default function SessionDetailsPage({
   const router = useRouter()
   const permissions = usePermissions()
   const isViewer = permissions.isViewer()
+  const isAdmin = permissions.isAdmin() || permissions.isSuperAdmin()
   const { userId: currentUserId } = useAuth()
   const resolvedParams = React.use(params)
   const queryClient = useQueryClient()
+  const { data: evaluations = [] } = useCoachEvaluations(
+    resolvedParams.sessionId,
+  )
 
   // Use TanStack Query for instant caching
   const {
@@ -970,23 +976,31 @@ export default function SessionDetailsPage({
 
                   {/* Recording Tab — video player + synced transcript + comments */}
                   {activeTab === 'recording' && !isViewer && (
-                    <VideoReviewPanel
-                      sessionId={sessionData.session.id}
-                      videoUrl={session.video_url ?? null}
-                      videoUnavailable={session.video_unavailable}
-                      videoAnchorAt={pickVideoAnchor(
-                        (session.metadata as any)?.recording_started_at,
-                        transcript,
-                        session.started_at,
-                      )}
-                      transcript={(transcript ?? []) as any}
-                      isOwner={
-                        !!currentUserId &&
-                        !!session.coach_id &&
-                        currentUserId === session.coach_id
-                      }
-                      onRefreshVideoUrl={handleRefreshVideoUrl}
-                    />
+                    <>
+                      <VideoReviewPanel
+                        sessionId={sessionData.session.id}
+                        videoUrl={session.video_url ?? null}
+                        videoUnavailable={session.video_unavailable}
+                        videoAnchorAt={pickVideoAnchor(
+                          (session.metadata as any)?.recording_started_at,
+                          transcript,
+                          session.started_at,
+                        )}
+                        transcript={(transcript ?? []) as any}
+                        isOwner={
+                          !!currentUserId &&
+                          !!session.coach_id &&
+                          currentUserId === session.coach_id
+                        }
+                        onRefreshVideoUrl={handleRefreshVideoUrl}
+                      />
+                      <EvaluationsList
+                        sessionId={sessionData.session.id}
+                        evaluations={evaluations}
+                        currentUserId={currentUserId}
+                        isAdmin={isAdmin}
+                      />
+                    </>
                   )}
                 </div>
               </div>

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -20,6 +20,7 @@ import {
   LayoutGrid,
   Plus,
   StickyNote,
+  Video,
 } from 'lucide-react'
 import { formatDate } from '@/lib/date-utils'
 import { Card, CardContent } from '@/components/ui/card'
@@ -28,6 +29,9 @@ import SessionHeader from './components/session-header'
 import { SessionHeroCard } from './components/session-hero-card'
 import { SessionOverviewTab } from './components/session-overview-tab'
 import { SessionAnalysisMerged } from './components/session-analysis-merged'
+import { VideoReviewPanel } from '@/components/sessions/video-review-panel'
+import { useAuth } from '@/contexts/auth-context'
+import { isPresignedUrlExpired } from '@/lib/presigned-url'
 import { GroupParticipantBar } from './components/group-participant-bar'
 import { QuickNote } from '@/components/session-notes/quick-note'
 import {
@@ -48,6 +52,30 @@ import { queryKeys } from '@/lib/query-client'
 import { useOptionalProcessing } from '@/contexts/processing-context'
 import { websocketService } from '@/services/websocket-service'
 
+/**
+ * Choose the wall-clock time that maps to t=0 of the recording.
+ *
+ * `recording_started_at` is when the Recall.ai bot started capturing video
+ * (when it fires, the video file's t=0 is at this moment). It is the
+ * authoritative anchor when present. Some transcripts may fire a few seconds
+ * BEFORE this — those are partial captures from before recording actually
+ * began, and the synced-transcript hook is responsible for dropping them so
+ * they don't appear ahead of the video.
+ *
+ * Fall back to the first transcript timestamp when recording_started_at is
+ * missing, and to session.started_at as a last resort (least reliable —
+ * it's when the DB row was created, ~60-90s before the bot actually joined).
+ */
+function pickVideoAnchor(
+  recordingStartedAt: string | null | undefined,
+  transcript: Array<{ timestamp: string; is_partial?: boolean }> | undefined,
+  sessionStartedAt: string | null | undefined,
+): string | null {
+  if (recordingStartedAt) return recordingStartedAt
+  const firstFinal = transcript?.find(t => !t.is_partial)?.timestamp
+  return firstFinal ?? transcript?.[0]?.timestamp ?? sessionStartedAt ?? null
+}
+
 export default function SessionDetailsPage({
   params,
 }: {
@@ -56,6 +84,7 @@ export default function SessionDetailsPage({
   const router = useRouter()
   const permissions = usePermissions()
   const isViewer = permissions.isViewer()
+  const { userId: currentUserId } = useAuth()
   const resolvedParams = React.use(params)
   const queryClient = useQueryClient()
 
@@ -66,6 +95,32 @@ export default function SessionDetailsPage({
     error: queryError,
   } = useSessionDetails(resolvedParams.sessionId)
   const error = queryError ? String(queryError) : null
+
+  // Share recipients land on the owner URL (`/sessions/[id]`) but `/details`
+  // is owner-only. On a /details error, probe /review — if accessible and
+  // we're not the owner, redirect to the narrow review surface.
+  const reviewProbedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!queryError) return
+    const sid = resolvedParams.sessionId
+    if (reviewProbedRef.current === sid) return
+    reviewProbedRef.current = sid
+    let cancelled = false
+    ;(async () => {
+      try {
+        const review = await SessionService.getSessionReview(sid)
+        if (cancelled) return
+        if (!review.is_owner) {
+          router.replace(`/sessions/${sid}/review`)
+        }
+      } catch {
+        // /review also failed — leave the existing not-found UI alone.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [queryError, resolvedParams.sessionId, router])
 
   // Group session state
   const [selectedClientId, setSelectedClientId] = useState<string | null>(null)
@@ -379,15 +434,46 @@ export default function SessionDetailsPage({
 
     try {
       await SessionService.refreshVideoUrl(sessionData.session.id)
-      // Invalidate session details to refetch with new video URL
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.sessions.detail(sessionData.session.id),
-      })
     } catch (error) {
       console.error('Failed to refresh video URL:', error)
       throw error // Re-throw so VideoPlayer can handle the error state
+    } finally {
+      // Refetch either way: on success to pick up the new presigned URL,
+      // on failure to pick up the `video_unavailable` flag the backend
+      // writes when Recall.ai no longer has the file.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.detail(sessionData.session.id),
+      })
     }
   }
+
+  // Auto-refresh an expired presigned video URL exactly once per landing.
+  // Without this, the user has to click "Refresh" themselves before they can
+  // play a recording older than the URL's 7-day signed window.
+  const autoRefreshedSessionRef = useRef<string | null>(null)
+  useEffect(() => {
+    const sid = sessionData?.session?.id
+    if (!sid) return
+    if (autoRefreshedSessionRef.current === sid) return
+    if (isViewer) return
+    if (sessionData?.session?.video_unavailable) return
+    const url = sessionData?.session?.video_url
+    if (!url || !isPresignedUrlExpired(url)) return
+
+    autoRefreshedSessionRef.current = sid
+    handleRefreshVideoUrl().catch(() => {
+      // Errors are already toasted/logged inside handleRefreshVideoUrl;
+      // swallowing here keeps the effect from triggering React error boundary.
+    })
+    // We intentionally don't include handleRefreshVideoUrl in deps —
+    // it's stable enough and we guard against re-runs via the ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    sessionData?.session?.id,
+    sessionData?.session?.video_url,
+    sessionData?.session?.video_unavailable,
+    isViewer,
+  ])
 
   if (loading) {
     return (
@@ -636,6 +722,18 @@ export default function SessionDetailsPage({
                         <Brain className="h-4 w-4 mr-2" />
                         Analysis
                       </TabsTrigger>
+                      {!isViewer &&
+                        (session.bot_id ||
+                          session.video_url ||
+                          session.video_unavailable) && (
+                          <TabsTrigger
+                            value="recording"
+                            className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-800 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
+                          >
+                            <Video className="h-4 w-4 mr-2" />
+                            Recording
+                          </TabsTrigger>
+                        )}
                     </TabsList>
                   </Tabs>
 
@@ -736,12 +834,8 @@ export default function SessionDetailsPage({
                       clientId={clientId}
                       transcript={transcript}
                       isViewer={isViewer}
-                      videoUrl={session.video_url}
                       onViewAnalysis={() => setActiveTab('analysis')}
                       onRefreshCommitments={refreshCommitments}
-                      onRefreshVideoUrl={
-                        !isViewer ? handleRefreshVideoUrl : undefined
-                      }
                       isGroupSession={isGroupSession}
                       selectedClientId={selectedClientId}
                       clientAnalyses={session.client_analyses}
@@ -873,6 +967,27 @@ export default function SessionDetailsPage({
                         </CardContent>
                       </Card>
                     ))}
+
+                  {/* Recording Tab — video player + synced transcript + comments */}
+                  {activeTab === 'recording' && !isViewer && (
+                    <VideoReviewPanel
+                      sessionId={sessionData.session.id}
+                      videoUrl={session.video_url ?? null}
+                      videoUnavailable={session.video_unavailable}
+                      videoAnchorAt={pickVideoAnchor(
+                        (session.metadata as any)?.recording_started_at,
+                        transcript,
+                        session.started_at,
+                      )}
+                      transcript={(transcript ?? []) as any}
+                      isOwner={
+                        !!currentUserId &&
+                        !!session.coach_id &&
+                        currentUserId === session.coach_id
+                      }
+                      onRefreshVideoUrl={handleRefreshVideoUrl}
+                    />
+                  )}
                 </div>
               </div>
             )}

--- a/src/app/sessions/[sessionId]/review/page.tsx
+++ b/src/app/sessions/[sessionId]/review/page.tsx
@@ -1,19 +1,24 @@
 'use client'
 
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowLeft, AlertCircle } from 'lucide-react'
+import { ArrowLeft, AlertCircle, ClipboardCheck } from 'lucide-react'
 import { ProtectedRoute } from '@/components/auth/protected-route'
 import PageLayout from '@/components/layout/page-layout'
 import { LoadingState } from '@/components/ui/loading-state'
 import { EmptyState } from '@/components/ui/empty-state'
+import { Button } from '@/components/ui/button'
 import { VideoReviewPanel } from '@/components/sessions/video-review-panel'
+import { CoachEvaluationDialog } from '@/components/sessions/coach-evaluation-dialog'
+import { EvaluationsList } from '@/components/sessions/evaluations-list'
 import { useSessionReview } from '@/hooks/queries/use-session-review'
+import { useCoachEvaluations } from '@/hooks/queries/use-coach-evaluations'
 import { SessionService } from '@/services/session-service'
 import { isPresignedUrlExpired } from '@/lib/presigned-url'
 import { formatDate } from '@/lib/date-utils'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-client'
+import { useAuth } from '@/contexts/auth-context'
 
 function pickVideoAnchor(
   recordingStartedAt: string | null | undefined,
@@ -40,8 +45,18 @@ export default function SessionReviewPage({
   const router = useRouter()
   const resolvedParams = React.use(params)
   const queryClient = useQueryClient()
+  const { userId } = useAuth()
+  const [evalDialogOpen, setEvalDialogOpen] = useState(false)
 
   const { data, isLoading, error } = useSessionReview(resolvedParams.sessionId)
+  const { data: evaluations = [] } = useCoachEvaluations(data?.id, {
+    enabled: !!data?.id,
+  })
+
+  const myEvaluation = useMemo(
+    () => evaluations.find(e => e.reviewer_id === userId) ?? null,
+    [evaluations, userId],
+  )
 
   const handleRefreshVideoUrl = async () => {
     if (!data?.id) return
@@ -138,6 +153,19 @@ export default function SessionReviewPage({
                   </p>
                 )}
               </div>
+              <div className="shrink-0">
+                <Button
+                  type="button"
+                  variant={myEvaluation ? 'outline' : 'default'}
+                  size="sm"
+                  onClick={() => setEvalDialogOpen(true)}
+                >
+                  <ClipboardCheck className="h-4 w-4 mr-1.5" />
+                  {myEvaluation
+                    ? 'View / edit your evaluation'
+                    : 'Evaluate session'}
+                </Button>
+              </div>
             </div>
 
             <VideoReviewPanel
@@ -152,9 +180,26 @@ export default function SessionReviewPage({
               transcript={data.transcript}
               isOwner={data.is_owner}
               onRefreshVideoUrl={handleRefreshVideoUrl}
+              transcriptCollapsedByDefault
             />
+
+            {(data.is_owner || data.is_admin) && (
+              <EvaluationsList
+                sessionId={data.id}
+                evaluations={evaluations}
+                currentUserId={userId}
+                isAdmin={data.is_admin}
+              />
+            )}
           </div>
         </div>
+
+        <CoachEvaluationDialog
+          sessionId={data.id}
+          open={evalDialogOpen}
+          onOpenChange={setEvalDialogOpen}
+          existingEvaluation={myEvaluation}
+        />
       </PageLayout>
     </ProtectedRoute>
   )

--- a/src/app/sessions/[sessionId]/review/page.tsx
+++ b/src/app/sessions/[sessionId]/review/page.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import React, { useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { ArrowLeft, AlertCircle } from 'lucide-react'
+import { ProtectedRoute } from '@/components/auth/protected-route'
+import PageLayout from '@/components/layout/page-layout'
+import { LoadingState } from '@/components/ui/loading-state'
+import { EmptyState } from '@/components/ui/empty-state'
+import { VideoReviewPanel } from '@/components/sessions/video-review-panel'
+import { useSessionReview } from '@/hooks/queries/use-session-review'
+import { SessionService } from '@/services/session-service'
+import { isPresignedUrlExpired } from '@/lib/presigned-url'
+import { formatDate } from '@/lib/date-utils'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query-client'
+
+function pickVideoAnchor(
+  recordingStartedAt: string | null | undefined,
+  transcript: Array<{ timestamp: string }> | undefined,
+  sessionStartedAt: string | null | undefined,
+): string | null {
+  if (recordingStartedAt) return recordingStartedAt
+  return transcript?.[0]?.timestamp ?? sessionStartedAt ?? null
+}
+
+function formatDuration(seconds: number | null | undefined): string | null {
+  if (!seconds || seconds <= 0) return null
+  const m = Math.floor(seconds / 60)
+  const h = Math.floor(m / 60)
+  if (h > 0) return `${h}h ${m % 60}m`
+  return `${m}m`
+}
+
+export default function SessionReviewPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>
+}) {
+  const router = useRouter()
+  const resolvedParams = React.use(params)
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, error } = useSessionReview(resolvedParams.sessionId)
+
+  const handleRefreshVideoUrl = async () => {
+    if (!data?.id) return
+    try {
+      await SessionService.refreshVideoUrl(data.id)
+    } catch (err) {
+      console.error('Failed to refresh video URL:', err)
+      throw err
+    } finally {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.review(data.id),
+      })
+    }
+  }
+
+  // Auto-refresh expired SigV4 URL on landing — same logic as the owner detail
+  // page. Without this, recipients land on a dead URL and have to click
+  // Refresh themselves.
+  const autoRefreshedRef = useRef<string | null>(null)
+  useEffect(() => {
+    const sid = data?.id
+    if (!sid) return
+    if (autoRefreshedRef.current === sid) return
+    if (data.video_unavailable) return
+    if (!data.is_owner && !data.is_admin) return // only owner/admin can refresh
+    const url = data.video_url
+    if (!url || !isPresignedUrlExpired(url)) return
+    autoRefreshedRef.current = sid
+    handleRefreshVideoUrl().catch(() => {})
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.id, data?.video_url, data?.video_unavailable])
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-app-surface">
+        <LoadingState
+          message="Loading review..."
+          variant="default"
+          className="min-h-screen"
+        />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen bg-app-surface flex items-center justify-center p-4">
+        <div className="text-center max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8 border border-app-border">
+          <EmptyState
+            icon={AlertCircle}
+            title="Session not available"
+            description="This session may have been unshared, or you don't have access."
+            action={{
+              label: 'Back to shared',
+              onClick: () => router.push('/sessions/shared'),
+              icon: ArrowLeft,
+            }}
+            iconClassName="w-20 h-20 bg-app-surface"
+          />
+        </div>
+      </div>
+    )
+  }
+
+  const dateLabel = data.started_at ? formatDate(data.started_at) : null
+  const durationLabel = formatDuration(data.duration_seconds)
+  const metaParts = [data.coach_name, durationLabel, dateLabel].filter(
+    Boolean,
+  ) as string[]
+
+  const backHref = data.is_owner ? '/sessions' : '/sessions/shared'
+  const backLabel = data.is_owner ? 'Back to sessions' : 'Back to shared'
+
+  return (
+    <ProtectedRoute loadingMessage="Loading review...">
+      <PageLayout>
+        <div className="min-h-screen bg-white dark:bg-gray-900">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <div className="mb-6 flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <button
+                  onClick={() => router.push(backHref)}
+                  className="text-sm text-app-secondary hover:text-app-primary transition-colors flex items-center gap-1 mb-2"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  {backLabel}
+                </button>
+                <h1 className="text-xl font-semibold text-app-primary truncate">
+                  {data.title || 'Session review'}
+                </h1>
+                {metaParts.length > 0 && (
+                  <p className="text-sm text-app-secondary mt-1">
+                    {metaParts.join(' · ')}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <VideoReviewPanel
+              sessionId={data.id}
+              videoUrl={data.video_url}
+              videoUnavailable={data.video_unavailable}
+              videoAnchorAt={pickVideoAnchor(
+                data.recording_started_at,
+                data.transcript,
+                data.started_at,
+              )}
+              transcript={data.transcript}
+              isOwner={data.is_owner}
+              onRefreshVideoUrl={handleRefreshVideoUrl}
+            />
+          </div>
+        </div>
+      </PageLayout>
+    </ProtectedRoute>
+  )
+}

--- a/src/app/sessions/components/sessions-filters.tsx
+++ b/src/app/sessions/components/sessions-filters.tsx
@@ -15,6 +15,7 @@ import {
   ChevronDown,
   Search,
   Check,
+  Activity,
 } from 'lucide-react'
 
 interface Client {
@@ -30,6 +31,30 @@ interface Coach {
 
 export type SessionTypeFilter = 'all' | '1:1' | 'group'
 
+export type SessionStatusFilter =
+  | 'all'
+  | 'completed'
+  | 'processing'
+  | 'scheduled'
+  | 'pending_upload'
+  | 'active'
+
+const STATUS_OPTIONS: {
+  value: SessionStatusFilter
+  label: string
+  dot: string
+}[] = [
+  { value: 'all', label: 'All Statuses', dot: 'bg-slate-400' },
+  { value: 'completed', label: 'Completed', dot: 'bg-emerald-500' },
+  { value: 'active', label: 'Active', dot: 'bg-rose-500' },
+  { value: 'processing', label: 'Processing', dot: 'bg-amber-500' },
+  { value: 'scheduled', label: 'Scheduled', dot: 'bg-sky-500' },
+  { value: 'pending_upload', label: 'Pending Upload', dot: 'bg-violet-500' },
+]
+
+const getStatusOption = (value: SessionStatusFilter) =>
+  STATUS_OPTIONS.find(o => o.value === value) ?? STATUS_OPTIONS[0]
+
 interface SessionsFiltersProps {
   clients: Client[]
   coaches: Coach[]
@@ -40,10 +65,12 @@ interface SessionsFiltersProps {
   selectedCoachId: string | null
   selectedCoach: Coach | undefined
   sessionType: SessionTypeFilter
+  selectedStatus: SessionStatusFilter
   hasActiveFilters: boolean
   onClientFilter: (clientId: string | null) => void
   onCoachFilter: (coachId: string | null) => void
   onSessionTypeFilter: (type: SessionTypeFilter) => void
+  onStatusFilter: (status: SessionStatusFilter) => void
   onClearFilters: () => void
 }
 
@@ -57,16 +84,20 @@ export default function SessionsFilters({
   selectedCoachId,
   selectedCoach,
   sessionType,
+  selectedStatus,
   hasActiveFilters,
   onClientFilter,
   onCoachFilter,
   onSessionTypeFilter,
+  onStatusFilter,
   onClearFilters,
 }: SessionsFiltersProps) {
   const [clientSearch, setClientSearch] = useState('')
   const [coachSearch, setCoachSearch] = useState('')
   const [clientPopoverOpen, setClientPopoverOpen] = useState(false)
   const [coachPopoverOpen, setCoachPopoverOpen] = useState(false)
+  const [statusPopoverOpen, setStatusPopoverOpen] = useState(false)
+  const activeStatus = getStatusOption(selectedStatus)
 
   // Filter clients based on search
   const filteredClients = clients.filter(client =>
@@ -297,6 +328,60 @@ export default function SessionsFilters({
               </button>
             ))}
           </div>
+        </div>
+
+        {/* Status Filter */}
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Activity className="h-4 w-4 text-slate-600 dark:text-slate-400" />
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              Status:
+            </span>
+          </div>
+
+          <Popover open={statusPopoverOpen} onOpenChange={setStatusPopoverOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-w-[180px] justify-between text-xs"
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`h-2 w-2 rounded-full ${activeStatus.dot}`}
+                    aria-hidden="true"
+                  />
+                  {activeStatus.label}
+                </div>
+                <ChevronDown className="h-3 w-3 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[220px] p-1" align="start">
+              {STATUS_OPTIONS.map(option => (
+                <button
+                  key={option.value}
+                  onClick={() => {
+                    onStatusFilter(option.value)
+                    setStatusPopoverOpen(false)
+                  }}
+                  className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                    selectedStatus === option.value
+                      ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                      : ''
+                  }`}
+                >
+                  <span
+                    className={`h-2 w-2 rounded-full ${option.dot}`}
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1 text-left">{option.label}</span>
+                  {selectedStatus === option.value && (
+                    <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                  )}
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
         </div>
 
         {/* Clear All Filters - inline */}

--- a/src/app/sessions/hooks/use-sessions-data.ts
+++ b/src/app/sessions/hooks/use-sessions-data.ts
@@ -2,7 +2,10 @@ import { useState, useMemo } from 'react'
 import { useMeetingHistory } from '@/hooks/use-meeting-history'
 import { useClients } from '@/hooks/queries/use-clients'
 import { useCoaches } from '@/hooks/queries/use-coaches'
-import type { SessionTypeFilter } from '../components/sessions-filters'
+import type {
+  SessionStatusFilter,
+  SessionTypeFilter,
+} from '../components/sessions-filters'
 
 /**
  * Custom hook for sessions page data management
@@ -14,6 +17,8 @@ export function useSessionsData(pageSize: number = 12) {
   const [selectedClientId, setSelectedClientId] = useState<string | null>(null)
   const [selectedCoachId, setSelectedCoachId] = useState<string | null>(null)
   const [sessionType, setSessionType] = useState<SessionTypeFilter>('all')
+  const [selectedStatus, setSelectedStatus] =
+    useState<SessionStatusFilter>('all')
 
   // Pass filters to useMeetingHistory for server-side filtering
   const {
@@ -25,6 +30,7 @@ export function useSessionsData(pageSize: number = 12) {
   } = useMeetingHistory(pageSize, {
     client_id: selectedClientId,
     coach_id: selectedCoachId,
+    status: selectedStatus === 'all' ? null : selectedStatus,
     page: currentPage + 1, // API uses 1-based pagination
   })
 
@@ -71,10 +77,16 @@ export function useSessionsData(pageSize: number = 12) {
     setCurrentPage(0)
   }
 
+  const handleStatusFilter = (status: SessionStatusFilter) => {
+    setSelectedStatus(status)
+    setCurrentPage(0)
+  }
+
   const handleClearFilters = () => {
     setSelectedClientId(null)
     setSelectedCoachId(null)
     setSessionType('all')
+    setSelectedStatus('all')
     setCurrentPage(0)
     // TanStack Query auto-refetches when queryKey changes (filters are part of queryKey)
   }
@@ -94,7 +106,8 @@ export function useSessionsData(pageSize: number = 12) {
   const hasActiveFilters =
     selectedClientId !== null ||
     selectedCoachId !== null ||
-    sessionType !== 'all'
+    sessionType !== 'all' ||
+    selectedStatus !== 'all'
 
   return {
     currentPage,
@@ -111,6 +124,7 @@ export function useSessionsData(pageSize: number = 12) {
     selectedCoachId,
     selectedCoach,
     sessionType,
+    selectedStatus,
     hasActiveFilters,
     hasNextPage,
     hasPrevPage,
@@ -120,6 +134,7 @@ export function useSessionsData(pageSize: number = 12) {
     handleClientFilter,
     handleCoachFilter,
     handleSessionTypeFilter,
+    handleStatusFilter,
     handleClearFilters,
     refetch,
   }

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -36,6 +36,7 @@ export default function SessionsHistoryPage() {
     selectedCoachId,
     selectedCoach,
     sessionType,
+    selectedStatus,
     hasActiveFilters,
     hasNextPage,
     hasPrevPage,
@@ -44,6 +45,7 @@ export default function SessionsHistoryPage() {
     handleClientFilter,
     handleCoachFilter,
     handleSessionTypeFilter,
+    handleStatusFilter,
     handleClearFilters,
     refetch,
   } = useSessionsData(pageSize)
@@ -113,10 +115,12 @@ export default function SessionsHistoryPage() {
             selectedCoachId={selectedCoachId}
             selectedCoach={selectedCoach}
             sessionType={sessionType}
+            selectedStatus={selectedStatus}
             hasActiveFilters={hasActiveFilters}
             onClientFilter={handleClientFilter}
             onCoachFilter={handleCoachFilter}
             onSessionTypeFilter={handleSessionTypeFilter}
+            onStatusFilter={handleStatusFilter}
             onClearFilters={handleClearFilters}
           />
 

--- a/src/app/sessions/shared/page.tsx
+++ b/src/app/sessions/shared/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import PageLayout from '@/components/layout/page-layout'
+import { ProtectedRoute } from '@/components/auth/protected-route'
+import { PageHeader } from '@/components/ui/page-header'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { EmptyState } from '@/components/ui/empty-state'
+import { SharedSessionRow } from '@/components/sessions/shared-session-row'
+import { Users, MessageSquare } from 'lucide-react'
+import { useSessions } from '@/hooks/queries/use-sessions'
+
+export default function SharedSessionsPage() {
+  const router = useRouter()
+  const { data, isLoading, error, refetch } = useSessions(
+    { scope: 'shared', per_page: 50 },
+    { staleTime: 60 * 1000 },
+  )
+
+  const sessions = data?.sessions ?? []
+
+  return (
+    <ProtectedRoute loadingMessage="Loading shared sessions...">
+      <PageLayout>
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <PageHeader
+            title="Shared with me"
+            description="Coaching sessions other coaches have shared with you for review."
+            icon={Users}
+            iconVariant="gradient"
+          />
+
+          <div className="mt-6">
+            {error && !isLoading && (
+              <Card>
+                <CardContent className="p-6">
+                  <EmptyState
+                    icon={MessageSquare}
+                    title="Couldn't load shared sessions"
+                    description={
+                      error instanceof Error
+                        ? error.message
+                        : 'Please try again.'
+                    }
+                    action={{
+                      label: 'Try again',
+                      onClick: () => refetch(),
+                    }}
+                  />
+                </CardContent>
+              </Card>
+            )}
+
+            {isLoading && (
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Card key={i}>
+                    <CardContent className="p-4">
+                      <div className="flex flex-col sm:flex-row gap-4">
+                        <Skeleton className="w-full sm:w-64 aspect-video rounded-lg" />
+                        <div className="flex-1 space-y-2">
+                          <Skeleton className="h-5 w-2/3" />
+                          <Skeleton className="h-4 w-1/2" />
+                          <Skeleton className="h-4 w-1/3" />
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {!isLoading && !error && sessions.length === 0 && (
+              <Card>
+                <CardContent className="p-10">
+                  <EmptyState
+                    icon={Users}
+                    title="Nothing shared yet"
+                    description="When other coaches share sessions for you to review, they'll show up here."
+                  />
+                </CardContent>
+              </Card>
+            )}
+
+            {!isLoading && sessions.length > 0 && (
+              <div className="space-y-3">
+                {sessions.map((s: any) => (
+                  <SharedSessionRow
+                    key={s.id}
+                    session={s}
+                    onOpen={id => router.push(`/sessions/${id}/review`)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </PageLayout>
+    </ProtectedRoute>
+  )
+}

--- a/src/components/admin/admin-shell.tsx
+++ b/src/components/admin/admin-shell.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { Button } from '@/components/ui/button'
+import { Badge, badgeVariants } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { AppShell, type AppShellNavItem } from '@/components/layout/app-shell'
+import { RoleSwitcher } from '@/components/auth/role-switcher'
+import type { VariantProps } from 'class-variance-authority'
+import {
+  LayoutDashboard,
+  Users,
+  Users2,
+  Shield,
+  Network,
+  FolderKanban,
+  BookOpen,
+  User,
+  LogOut,
+  Settings,
+} from 'lucide-react'
+
+type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>['variant']>
+
+interface AdminShellProps {
+  children: ReactNode
+}
+
+const ADMIN_ITEMS: Array<AppShellNavItem & { roles: string[] }> = [
+  {
+    href: '/admin/dashboard',
+    label: 'Dashboard',
+    icon: LayoutDashboard,
+    exact: true,
+    roles: ['admin', 'super_admin'],
+  },
+  {
+    href: '/admin/users',
+    label: 'Users',
+    icon: Users,
+    roles: ['admin', 'super_admin'],
+  },
+  {
+    href: '/admin/programs',
+    label: 'Sandboxes',
+    icon: FolderKanban,
+    roles: ['super_admin'],
+  },
+  {
+    href: '/admin/clients',
+    label: 'Clients',
+    icon: Users2,
+    roles: ['super_admin'],
+  },
+  {
+    href: '/admin/resources',
+    label: 'Global Resources',
+    icon: BookOpen,
+    roles: ['admin', 'super_admin'],
+  },
+  {
+    href: '/admin/access',
+    label: 'Access Management',
+    icon: Network,
+    roles: ['admin', 'super_admin'],
+  },
+  {
+    href: '/admin/roles',
+    label: 'Roles',
+    icon: Shield,
+    roles: ['super_admin'],
+  },
+]
+
+const ROLE_TO_BADGE: Record<string, BadgeVariant> = {
+  super_admin: 'bad',
+  admin: 'info',
+  coach: 'ok',
+  viewer: 'neutral',
+  client: 'neutral',
+  trainee: 'ok',
+}
+
+const formatRoleName = (role: string) =>
+  role
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+/**
+ * Admin app shell. Renders `<AppShell variant="sidebar">` with the admin
+ * left rail, role-filtered nav items, and a top action bar containing role
+ * badges, RoleSwitcher, and the user menu.
+ */
+export function AdminShell({ children }: AdminShellProps) {
+  const router = useRouter()
+  const { hasAnyRole, roles, signOut, user } = useAuth()
+
+  const navItems = ADMIN_ITEMS.filter(item => hasAnyRole(item.roles)).map(
+    ({ roles: _roles, ...rest }) => rest,
+  )
+
+  const navActions = (
+    <>
+      <div className="hidden md:flex items-center gap-2">
+        {roles.map(role => (
+          <Badge key={role} variant={ROLE_TO_BADGE[role] ?? 'neutral'}>
+            <Shield className="h-3 w-3" />
+            {formatRoleName(role)}
+          </Badge>
+        ))}
+      </div>
+      <RoleSwitcher />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="sm" className="gap-2">
+            <div className="h-7 w-7 rounded-sm bg-surface-2 flex items-center justify-center">
+              <User className="h-4 w-4 text-ink-3" />
+            </div>
+            <span className="hidden sm:inline">
+              {user?.full_name || 'Admin User'}
+            </span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuLabel>My Account</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => router.push('/profile')}>
+            <User className="h-4 w-4 mr-2" />
+            Profile
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => router.push('/settings')}>
+            <Settings className="h-4 w-4 mr-2" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => signOut()}
+            className="text-vermillion focus:text-vermillion"
+          >
+            <LogOut className="h-4 w-4 mr-2" />
+            Sign Out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  )
+
+  return (
+    <AppShell
+      variant="sidebar"
+      brand={{
+        label: 'Admin Panel',
+        subtitle: 'Coach Sidekick',
+        href: '/admin/dashboard',
+      }}
+      navItems={navItems}
+      navActions={navActions}
+    >
+      <div className="container mx-auto px-6 py-8">{children}</div>
+    </AppShell>
+  )
+}

--- a/src/components/admin/admin-shell.tsx
+++ b/src/components/admin/admin-shell.tsx
@@ -82,12 +82,12 @@ const ADMIN_ITEMS: Array<AppShellNavItem & { roles: string[] }> = [
 ]
 
 const ROLE_TO_BADGE: Record<string, BadgeVariant> = {
-  super_admin: 'bad',
-  admin: 'info',
-  coach: 'ok',
-  viewer: 'neutral',
-  client: 'neutral',
-  trainee: 'ok',
+  super_admin: 'destructive',
+  admin: 'default',
+  coach: 'secondary',
+  viewer: 'outline',
+  client: 'outline',
+  trainee: 'secondary',
 }
 
 const formatRoleName = (role: string) =>
@@ -113,7 +113,7 @@ export function AdminShell({ children }: AdminShellProps) {
     <>
       <div className="hidden md:flex items-center gap-2">
         {roles.map(role => (
-          <Badge key={role} variant={ROLE_TO_BADGE[role] ?? 'neutral'}>
+          <Badge key={role} variant={ROLE_TO_BADGE[role] ?? 'outline'}>
             <Shield className="h-3 w-3" />
             {formatRoleName(role)}
           </Badge>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { ReactNode, useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { usePathname } from 'next/navigation'
+import { ChevronLeft, ChevronRight, type LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * AppShell — one shell, role-aware.
+ *
+ * Consolidates the three pre-foundation shells (coach top nav · client portal
+ * top nav · admin sidebar) into a single primitive. Pick `variant` per
+ * surface; everything else is shared tokens, typography, and a right-side
+ * action slot. Consumers compose their own `navActions` (theme toggle, role
+ * switcher, user menu, role badges) — the shell doesn't impose composition.
+ */
+
+export interface AppShellNavItem {
+  href: string
+  label: string
+  icon?: LucideIcon
+  /** Use exact path equality instead of prefix match. */
+  exact?: boolean
+}
+
+export interface AppShellBrand {
+  label: string
+  /** Eyebrow under the brand label, e.g. "Novus Global". */
+  subtitle?: string
+  /** Click target for the logo. */
+  href: string
+  /** Optional logo image source. Defaults to a Fraunces monogram on ink. */
+  logoSrc?: string
+  /** Single-letter monogram when no logoSrc. Defaults to "S". */
+  monogram?: string
+}
+
+export interface AppShellProps {
+  variant: 'topnav' | 'sidebar'
+  brand: AppShellBrand
+  navItems: AppShellNavItem[]
+  navActions?: ReactNode
+  /** Optional banner rendered above the chrome (impersonation notice, etc.). */
+  banner?: ReactNode
+  children: ReactNode
+}
+
+function isItemActive(pathname: string, item: AppShellNavItem): boolean {
+  if (item.exact) return pathname === item.href
+  if (item.href === '/' || item.href === '/client-portal/dashboard') {
+    return pathname === item.href
+  }
+  return pathname === item.href || pathname.startsWith(item.href + '/')
+}
+
+function BrandTopNav({ brand }: { brand: AppShellBrand }) {
+  return (
+    <Link href={brand.href} className="flex items-center gap-3 group min-w-0">
+      <div className="w-10 h-10 rounded-md bg-ink flex items-center justify-center overflow-hidden shrink-0">
+        {brand.logoSrc ? (
+          <Image
+            src={brand.logoSrc}
+            alt=""
+            width={28}
+            height={28}
+            className="object-contain filter brightness-0 invert"
+          />
+        ) : (
+          <span className="font-display text-paper text-[16px] font-semibold leading-none">
+            {brand.monogram ?? 'S'}
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col leading-tight min-w-0">
+        <span className="font-sans text-[15px] font-semibold text-ink truncate">
+          {brand.label}
+        </span>
+        {brand.subtitle && (
+          <span className="eyebrow tnum mt-0.5">{brand.subtitle}</span>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+function BrandSidebar({
+  brand,
+  collapsed,
+}: {
+  brand: AppShellBrand
+  collapsed: boolean
+}) {
+  return (
+    <Link
+      href={brand.href}
+      className={cn(
+        'flex items-center gap-3 group min-w-0',
+        collapsed && 'justify-center',
+      )}
+    >
+      <div className="w-9 h-9 rounded-md bg-sidebar-primary flex items-center justify-center shrink-0">
+        {brand.logoSrc ? (
+          <Image
+            src={brand.logoSrc}
+            alt=""
+            width={24}
+            height={24}
+            className="object-contain"
+          />
+        ) : (
+          <span className="font-display text-sidebar-primary-foreground text-[14px] font-semibold leading-none">
+            {brand.monogram ?? 'S'}
+          </span>
+        )}
+      </div>
+      {!collapsed && (
+        <div className="flex flex-col leading-tight min-w-0">
+          <span className="font-sans text-[14px] font-semibold truncate">
+            {brand.label}
+          </span>
+          {brand.subtitle && (
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] opacity-60 mt-0.5 truncate">
+              {brand.subtitle}
+            </span>
+          )}
+        </div>
+      )}
+    </Link>
+  )
+}
+
+function TopNavShell({
+  brand,
+  navItems,
+  navActions,
+  banner,
+  children,
+}: AppShellProps) {
+  const pathname = usePathname() ?? ''
+
+  return (
+    <div className="min-h-screen bg-bg flex flex-col">
+      {banner}
+      <header className="bg-paper border-b border-line sticky top-0 z-50">
+        <div className="max-w-[1280px] mx-auto px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16 gap-6">
+            <div className="flex items-center gap-8 min-w-0">
+              <BrandTopNav brand={brand} />
+
+              <nav className="hidden md:flex items-center gap-1">
+                {navItems.map(item => {
+                  const active = isItemActive(pathname, item)
+                  const Icon = item.icon
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      aria-current={active ? 'page' : undefined}
+                      className={cn(
+                        'inline-flex items-center gap-2 h-8 px-3 rounded-sm font-sans text-[13px] font-medium transition-colors',
+                        active
+                          ? 'bg-surface-2 text-ink'
+                          : 'text-ink-3 hover:text-ink hover:bg-surface-2',
+                      )}
+                    >
+                      {Icon && <Icon className="h-4 w-4" strokeWidth={1.75} />}
+                      {item.label}
+                    </Link>
+                  )
+                })}
+              </nav>
+            </div>
+
+            {navActions && (
+              <div className="flex items-center gap-2 shrink-0">
+                {navActions}
+              </div>
+            )}
+          </div>
+        </div>
+      </header>
+      <main className="flex-1">{children}</main>
+    </div>
+  )
+}
+
+function SidebarShell({
+  brand,
+  navItems,
+  navActions,
+  banner,
+  children,
+}: AppShellProps) {
+  const pathname = usePathname() ?? ''
+  const [collapsed, setCollapsed] = useState(false)
+
+  return (
+    <>
+      {banner}
+      <div className="flex h-screen bg-bg">
+        <aside
+          className={cn(
+            'bg-sidebar text-sidebar-foreground flex flex-col transition-[width] duration-200 ease-in-out shrink-0',
+            collapsed ? 'w-16' : 'w-64',
+          )}
+        >
+          <div className="flex items-center justify-between p-4 border-b border-sidebar-border h-16 shrink-0">
+            <BrandSidebar brand={brand} collapsed={collapsed} />
+            {!collapsed && (
+              <button
+                onClick={() => setCollapsed(true)}
+                className="p-1 rounded-sm hover:bg-sidebar-accent transition-colors"
+                aria-label="Collapse sidebar"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          {collapsed && (
+            <button
+              onClick={() => setCollapsed(false)}
+              className="mx-auto my-2 p-1 rounded-sm hover:bg-sidebar-accent transition-colors"
+              aria-label="Expand sidebar"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          )}
+
+          <nav className="flex-1 py-4 overflow-y-auto">
+            <ul className="space-y-1 px-2">
+              {navItems.map(item => {
+                const active = isItemActive(pathname, item)
+                const Icon = item.icon
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      aria-current={active ? 'page' : undefined}
+                      title={collapsed ? item.label : undefined}
+                      className={cn(
+                        'flex items-center gap-3 px-3 py-2 rounded-sm font-sans text-[13px] font-medium transition-colors',
+                        'text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-foreground',
+                        active &&
+                          'bg-sidebar-accent text-sidebar-foreground border-l-2 border-sidebar-foreground pl-[10px]',
+                        collapsed && 'justify-center px-0',
+                      )}
+                    >
+                      {Icon && (
+                        <Icon className="h-5 w-5 shrink-0" strokeWidth={1.75} />
+                      )}
+                      {!collapsed && <span>{item.label}</span>}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
+        </aside>
+
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {navActions && (
+            <header className="bg-paper border-b border-line h-16 flex items-center justify-end px-6 shrink-0">
+              <div className="flex items-center gap-2">{navActions}</div>
+            </header>
+          )}
+          <main className="flex-1 overflow-y-auto">{children}</main>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export function AppShell(props: AppShellProps) {
+  if (props.variant === 'sidebar') return <SidebarShell {...props} />
+  return <TopNavShell {...props} />
+}

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -13,7 +13,6 @@ import {
   BookOpen,
   Shield,
   Eye,
-  Users,
 } from 'lucide-react'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
@@ -62,12 +61,6 @@ export default function Navigation() {
       path: '/sessions',
       label: 'Sessions',
       icon: History,
-      permission: { resource: 'sessions', action: 'view' },
-    },
-    {
-      path: '/sessions/shared',
-      label: 'Shared with me',
-      icon: Users,
       permission: { resource: 'sessions', action: 'view' },
     },
     {

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -13,6 +13,7 @@ import {
   BookOpen,
   Shield,
   Eye,
+  Users,
 } from 'lucide-react'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
@@ -61,6 +62,12 @@ export default function Navigation() {
       path: '/sessions',
       label: 'Sessions',
       icon: History,
+      permission: { resource: 'sessions', action: 'view' },
+    },
+    {
+      path: '/sessions/shared',
+      label: 'Shared with me',
+      icon: Users,
       permission: { resource: 'sessions', action: 'view' },
     },
     {
@@ -140,7 +147,16 @@ export default function Navigation() {
                 <div className="flex items-center bg-gray-50 dark:bg-gray-800 rounded-lg p-1">
                   {navItems.map(item => {
                     const Icon = item.icon
-                    const isActive = isActivePath(item.path)
+                    // Only the longest-matching nav item lights up — avoids
+                    // both /sessions and /sessions/shared appearing active at once.
+                    const isActive =
+                      isActivePath(item.path) &&
+                      !navItems.some(
+                        other =>
+                          other.path !== item.path &&
+                          other.path.length > item.path.length &&
+                          isActivePath(other.path),
+                      )
 
                     return (
                       <button

--- a/src/components/sessions/coach-evaluation-dialog.tsx
+++ b/src/components/sessions/coach-evaluation-dialog.tsx
@@ -1,0 +1,446 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowLeft, ArrowRight, Loader2, Trash2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  EVALUATION_QUESTIONS,
+  SCORE_OPTIONS,
+  ScoreValue,
+  scoreChipClass,
+} from '@/lib/coach-evaluation-questions'
+import { CoachEvaluation } from '@/services/coach-evaluations-service'
+import {
+  useCreateCoachEvaluation,
+  useDeleteCoachEvaluation,
+  useUpdateCoachEvaluation,
+} from '@/hooks/mutations/use-coach-evaluation-mutations'
+import { cn } from '@/lib/utils'
+
+type AnswerMap = Record<string, ScoreValue | undefined>
+
+const REVIEW_STEP = EVALUATION_QUESTIONS.length
+
+interface CoachEvaluationDialogProps {
+  sessionId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  existingEvaluation?: CoachEvaluation | null
+}
+
+function buildInitialAnswers(
+  existing: CoachEvaluation | null | undefined,
+): AnswerMap {
+  const map: AnswerMap = {}
+  for (const q of EVALUATION_QUESTIONS) {
+    map[q.id] =
+      existing && q.id in existing.scores ? existing.scores[q.id] : undefined
+  }
+  return map
+}
+
+export function CoachEvaluationDialog({
+  sessionId,
+  open,
+  onOpenChange,
+  existingEvaluation,
+}: CoachEvaluationDialogProps) {
+  const [step, setStep] = useState(0)
+  const [answers, setAnswers] = useState<AnswerMap>(() =>
+    buildInitialAnswers(existingEvaluation),
+  )
+  const [feedback, setFeedback] = useState<string>(
+    existingEvaluation?.feedback ?? '',
+  )
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const createMut = useCreateCoachEvaluation(sessionId)
+  const updateMut = useUpdateCoachEvaluation(sessionId)
+  const deleteMut = useDeleteCoachEvaluation(sessionId)
+
+  const isEditing = !!existingEvaluation
+  const isPending =
+    createMut.isPending || updateMut.isPending || deleteMut.isPending
+
+  // Reset state whenever the dialog opens or the underlying record changes.
+  useEffect(() => {
+    if (open) {
+      setStep(0)
+      setAnswers(buildInitialAnswers(existingEvaluation))
+      setFeedback(existingEvaluation?.feedback ?? '')
+    }
+  }, [open, existingEvaluation])
+
+  // Cancel any pending auto-advance when the modal closes.
+  useEffect(() => {
+    if (!open && advanceTimerRef.current) {
+      clearTimeout(advanceTimerRef.current)
+      advanceTimerRef.current = null
+    }
+  }, [open])
+
+  const answeredCount = useMemo(
+    () => EVALUATION_QUESTIONS.filter(q => answers[q.id] !== undefined).length,
+    [answers],
+  )
+  const allAnswered = answeredCount === EVALUATION_QUESTIONS.length
+
+  const onReview = step === REVIEW_STEP
+  const currentQuestion = !onReview ? EVALUATION_QUESTIONS[step] : null
+
+  const handleSelect = useCallback(
+    (value: ScoreValue) => {
+      if (!currentQuestion) return
+      setAnswers(prev => ({ ...prev, [currentQuestion.id]: value }))
+      // Auto-advance after a brief moment so the user sees the selection
+      // register before the screen changes.
+      if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
+      advanceTimerRef.current = setTimeout(() => {
+        setStep(s => Math.min(s + 1, REVIEW_STEP))
+      }, 180)
+    },
+    [currentQuestion],
+  )
+
+  const goBack = () => setStep(s => Math.max(s - 1, 0))
+  const goNext = () => setStep(s => Math.min(s + 1, REVIEW_STEP))
+
+  // Keyboard shortcuts on question steps: 1–4 for scores, N/0 for Not Observed,
+  // arrow keys to navigate. Disabled when typing into the textarea on review.
+  useEffect(() => {
+    if (!open || onReview || !currentQuestion) return
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      if (
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')
+      ) {
+        return
+      }
+      if (e.key === '1') handleSelect(1)
+      else if (e.key === '2') handleSelect(2)
+      else if (e.key === '3') handleSelect(3)
+      else if (e.key === '4') handleSelect(4)
+      else if (e.key === '0' || e.key === 'n' || e.key === 'N')
+        handleSelect(null)
+      else if (e.key === 'ArrowLeft') goBack()
+      else if (e.key === 'ArrowRight') {
+        if (answers[currentQuestion.id] !== undefined) goNext()
+      } else {
+        return
+      }
+      e.preventDefault()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onReview, currentQuestion, answers, handleSelect])
+
+  const handleSubmit = async () => {
+    if (!allAnswered) return
+    const scores: Record<string, number | null> = {}
+    for (const q of EVALUATION_QUESTIONS) {
+      const v = answers[q.id]
+      scores[q.id] = v === undefined ? null : v
+    }
+    const trimmedFeedback = feedback.trim() || null
+
+    try {
+      if (existingEvaluation) {
+        await updateMut.mutateAsync({
+          evaluationId: existingEvaluation.id,
+          payload: { scores, feedback: trimmedFeedback },
+        })
+      } else {
+        await createMut.mutateAsync({ scores, feedback: trimmedFeedback })
+      }
+      onOpenChange(false)
+    } catch {
+      // Error toast handled by mutation hook.
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!existingEvaluation) return
+    try {
+      await deleteMut.mutateAsync(existingEvaluation.id)
+      setConfirmDeleteOpen(false)
+      onOpenChange(false)
+    } catch {
+      // Error toast handled by mutation hook.
+    }
+  }
+
+  const titleText = onReview
+    ? isEditing
+      ? 'Review your changes'
+      : 'Review and submit'
+    : isEditing
+      ? 'Edit your evaluation'
+      : 'Evaluate this session'
+
+  const descriptionText = onReview
+    ? `${answeredCount} of ${EVALUATION_QUESTIONS.length} answered. Add optional feedback and submit.`
+    : `Question ${step + 1} of ${EVALUATION_QUESTIONS.length} · scale 1–4 (4 = demonstrates with proficiency)`
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{titleText}</DialogTitle>
+          <DialogDescription>{descriptionText}</DialogDescription>
+        </DialogHeader>
+
+        {/* Progress bar — clickable to jump to any question. */}
+        <ol className="flex items-center gap-1.5 px-1">
+          {EVALUATION_QUESTIONS.map((q, i) => {
+            const answered = answers[q.id] !== undefined
+            const active = !onReview && i === step
+            return (
+              <li key={q.id} className="flex-1">
+                <button
+                  type="button"
+                  onClick={() => setStep(i)}
+                  aria-label={`Go to question ${i + 1}`}
+                  className={cn(
+                    'block w-full h-1.5 rounded-full transition',
+                    active
+                      ? 'bg-indigo-500'
+                      : answered
+                        ? 'bg-indigo-300 hover:bg-indigo-400'
+                        : 'bg-gray-200 hover:bg-gray-300',
+                  )}
+                />
+              </li>
+            )
+          })}
+          <li>
+            <button
+              type="button"
+              onClick={() => allAnswered && setStep(REVIEW_STEP)}
+              disabled={!allAnswered}
+              aria-label="Review and submit"
+              className={cn(
+                'block h-1.5 w-6 rounded-full transition',
+                onReview
+                  ? 'bg-indigo-500'
+                  : allAnswered
+                    ? 'bg-indigo-300 hover:bg-indigo-400'
+                    : 'bg-gray-100',
+              )}
+            />
+          </li>
+        </ol>
+
+        {/* Body */}
+        {currentQuestion && (
+          <div className="flex flex-col items-center justify-center text-center px-2 py-8 min-h-[280px]">
+            <p className="text-base sm:text-lg text-app-primary leading-snug max-w-xl">
+              {currentQuestion.text}
+            </p>
+            <div className="mt-7 grid grid-cols-5 gap-2 w-full max-w-md">
+              {SCORE_OPTIONS.map(opt => {
+                const isSelected = answers[currentQuestion.id] === opt.value
+                return (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    onClick={() => handleSelect(opt.value)}
+                    disabled={isPending}
+                    className={cn(
+                      'h-12 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-400',
+                      'flex flex-col items-center justify-center px-1',
+                      isSelected ? opt.selectedClass : opt.unselectedClass,
+                    )}
+                  >
+                    <span className="leading-none">{opt.label}</span>
+                  </button>
+                )
+              })}
+            </div>
+            <p className="mt-5 text-xs text-app-secondary">
+              Press{' '}
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+                1
+              </kbd>
+              –
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+                4
+              </kbd>{' '}
+              ·{' '}
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+                N
+              </kbd>{' '}
+              for Not Observed ·{' '}
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+                ←
+              </kbd>
+              /
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+                →
+              </kbd>{' '}
+              to navigate
+            </p>
+          </div>
+        )}
+
+        {onReview && (
+          <div className="px-1 py-4 space-y-5 min-h-[280px]">
+            <div>
+              <p className="text-[11px] uppercase tracking-wide font-medium text-app-secondary mb-2">
+                Your answers — click any to revise
+              </p>
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-1.5">
+                {EVALUATION_QUESTIONS.map((q, i) => {
+                  const v = answers[q.id]
+                  return (
+                    <button
+                      key={q.id}
+                      type="button"
+                      onClick={() => setStep(i)}
+                      title={q.text}
+                      className="flex items-center gap-2 rounded-md border border-app-border px-2 py-1.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                    >
+                      <span className="text-[10px] font-medium text-app-secondary shrink-0">
+                        Q{i + 1}
+                      </span>
+                      <span
+                        className={cn(
+                          'inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[10px] font-semibold ml-auto',
+                          scoreChipClass(v),
+                        )}
+                      >
+                        {v === null ? '—' : (v ?? '?')}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+            <div>
+              <label
+                htmlFor="evaluation-feedback"
+                className="text-sm font-medium text-app-primary"
+              >
+                Feedback{' '}
+                <span className="text-xs font-normal text-app-secondary">
+                  (optional)
+                </span>
+              </label>
+              <Textarea
+                id="evaluation-feedback"
+                value={feedback}
+                onChange={e => setFeedback(e.target.value)}
+                placeholder="Please share your occurrences."
+                maxLength={4000}
+                rows={3}
+                className="mt-1.5"
+              />
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="flex-row sm:justify-between gap-2 mt-2">
+          <div className="flex gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={goBack}
+              disabled={step === 0 || isPending}
+            >
+              <ArrowLeft className="h-4 w-4 mr-1" />
+              Back
+            </Button>
+            {isEditing && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                onClick={() => setConfirmDeleteOpen(true)}
+                disabled={isPending}
+              >
+                <Trash2 className="h-4 w-4 mr-1" />
+                Delete
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            {onReview ? (
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!allAnswered || isPending}
+              >
+                {isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+                {isEditing ? 'Save changes' : 'Submit evaluation'}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                onClick={goNext}
+                disabled={
+                  !currentQuestion ||
+                  answers[currentQuestion.id] === undefined ||
+                  isPending
+                }
+              >
+                Next
+                <ArrowRight className="h-4 w-4 ml-1" />
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this evaluation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your answers and feedback will be removed. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isPending}
+              className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Dialog>
+  )
+}

--- a/src/components/sessions/comments-sidebar.tsx
+++ b/src/components/sessions/comments-sidebar.tsx
@@ -1,0 +1,849 @@
+'use client'
+
+import {
+  forwardRef,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {
+  MessageSquare,
+  Trash2,
+  Pencil,
+  Clock,
+  X,
+  Check,
+  CornerDownRight,
+  Reply,
+} from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+import { formatVideoOffset } from '@/hooks/use-synced-transcript'
+import { VideoComment } from '@/services/video-comments-service'
+
+export type CommentsSidebarHandle = {
+  focusComposer: (atSeconds?: number) => void
+}
+
+interface CommentsSidebarProps {
+  sessionId: string
+  comments: VideoComment[]
+  isLoading?: boolean
+  currentUserId: string | null | undefined
+  isAdmin: boolean
+  currentTimeSec: number
+  getCurrentTime: () => number
+  /** False on transcript-only sessions; suppresses playback affordances. */
+  hasPlayableVideo?: boolean
+  onSeek: (offsetSec: number) => void
+  onPause: () => void
+  onResume: () => void
+  isPlayingRef: React.MutableRefObject<boolean>
+  onCreate: (data: {
+    content: string
+    video_offset_seconds: number
+    parent_id?: string | null
+  }) => Promise<unknown>
+  onUpdate: (commentId: string, content: string) => Promise<unknown>
+  onDelete: (commentId: string) => Promise<unknown>
+  className?: string
+}
+
+type ThreadedComment = VideoComment & { replies: VideoComment[] }
+
+function parseClock(input: string): number | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  const parts = trimmed.split(':').map(p => p.trim())
+  if (parts.some(p => !/^\d+$/.test(p))) return null
+  const nums = parts.map(Number)
+  if (nums.length === 1) return nums[0]
+  if (nums.length === 2) return nums[0] * 60 + nums[1]
+  if (nums.length === 3) return nums[0] * 3600 + nums[1] * 60 + nums[2]
+  return null
+}
+
+function timeAgo(iso: string): string {
+  try {
+    return formatDistanceToNow(new Date(iso), { addSuffix: true })
+  } catch {
+    return ''
+  }
+}
+
+export const CommentsSidebar = forwardRef<
+  CommentsSidebarHandle,
+  CommentsSidebarProps
+>(function CommentsSidebar(
+  {
+    sessionId,
+    comments,
+    isLoading,
+    currentUserId,
+    isAdmin,
+    currentTimeSec,
+    getCurrentTime,
+    hasPlayableVideo = true,
+    onSeek,
+    onPause,
+    onResume,
+    isPlayingRef,
+    onCreate,
+    onUpdate,
+    onDelete,
+    className,
+  },
+  ref,
+) {
+  const [draftContent, setDraftContent] = useState('')
+  const [draftOffsetSec, setDraftOffsetSec] = useState<number | null>(null)
+  const [offsetEditValue, setOffsetEditValue] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const [replyingToId, setReplyingToId] = useState<string | null>(null)
+  const [replyValue, setReplyValue] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const replyTextareaRef = useRef<HTMLTextAreaElement>(null)
+  const wasPlayingOnFocusRef = useRef<boolean>(false)
+  const draftKey = `video-comment-draft:${sessionId}`
+
+  // Restore draft on mount.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(draftKey)
+      if (raw) {
+        const parsed = JSON.parse(raw) as {
+          content?: string
+          offset?: number | null
+        }
+        if (parsed.content) setDraftContent(parsed.content)
+        if (typeof parsed.offset === 'number') setDraftOffsetSec(parsed.offset)
+      }
+    } catch {
+      /* ignore parse errors */
+    }
+  }, [draftKey])
+
+  // Persist draft on every change.
+  useEffect(() => {
+    const payload = JSON.stringify({
+      content: draftContent,
+      offset: draftOffsetSec,
+    })
+    try {
+      if (draftContent.trim() || draftOffsetSec !== null) {
+        localStorage.setItem(draftKey, payload)
+      } else {
+        localStorage.removeItem(draftKey)
+      }
+    } catch {
+      /* ignore storage errors */
+    }
+  }, [draftKey, draftContent, draftOffsetSec])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focusComposer: atSeconds => {
+        if (typeof atSeconds === 'number') setDraftOffsetSec(atSeconds)
+        setTimeout(() => textareaRef.current?.focus(), 0)
+      },
+    }),
+    [],
+  )
+
+  // Tree builder: top-level sorted by offset asc, replies sorted by
+  // created_at asc within each thread (chronological — Slack convention).
+  const threads = useMemo<ThreadedComment[]>(() => {
+    const repliesByParent = new Map<string, VideoComment[]>()
+    for (const c of comments ?? []) {
+      if (c.parent_id) {
+        const arr = repliesByParent.get(c.parent_id) ?? []
+        arr.push(c)
+        repliesByParent.set(c.parent_id, arr)
+      }
+    }
+    for (const arr of repliesByParent.values()) {
+      arr.sort((a, b) => a.created_at.localeCompare(b.created_at))
+    }
+    return (comments ?? [])
+      .filter(c => !c.parent_id)
+      .sort((a, b) => a.video_offset_seconds - b.video_offset_seconds)
+      .map(c => ({ ...c, replies: repliesByParent.get(c.id) ?? [] }))
+  }, [comments])
+
+  const activeThreadId = useMemo(() => {
+    if (threads.length === 0) return null
+    let answer: string | null = null
+    for (const t of threads) {
+      if (t.video_offset_seconds <= currentTimeSec) answer = t.id
+      else break
+    }
+    return answer
+  }, [threads, currentTimeSec])
+
+  const handleComposerFocus = useCallback(() => {
+    // Capture timestamp at focus moment, not at submit.
+    if (draftOffsetSec === null) {
+      setDraftOffsetSec(getCurrentTime())
+    }
+    // Auto-pause; remember whether to resume on blur.
+    wasPlayingOnFocusRef.current = isPlayingRef.current
+    if (isPlayingRef.current) onPause()
+  }, [draftOffsetSec, getCurrentTime, isPlayingRef, onPause])
+
+  const handleComposerBlur = useCallback(() => {
+    if (wasPlayingOnFocusRef.current && !draftContent.trim()) {
+      onResume()
+    }
+    wasPlayingOnFocusRef.current = false
+  }, [draftContent, onResume])
+
+  const handleSubmit = useCallback(() => {
+    const content = draftContent.trim()
+    if (!content) return
+    const offset = draftOffsetSec ?? getCurrentTime()
+    // Optimistic insert handles the visual update via the mutation's
+    // onMutate; close the composer synchronously so the user doesn't
+    // see the typed-out content lingering while the network resolves.
+    // Resume video — message has been sent.
+    if (wasPlayingOnFocusRef.current) onResume()
+    wasPlayingOnFocusRef.current = false
+    setDraftContent('')
+    setDraftOffsetSec(null)
+    try {
+      localStorage.removeItem(draftKey)
+    } catch {
+      /* ignore */
+    }
+    void onCreate({ content, video_offset_seconds: Math.max(0, offset) })
+  }, [
+    draftContent,
+    draftOffsetSec,
+    getCurrentTime,
+    onCreate,
+    onResume,
+    draftKey,
+  ])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault()
+        handleSubmit()
+      }
+    },
+    [handleSubmit],
+  )
+
+  const startEditingOffset = useCallback(() => {
+    setOffsetEditValue(formatVideoOffset(draftOffsetSec ?? getCurrentTime()))
+  }, [draftOffsetSec, getCurrentTime])
+
+  const commitOffsetEdit = useCallback(() => {
+    if (offsetEditValue === null) return
+    const parsed = parseClock(offsetEditValue)
+    if (parsed !== null) setDraftOffsetSec(parsed)
+    setOffsetEditValue(null)
+  }, [offsetEditValue])
+
+  // -- Reply composer --
+
+  const openReply = useCallback(
+    (parentId: string) => {
+      setReplyingToId(parentId)
+      setReplyValue('')
+      // Auto-pause on opening, remember to resume if cancelled empty.
+      wasPlayingOnFocusRef.current = isPlayingRef.current
+      if (isPlayingRef.current) onPause()
+      setTimeout(() => replyTextareaRef.current?.focus(), 0)
+    },
+    [isPlayingRef, onPause],
+  )
+
+  const closeReply = useCallback(() => {
+    if (wasPlayingOnFocusRef.current && !replyValue.trim()) {
+      onResume()
+    }
+    wasPlayingOnFocusRef.current = false
+    setReplyingToId(null)
+    setReplyValue('')
+  }, [onResume, replyValue])
+
+  const submitReply = useCallback(
+    (parent: ThreadedComment) => {
+      const content = replyValue.trim()
+      if (!content) return
+      // Resume video — message sent.
+      if (wasPlayingOnFocusRef.current) onResume()
+      wasPlayingOnFocusRef.current = false
+      // Close the composer synchronously; the mutation's onMutate inserts
+      // the optimistic reply, so the new card appears in its place.
+      setReplyingToId(null)
+      setReplyValue('')
+      void onCreate({
+        content,
+        video_offset_seconds: parent.video_offset_seconds,
+        parent_id: parent.id,
+      })
+    },
+    [onCreate, onResume, replyValue],
+  )
+
+  return (
+    <Card className={cn('border-gray-200 flex flex-col', className)}>
+      <CardHeader className="border-b border-gray-200 py-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base font-semibold">
+            <MessageSquare className="h-4 w-4 text-gray-500" />
+            Comments
+          </CardTitle>
+          <Badge variant="secondary" className="text-xs">
+            {threads.length}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="border-b border-gray-100 p-3">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+              At
+            </span>
+            {offsetEditValue === null ? (
+              <button
+                type="button"
+                onClick={startEditingOffset}
+                className="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-0.5 font-mono text-xs text-indigo-700 ring-1 ring-indigo-100 hover:bg-indigo-100"
+                title="Click to edit timestamp"
+              >
+                <Clock className="h-3 w-3" />
+                {formatVideoOffset(draftOffsetSec ?? currentTimeSec)}
+              </button>
+            ) : (
+              <span className="inline-flex items-center gap-1">
+                <Input
+                  autoFocus
+                  value={offsetEditValue}
+                  onChange={e => setOffsetEditValue(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      commitOffsetEdit()
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault()
+                      setOffsetEditValue(null)
+                    }
+                  }}
+                  onBlur={commitOffsetEdit}
+                  placeholder="m:ss"
+                  className="h-7 w-20 px-2 text-xs"
+                />
+              </span>
+            )}
+            {hasPlayableVideo && (
+              <button
+                type="button"
+                onClick={() => setDraftOffsetSec(getCurrentTime())}
+                className="text-[11px] text-gray-500 hover:text-indigo-600 hover:underline"
+                title="Pin to current playback time"
+              >
+                use current
+              </button>
+            )}
+          </div>
+          <Textarea
+            ref={textareaRef}
+            value={draftContent}
+            onChange={e => setDraftContent(e.target.value)}
+            onFocus={handleComposerFocus}
+            onBlur={handleComposerBlur}
+            onKeyDown={handleKeyDown}
+            placeholder="Leave a comment for this moment…"
+            className="min-h-[72px] resize-none text-sm"
+          />
+          <div className="mt-2 flex items-center justify-between">
+            <span className="text-[11px] text-gray-400">
+              ⌘/Ctrl + Enter to send
+            </span>
+            <div className="flex items-center gap-2">
+              {(draftContent || draftOffsetSec !== null) && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setDraftContent('')
+                    setDraftOffsetSec(null)
+                  }}
+                >
+                  Cancel
+                </Button>
+              )}
+              <Button
+                size="sm"
+                onClick={handleSubmit}
+                disabled={!draftContent.trim()}
+                className="bg-indigo-600 hover:bg-indigo-700 text-white"
+              >
+                Comment
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="max-h-[28rem] overflow-y-auto">
+          {isLoading && threads.length === 0 ? (
+            <div className="space-y-3 p-3">
+              {[0, 1, 2].map(i => (
+                <div
+                  key={i}
+                  className="h-16 animate-pulse rounded-md bg-gray-100"
+                />
+              ))}
+            </div>
+          ) : threads.length === 0 ? (
+            <div className="px-4 py-10 text-center text-sm text-gray-500">
+              <p className="font-medium text-gray-700">No comments yet.</p>
+              <p className="mt-1 text-gray-500">
+                Click any line in the transcript or the button above to leave
+                the first one.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-100">
+              {threads.map(thread => (
+                <ThreadItem
+                  key={thread.id}
+                  thread={thread}
+                  isActive={thread.id === activeThreadId}
+                  currentUserId={currentUserId}
+                  isAdmin={isAdmin}
+                  onSeek={onSeek}
+                  onUpdate={onUpdate}
+                  onDelete={onDelete}
+                  editingId={editingId}
+                  setEditingId={setEditingId}
+                  editValue={editValue}
+                  setEditValue={setEditValue}
+                  replyingToId={replyingToId}
+                  replyValue={replyValue}
+                  setReplyValue={setReplyValue}
+                  onOpenReply={() => openReply(thread.id)}
+                  onCloseReply={closeReply}
+                  onSubmitReply={() => submitReply(thread)}
+                  replyTextareaRef={replyTextareaRef}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+})
+
+interface ThreadItemProps {
+  thread: ThreadedComment
+  isActive: boolean
+  currentUserId: string | null | undefined
+  isAdmin: boolean
+  onSeek: (offsetSec: number) => void
+  onUpdate: (commentId: string, content: string) => Promise<unknown>
+  onDelete: (commentId: string) => Promise<unknown>
+  editingId: string | null
+  setEditingId: (id: string | null) => void
+  editValue: string
+  setEditValue: (v: string) => void
+  replyingToId: string | null
+  replyValue: string
+  setReplyValue: (v: string) => void
+  onOpenReply: () => void
+  onCloseReply: () => void
+  onSubmitReply: () => void
+  replyTextareaRef: React.RefObject<HTMLTextAreaElement | null>
+}
+
+function ThreadItem({
+  thread,
+  isActive,
+  currentUserId,
+  isAdmin,
+  onSeek,
+  onUpdate,
+  onDelete,
+  editingId,
+  setEditingId,
+  editValue,
+  setEditValue,
+  replyingToId,
+  replyValue,
+  setReplyValue,
+  onOpenReply,
+  onCloseReply,
+  onSubmitReply,
+  replyTextareaRef,
+}: ThreadItemProps) {
+  const replyCount = thread.replies.length
+  const showingReplyComposer = replyingToId === thread.id
+
+  return (
+    <li
+      className={cn(
+        'transition-colors',
+        isActive
+          ? 'bg-indigo-50/60 ring-inset ring-1 ring-indigo-200'
+          : 'hover:bg-gray-50',
+      )}
+    >
+      <CommentBody
+        comment={thread}
+        currentUserId={currentUserId}
+        isAdmin={isAdmin}
+        onSeek={() => onSeek(thread.video_offset_seconds)}
+        onUpdate={onUpdate}
+        onDelete={onDelete}
+        editingId={editingId}
+        setEditingId={setEditingId}
+        editValue={editValue}
+        setEditValue={setEditValue}
+        showOffsetChip
+        replyCount={replyCount}
+        onReply={onOpenReply}
+      />
+
+      {(replyCount > 0 || showingReplyComposer) && (
+        <div className="ml-7 border-l-2 border-indigo-100 pl-3 pb-3 pr-3 space-y-2">
+          {thread.replies.map(reply => (
+            <CommentBody
+              key={reply.id}
+              comment={reply}
+              currentUserId={currentUserId}
+              isAdmin={isAdmin}
+              onSeek={() => onSeek(thread.video_offset_seconds)}
+              onUpdate={onUpdate}
+              onDelete={onDelete}
+              editingId={editingId}
+              setEditingId={setEditingId}
+              editValue={editValue}
+              setEditValue={setEditValue}
+              compact
+            />
+          ))}
+          {showingReplyComposer && (
+            <div className="rounded-md border border-gray-200 bg-white p-2">
+              <Textarea
+                ref={replyTextareaRef}
+                value={replyValue}
+                onChange={e => setReplyValue(e.target.value)}
+                onKeyDown={e => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                    e.preventDefault()
+                    onSubmitReply()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    onCloseReply()
+                  }
+                }}
+                placeholder="Reply…"
+                className="min-h-[56px] resize-none text-sm"
+              />
+              <div className="mt-1.5 flex items-center justify-between">
+                <span className="text-[11px] text-gray-400">
+                  ⌘/Ctrl + Enter to send · Esc to cancel
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button variant="ghost" size="sm" onClick={onCloseReply}>
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={onSubmitReply}
+                    disabled={!replyValue.trim()}
+                    className="bg-indigo-600 hover:bg-indigo-700 text-white"
+                  >
+                    Reply
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+interface CommentBodyProps {
+  comment: VideoComment
+  currentUserId: string | null | undefined
+  isAdmin: boolean
+  onSeek: () => void
+  onUpdate: (commentId: string, content: string) => Promise<unknown>
+  onDelete: (commentId: string) => Promise<unknown>
+  editingId: string | null
+  setEditingId: (id: string | null) => void
+  editValue: string
+  setEditValue: (v: string) => void
+  showOffsetChip?: boolean
+  replyCount?: number
+  onReply?: () => void
+  compact?: boolean
+}
+
+function CommentBody({
+  comment,
+  currentUserId,
+  isAdmin,
+  onSeek,
+  onUpdate,
+  onDelete,
+  editingId,
+  setEditingId,
+  editValue,
+  setEditValue,
+  showOffsetChip,
+  replyCount = 0,
+  onReply,
+  compact,
+}: CommentBodyProps) {
+  const isMine = !!currentUserId && comment.author_id === currentUserId
+  const canDelete = isMine || isAdmin
+  const isEditing = editingId === comment.id
+  const authorLabel = isMine
+    ? 'You'
+    : comment.author_name || comment.author_email || 'Unknown'
+  const cascadeWarning =
+    replyCount > 0
+      ? `Delete this comment and its ${replyCount} ${
+          replyCount === 1 ? 'reply' : 'replies'
+        }? This cannot be undone.`
+      : 'This cannot be undone.'
+
+  const inlineActions = !isEditing && (isMine || canDelete) && (
+    <span
+      className="hidden group-hover:inline-flex items-center gap-0.5"
+      onClick={e => e.stopPropagation()}
+    >
+      {isMine && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 w-5 p-0 text-gray-500 hover:text-indigo-700"
+          title="Edit"
+          onClick={() => {
+            setEditingId(comment.id)
+            setEditValue(comment.content)
+          }}
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+      )}
+      {canDelete && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-5 w-5 p-0 text-gray-500 hover:text-red-600 hover:bg-red-50"
+              title="Delete"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete comment?</AlertDialogTitle>
+              <AlertDialogDescription>{cascadeWarning}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => onDelete(comment.id)}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </span>
+  )
+
+  return (
+    <div
+      className={cn('group cursor-pointer', compact ? 'py-1.5' : 'p-3')}
+      onClick={() => !isEditing && onSeek()}
+    >
+      <div className="flex items-center justify-between gap-2">
+        {showOffsetChip ? (
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation()
+              onSeek()
+            }}
+            className="rounded-full bg-gray-100 px-2 py-0.5 font-mono text-[11px] text-gray-700 hover:bg-indigo-100 hover:text-indigo-700"
+          >
+            {formatVideoOffset(comment.video_offset_seconds)}
+          </button>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
+            <CornerDownRight className="h-3 w-3" />
+            <span className="font-medium text-gray-700">{authorLabel}</span>
+          </span>
+        )}
+        <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
+          {showOffsetChip && (
+            <>
+              <span className="font-medium text-gray-700">{authorLabel}</span>
+              <span className="mx-1">·</span>
+            </>
+          )}
+          <span
+            className={cn(compact && inlineActions && 'group-hover:hidden')}
+          >
+            {timeAgo(comment.created_at)}
+          </span>
+          {compact && inlineActions}
+        </span>
+      </div>
+      {isEditing ? (
+        <div className="mt-2" onClick={e => e.stopPropagation()}>
+          <Textarea
+            value={editValue}
+            onChange={e => setEditValue(e.target.value)}
+            className="min-h-[60px] text-sm"
+            autoFocus
+          />
+          <div className="mt-2 flex items-center justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setEditingId(null)
+                setEditValue('')
+              }}
+            >
+              <X className="h-3.5 w-3.5 mr-1" />
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              disabled={
+                !editValue.trim() || editValue.trim() === comment.content
+              }
+              onClick={async () => {
+                await onUpdate(comment.id, editValue.trim())
+                setEditingId(null)
+                setEditValue('')
+              }}
+              className="bg-indigo-600 hover:bg-indigo-700 text-white"
+            >
+              <Check className="h-3.5 w-3.5 mr-1" />
+              Save
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <p
+          className={cn(
+            'whitespace-pre-wrap text-sm leading-relaxed text-gray-800',
+            compact ? 'mt-0.5' : 'mt-1',
+          )}
+        >
+          {comment.content}
+        </p>
+      )}
+      {!isEditing && !compact && (
+        <div
+          className="mt-1 flex items-center gap-1"
+          onClick={e => e.stopPropagation()}
+        >
+          {onReply && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs text-gray-600 hover:text-indigo-700"
+              onClick={onReply}
+            >
+              <Reply className="h-3 w-3 mr-1" />
+              Reply
+              {replyCount > 0 && (
+                <span className="ml-1 text-[10px] text-gray-500">
+                  ({replyCount})
+                </span>
+              )}
+            </Button>
+          )}
+          <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            {isMine && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => {
+                  setEditingId(comment.id)
+                  setEditValue(comment.content)
+                }}
+              >
+                <Pencil className="h-3 w-3 mr-1" />
+                Edit
+              </Button>
+            )}
+            {canDelete && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
+                  >
+                    <Trash2 className="h-3 w-3 mr-1" />
+                    Delete
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete comment?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {cascadeWarning}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => onDelete(comment.id)}
+                      className="bg-red-600 hover:bg-red-700"
+                    >
+                      Delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/sessions/evaluations-list.tsx
+++ b/src/components/sessions/evaluations-list.tsx
@@ -1,0 +1,256 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react'
+import {
+  EVALUATION_QUESTIONS,
+  averageScore,
+  scoreChipClass,
+  scoreLabel,
+} from '@/lib/coach-evaluation-questions'
+import { CoachEvaluation } from '@/services/coach-evaluations-service'
+import { useDeleteCoachEvaluation } from '@/hooks/mutations/use-coach-evaluation-mutations'
+import { formatRelativeTime } from '@/lib/date-utils'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+
+interface EvaluationsListProps {
+  sessionId: string
+  evaluations: CoachEvaluation[]
+  currentUserId: string | null
+  isAdmin: boolean
+}
+
+export function EvaluationsList({
+  sessionId,
+  evaluations,
+  currentUserId,
+  isAdmin,
+}: EvaluationsListProps) {
+  const avg = useMemo(() => averageScore(evaluations), [evaluations])
+
+  return (
+    <section className="mt-6 rounded-lg border border-app-border bg-white dark:bg-gray-900 p-4">
+      <header className="flex items-baseline justify-between mb-3">
+        <h2 className="text-base font-semibold text-app-primary">
+          Peer evaluations{' '}
+          <span className="text-sm font-normal text-app-secondary">
+            ({evaluations.length})
+          </span>
+        </h2>
+        {avg !== null && (
+          <span className="text-xs text-app-secondary">
+            Avg across reviewers:{' '}
+            <span className="font-semibold text-app-primary">
+              {avg.toFixed(1)} / 4
+            </span>
+          </span>
+        )}
+      </header>
+
+      {evaluations.length === 0 ? (
+        <p className="text-sm text-app-secondary">No evaluations yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {evaluations.map(e => (
+            <EvaluationRow
+              key={e.id}
+              sessionId={sessionId}
+              evaluation={e}
+              isOwn={e.reviewer_id === currentUserId}
+              canDelete={isAdmin || e.reviewer_id === currentUserId}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+interface EvaluationRowProps {
+  sessionId: string
+  evaluation: CoachEvaluation
+  isOwn: boolean
+  canDelete: boolean
+}
+
+function EvaluationRow({
+  sessionId,
+  evaluation,
+  isOwn,
+  canDelete,
+}: EvaluationRowProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const deleteMut = useDeleteCoachEvaluation(sessionId)
+
+  const reviewerLabel =
+    evaluation.reviewer_name || evaluation.reviewer_email || 'Unknown reviewer'
+
+  const numericScores = useMemo(() => {
+    const nums: number[] = []
+    for (const v of Object.values(evaluation.scores)) {
+      if (typeof v === 'number') nums.push(v)
+    }
+    return nums
+  }, [evaluation.scores])
+
+  const reviewerAvg =
+    numericScores.length === 0
+      ? null
+      : numericScores.reduce((a, b) => a + b, 0) / numericScores.length
+
+  const handleDelete = async () => {
+    try {
+      await deleteMut.mutateAsync(evaluation.id)
+      setConfirmOpen(false)
+    } catch {
+      // toast handled by mutation
+    }
+  }
+
+  return (
+    <li className="rounded-md border border-app-border bg-white dark:bg-gray-800">
+      <button
+        type="button"
+        onClick={() => setExpanded(prev => !prev)}
+        className="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60"
+      >
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 mt-0.5 text-gray-400 shrink-0" />
+        ) : (
+          <ChevronRight className="h-4 w-4 mt-0.5 text-gray-400 shrink-0" />
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm font-medium text-app-primary">
+              {reviewerLabel}
+            </span>
+            {isOwn && (
+              <span className="text-[10px] uppercase tracking-wide rounded bg-indigo-50 text-indigo-700 px-1.5 py-0.5">
+                you
+              </span>
+            )}
+            <span className="text-xs text-app-secondary">
+              {formatRelativeTime(evaluation.created_at)}
+            </span>
+            {reviewerAvg !== null && (
+              <span className="text-xs text-app-secondary ml-auto">
+                Avg{' '}
+                <span className="font-semibold text-app-primary">
+                  {reviewerAvg.toFixed(1)} / 4
+                </span>
+              </span>
+            )}
+          </div>
+          <div className="mt-1.5 flex flex-wrap gap-1">
+            {EVALUATION_QUESTIONS.map(q => {
+              const v = evaluation.scores[q.id]
+              return (
+                <span
+                  key={q.id}
+                  title={`${q.id.toUpperCase()}: ${scoreLabel(v)}`}
+                  className={cn(
+                    'inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[10px] font-medium',
+                    scoreChipClass(v),
+                  )}
+                >
+                  {v === null ? '—' : v}
+                </span>
+              )
+            })}
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 pl-9 space-y-2 border-t border-app-border/60">
+          <ol className="space-y-1.5 mt-2">
+            {EVALUATION_QUESTIONS.map((q, idx) => {
+              const v = evaluation.scores[q.id]
+              return (
+                <li key={q.id} className="flex items-start gap-2 text-xs">
+                  <span className="text-app-secondary shrink-0">
+                    {idx + 1}.
+                  </span>
+                  <span className="flex-1 text-app-primary leading-snug">
+                    {q.text}
+                  </span>
+                  <span
+                    className={cn(
+                      'inline-flex shrink-0 items-center justify-center rounded-full px-2 py-0.5 text-[11px] font-medium',
+                      scoreChipClass(v),
+                    )}
+                  >
+                    {scoreLabel(v)}
+                  </span>
+                </li>
+              )
+            })}
+          </ol>
+          {evaluation.feedback && (
+            <div className="rounded bg-gray-50 dark:bg-gray-900/40 p-2 mt-2">
+              <p className="text-[10px] uppercase tracking-wide text-app-secondary mb-1">
+                Feedback
+              </p>
+              <p className="text-xs text-app-primary whitespace-pre-wrap">
+                {evaluation.feedback}
+              </p>
+            </div>
+          )}
+          {canDelete && (
+            <div className="flex justify-end pt-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                onClick={() => setConfirmOpen(true)}
+                disabled={deleteMut.isPending}
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-1" />
+                Delete
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this evaluation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {isOwn
+                ? 'Your answers and feedback will be removed.'
+                : `Remove the evaluation submitted by ${reviewerLabel}.`}{' '}
+              This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteMut.isPending}
+              className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </li>
+  )
+}

--- a/src/components/sessions/share-session-dialog.tsx
+++ b/src/components/sessions/share-session-dialog.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Search, Share2, X, Users, Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { cn } from '@/lib/utils'
+import {
+  useCoachSearch,
+  useSessionShares,
+} from '@/hooks/queries/use-session-shares'
+import {
+  useRevokeShare,
+  useShareSession,
+  useToggleShareWithAll,
+} from '@/hooks/mutations/use-session-share-mutations'
+
+interface ShareSessionDialogProps {
+  sessionId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const RECENT_KEY = 'video-share-recent-coaches'
+const RECENT_LIMIT = 5
+
+interface RecentEntry {
+  id: string
+  full_name: string | null
+  email: string
+}
+
+function loadRecent(): RecentEntry[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.slice(0, RECENT_LIMIT)
+  } catch {
+    return []
+  }
+}
+
+function saveRecent(entries: RecentEntry[]) {
+  try {
+    localStorage.setItem(
+      RECENT_KEY,
+      JSON.stringify(entries.slice(0, RECENT_LIMIT)),
+    )
+  } catch {
+    /* ignore */
+  }
+}
+
+function useDebounced<T>(value: T, delay = 200): T {
+  const [v, setV] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), delay)
+    return () => clearTimeout(t)
+  }, [value, delay])
+  return v
+}
+
+export function ShareSessionDialog({
+  sessionId,
+  open,
+  onOpenChange,
+}: ShareSessionDialogProps) {
+  const [search, setSearch] = useState('')
+  const debouncedSearch = useDebounced(search, 200)
+  const [recent, setRecent] = useState<RecentEntry[]>([])
+
+  const sharesQuery = useSessionShares(sessionId, { enabled: open })
+  const searchQuery = useCoachSearch(debouncedSearch.trim(), open)
+  const shareMut = useShareSession(sessionId)
+  const revokeMut = useRevokeShare(sessionId)
+  const toggleAllMut = useToggleShareWithAll(sessionId)
+
+  useEffect(() => {
+    if (open) setRecent(loadRecent())
+  }, [open])
+
+  const sharedUserIds = useMemo(() => {
+    const set = new Set<string>()
+    sharesQuery.data?.shares.forEach(s => set.add(s.shared_with_user_id))
+    return set
+  }, [sharesQuery.data])
+
+  const visibleResults = useMemo(() => {
+    const candidates = searchQuery.data ?? []
+    return candidates.filter(c => !sharedUserIds.has(c.id))
+  }, [searchQuery.data, sharedUserIds])
+
+  const recentVisible = useMemo(
+    () => recent.filter(r => !sharedUserIds.has(r.id)),
+    [recent, sharedUserIds],
+  )
+
+  const handleAdd = async (entry: RecentEntry) => {
+    await shareMut.mutateAsync([entry.id])
+    const next = [entry, ...recent.filter(r => r.id !== entry.id)].slice(
+      0,
+      RECENT_LIMIT,
+    )
+    setRecent(next)
+    saveRecent(next)
+    setSearch('')
+  }
+
+  const handleRevoke = async (shareId: string) => {
+    await revokeMut.mutateAsync(shareId)
+  }
+
+  const handleToggleAll = async (next: boolean) => {
+    await toggleAllMut.mutateAsync(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg">
+            <Share2 className="h-5 w-5 text-indigo-600" />
+            Share session
+          </DialogTitle>
+          <DialogDescription>
+            Share this recording with another coach so they can review and leave
+            feedback.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">
+              Add coaches
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Type a name or email…"
+                className="pl-8"
+              />
+              {searchQuery.isFetching && search && (
+                <Loader2 className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-gray-400" />
+              )}
+            </div>
+
+            {search.trim() && visibleResults.length > 0 && (
+              <div className="mt-2 max-h-48 overflow-y-auto rounded-md border border-gray-200">
+                {visibleResults.map(u => (
+                  <button
+                    key={u.id}
+                    type="button"
+                    onClick={() =>
+                      handleAdd({
+                        id: u.id,
+                        full_name: u.full_name,
+                        email: u.email,
+                      })
+                    }
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                  >
+                    <Initial label={u.full_name || u.email} />
+                    <span className="flex-1">
+                      <span className="block text-gray-900">
+                        {u.full_name || u.email}
+                      </span>
+                      {u.full_name && (
+                        <span className="block text-xs text-gray-500">
+                          {u.email}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {search.trim() &&
+              !searchQuery.isFetching &&
+              visibleResults.length === 0 && (
+                <p className="mt-2 text-xs text-gray-500">No matches.</p>
+              )}
+
+            {!search.trim() && recentVisible.length > 0 && (
+              <div className="mt-2">
+                <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-gray-400">
+                  Recently shared with
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {recentVisible.map(r => (
+                    <button
+                      key={r.id}
+                      type="button"
+                      onClick={() => handleAdd(r)}
+                      className="rounded-full border border-gray-200 px-2.5 py-1 text-xs text-gray-700 hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700"
+                    >
+                      {r.full_name || r.email}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-gray-500">
+              Shared with
+            </label>
+            {sharesQuery.isLoading ? (
+              <div className="space-y-2">
+                {[0, 1].map(i => (
+                  <div
+                    key={i}
+                    className="h-7 animate-pulse rounded bg-gray-100"
+                  />
+                ))}
+              </div>
+            ) : sharesQuery.data && sharesQuery.data.shares.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {sharesQuery.data.shares.map(s => (
+                  <span
+                    key={s.id}
+                    className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-700 ring-1 ring-indigo-200"
+                  >
+                    {s.shared_with_name || s.shared_with_email}
+                    <button
+                      type="button"
+                      onClick={() => handleRevoke(s.id)}
+                      disabled={revokeMut.isPending}
+                      className="rounded-full p-0.5 text-indigo-400 hover:bg-indigo-100 hover:text-indigo-700"
+                      aria-label={`Remove ${s.shared_with_name || s.shared_with_email}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-gray-500">
+                Not shared with anyone yet.
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+            <Users className="mt-0.5 h-4 w-4 text-gray-500" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-gray-900">
+                Share with all coaches
+              </p>
+              <p className="text-xs text-gray-500">
+                Anyone in your team with a coach role will be able to view and
+                comment.
+              </p>
+            </div>
+            <Switch
+              checked={!!sharesQuery.data?.is_shared_with_all_coaches}
+              onCheckedChange={handleToggleAll}
+              disabled={toggleAllMut.isPending}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Initial({ label }: { label: string }) {
+  const initial = (label || '?').trim().charAt(0).toUpperCase()
+  return (
+    <span
+      className={cn(
+        'flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-100 text-[11px] font-medium text-indigo-700',
+      )}
+    >
+      {initial}
+    </span>
+  )
+}

--- a/src/components/sessions/shared-session-row.tsx
+++ b/src/components/sessions/shared-session-row.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { Clock, MessageSquare, Play, User, Users, Video } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+import { formatDate, formatRelativeTime } from '@/lib/date-utils'
+import { cn } from '@/lib/utils'
+
+interface SharedSessionRowSession {
+  id: string
+  title?: string | null
+  status: string
+  created_at: string
+  duration_seconds?: number | null
+  coach_name?: string | null
+  client_name?: string | null
+  meeting_url?: string | null
+  video_url?: string | null
+  video_unavailable?: boolean
+  is_group_session?: boolean
+  participant_count?: number | null
+}
+
+interface SharedSessionRowProps {
+  session: SharedSessionRowSession
+  onOpen: (sessionId: string) => void
+}
+
+function platformLabel(url: string | null | undefined): string {
+  if (!url) return 'Meeting'
+  if (url.includes('zoom.us')) return 'Zoom'
+  if (url.includes('meet.google.com')) return 'Google Meet'
+  if (url.includes('teams.microsoft.com')) return 'Teams'
+  return 'Meeting'
+}
+
+function formatDuration(seconds: number | null | undefined): string | null {
+  if (!seconds || seconds <= 0) return null
+  const m = Math.floor(seconds / 60)
+  const h = Math.floor(m / 60)
+  if (h > 0) return `${h}h ${m % 60}m`
+  return `${m}m`
+}
+
+export function SharedSessionRow({ session, onOpen }: SharedSessionRowProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [thumbReady, setThumbReady] = useState(false)
+  const [thumbFailed, setThumbFailed] = useState(false)
+
+  const platform = platformLabel(session.meeting_url)
+  const dateLabel = formatDate(session.created_at, 'EEE, MMM d, yyyy')
+  const relative = formatRelativeTime(session.created_at)
+  const duration = formatDuration(session.duration_seconds)
+  const title =
+    session.title ||
+    `${platform} — ${formatDate(session.created_at, 'MMM d, yyyy')}`
+
+  const hasVideo = !!session.video_url && !session.video_unavailable
+
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(session.id)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onOpen(session.id)
+        }
+      }}
+      className={cn(
+        'group flex flex-col sm:flex-row gap-4 p-4 cursor-pointer',
+        'border border-app-border bg-white dark:bg-gray-900',
+        'hover:border-indigo-300 hover:shadow-md transition-all duration-150',
+        'focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2',
+      )}
+    >
+      {/* Thumbnail */}
+      <div
+        className={cn(
+          'relative flex-shrink-0 overflow-hidden rounded-lg bg-gray-900',
+          'w-full sm:w-64 aspect-video',
+        )}
+      >
+        {hasVideo && !thumbFailed ? (
+          <>
+            <video
+              ref={videoRef}
+              src={session.video_url ?? undefined}
+              preload="metadata"
+              muted
+              playsInline
+              onLoadedData={() => setThumbReady(true)}
+              onError={() => setThumbFailed(true)}
+              className={cn(
+                'h-full w-full object-cover transition-opacity duration-300',
+                thumbReady ? 'opacity-100' : 'opacity-0',
+              )}
+            />
+            {!thumbReady && (
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
+                <Video className="h-8 w-8 text-gray-500 animate-pulse" />
+              </div>
+            )}
+            {/* Play overlay */}
+            <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/20 transition-colors">
+              <div className="rounded-full bg-white/90 p-3 shadow-lg opacity-90 group-hover:opacity-100 group-hover:scale-110 transition-transform">
+                <Play className="h-5 w-5 text-gray-900 fill-current" />
+              </div>
+            </div>
+            {duration && (
+              <div className="absolute bottom-2 right-2 rounded bg-black/70 px-1.5 py-0.5 text-xs font-medium text-white">
+                {duration}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-gray-100 dark:bg-gray-800">
+            <Video className="h-8 w-8 text-gray-400" />
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {session.video_unavailable
+                ? 'Recording unavailable'
+                : 'No recording yet'}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 min-w-0 flex-col justify-between gap-2">
+        <div className="space-y-1.5">
+          <h3 className="text-base font-semibold text-app-primary truncate">
+            {title}
+          </h3>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-app-secondary">
+            {session.coach_name && (
+              <span className="flex items-center gap-1.5">
+                <User className="h-3.5 w-3.5 text-app-secondary" />
+                <span>
+                  Shared by{' '}
+                  <span className="font-medium text-app-primary">
+                    {session.coach_name}
+                  </span>
+                </span>
+              </span>
+            )}
+            {session.client_name && (
+              <span className="flex items-center gap-1.5">
+                <Users className="h-3.5 w-3.5 text-app-secondary" />
+                <span>
+                  Client:{' '}
+                  <span className="font-medium text-app-primary">
+                    {session.client_name}
+                  </span>
+                </span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <div className="flex items-center gap-3 text-xs text-app-secondary">
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {dateLabel} · {relative}
+            </span>
+          </div>
+          <span className="flex items-center gap-1.5 text-xs font-medium text-indigo-600 group-hover:text-indigo-700">
+            <MessageSquare className="h-3.5 w-3.5" />
+            Open review
+          </span>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/sessions/transcript-pane.tsx
+++ b/src/components/sessions/transcript-pane.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  forwardRef,
+} from 'react'
+import { Search, X, MessageSquarePlus } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  formatVideoOffset,
+  useSyncedTranscript,
+} from '@/hooks/use-synced-transcript'
+
+export interface TranscriptPaneEntry {
+  id: string
+  speaker: string
+  text: string
+  timestamp: string
+}
+
+export type TranscriptPaneHandle = {
+  focusSearch: () => void
+}
+
+interface TranscriptPaneProps {
+  transcript: TranscriptPaneEntry[]
+  /** Wall-clock time corresponding to video t=0. See useSyncedTranscript. */
+  videoAnchorAt: string | null | undefined
+  currentTimeSec: number
+  onSeek: (offsetSec: number) => void
+  onAddCommentAt?: (offsetSec: number) => void
+  className?: string
+}
+
+const SPEAKER_PALETTE = [
+  'bg-indigo-50 text-indigo-700 ring-indigo-100',
+  'bg-emerald-50 text-emerald-700 ring-emerald-100',
+  'bg-amber-50 text-amber-700 ring-amber-100',
+  'bg-rose-50 text-rose-700 ring-rose-100',
+  'bg-sky-50 text-sky-700 ring-sky-100',
+  'bg-violet-50 text-violet-700 ring-violet-100',
+]
+
+function speakerSwatch(speaker: string): string {
+  let hash = 0
+  for (let i = 0; i < speaker.length; i++) {
+    hash = (hash * 31 + speaker.charCodeAt(i)) | 0
+  }
+  return SPEAKER_PALETTE[Math.abs(hash) % SPEAKER_PALETTE.length]
+}
+
+function highlightMatch(text: string, needle: string): React.ReactNode {
+  if (!needle) return text
+  const idx = text.toLowerCase().indexOf(needle.toLowerCase())
+  if (idx === -1) return text
+  const before = text.slice(0, idx)
+  const match = text.slice(idx, idx + needle.length)
+  const after = text.slice(idx + needle.length)
+  return (
+    <>
+      {before}
+      <mark className="rounded bg-yellow-200 px-0.5 text-gray-900">
+        {match}
+      </mark>
+      {after}
+    </>
+  )
+}
+
+export const TranscriptPane = forwardRef<
+  TranscriptPaneHandle,
+  TranscriptPaneProps
+>(function TranscriptPane(
+  {
+    transcript,
+    videoAnchorAt,
+    currentTimeSec,
+    onSeek,
+    onAddCommentAt,
+    className,
+  },
+  ref,
+) {
+  const [search, setSearch] = useState('')
+  const [matchIndex, setMatchIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const lastManualScrollRef = useRef<number>(0)
+  const rowRefs = useRef<Record<string, HTMLDivElement | null>>({})
+
+  useImperativeHandle(
+    ref,
+    () => ({ focusSearch: () => searchRef.current?.focus() }),
+    [],
+  )
+
+  const getTimestamp = useCallback((e: TranscriptPaneEntry) => e.timestamp, [])
+
+  const { entries, activeIndex } = useSyncedTranscript({
+    transcript,
+    videoAnchorAt,
+    currentTimeSec,
+    getTimestamp,
+  })
+
+  const matches = useMemo(() => {
+    if (!search.trim()) return [] as number[]
+    const needle = search.trim().toLowerCase()
+    return entries
+      .map((e, i) => (e.entry.text.toLowerCase().includes(needle) ? i : -1))
+      .filter(i => i >= 0)
+  }, [entries, search])
+
+  useEffect(() => {
+    setMatchIndex(0)
+  }, [search])
+
+  const handleSearchKey = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (matches.length === 0) return
+      if (e.key === 'Enter' || e.key === 'ArrowDown') {
+        e.preventDefault()
+        const next = (matchIndex + 1) % matches.length
+        setMatchIndex(next)
+        const target = entries[matches[next]]
+        if (target) onSeek(target.offsetSec)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        const next = (matchIndex - 1 + matches.length) % matches.length
+        setMatchIndex(next)
+        const target = entries[matches[next]]
+        if (target) onSeek(target.offsetSec)
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        setSearch('')
+        searchRef.current?.blur()
+      }
+    },
+    [entries, matches, matchIndex, onSeek],
+  )
+
+  // Track manual scroll so we can pause auto-scroll for 3 seconds.
+  const handleScroll = useCallback(() => {
+    lastManualScrollRef.current = Date.now()
+  }, [])
+
+  // Auto-scroll to active row.
+  useEffect(() => {
+    if (activeIndex < 0) return
+    const since = Date.now() - lastManualScrollRef.current
+    if (since < 3000) return
+    const activeEntry = entries[activeIndex]
+    if (!activeEntry) return
+    const node = rowRefs.current[activeEntry.entry.id]
+    node?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  }, [activeIndex, entries])
+
+  const visibleMatchSet = useMemo(() => new Set(matches), [matches])
+
+  return (
+    <Card className={cn('border-gray-200 flex flex-col', className)}>
+      <CardHeader className="border-b border-gray-200 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base font-semibold text-gray-900">
+            Transcript
+          </CardTitle>
+          <Badge variant="secondary" className="text-xs">
+            {entries.length} {entries.length === 1 ? 'line' : 'lines'}
+          </Badge>
+        </div>
+        <div className="relative mt-2">
+          <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            ref={searchRef}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            onKeyDown={handleSearchKey}
+            placeholder="Search transcript… (Enter / ↑↓ to navigate)"
+            className="h-8 pl-8 pr-16 text-sm"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              aria-label="Clear search"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+          {search && matches.length > 0 && (
+            <span className="absolute right-7 top-1/2 -translate-y-1/2 text-[11px] text-gray-500">
+              {matchIndex + 1}/{matches.length}
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {entries.length === 0 ? (
+          <div className="px-4 py-12 text-center text-sm text-gray-500">
+            {videoAnchorAt
+              ? 'Transcript not available yet — usually ready a minute or two after the session ends.'
+              : 'Session timing data is not available, so the transcript cannot be synced with the video.'}
+          </div>
+        ) : (
+          <div
+            ref={containerRef}
+            onScroll={handleScroll}
+            className="max-h-[28rem] overflow-y-auto divide-y divide-gray-100"
+            role="list"
+            aria-label="Transcript synced with video"
+          >
+            {entries.map(({ entry, offsetSec }, i) => {
+              const isActive = i === activeIndex
+              const isMatch = visibleMatchSet.has(i)
+              return (
+                <div
+                  key={entry.id}
+                  ref={node => {
+                    rowRefs.current[entry.id] = node
+                  }}
+                  role="listitem"
+                  aria-current={isActive ? 'true' : undefined}
+                  className={cn(
+                    'group relative px-4 py-3 transition-colors',
+                    isActive
+                      ? 'bg-indigo-50/70 border-l-4 border-l-indigo-500 pl-3'
+                      : 'border-l-4 border-l-transparent hover:bg-gray-50',
+                    isMatch && !isActive && 'bg-yellow-50/60',
+                  )}
+                >
+                  <div className="flex items-start gap-3">
+                    <button
+                      type="button"
+                      onClick={() => onSeek(offsetSec)}
+                      className="shrink-0 rounded font-mono text-[11px] text-gray-500 hover:text-indigo-600 hover:underline"
+                      title="Jump to this moment"
+                    >
+                      {formatVideoOffset(offsetSec)}
+                    </button>
+                    <span
+                      className={cn(
+                        'shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1',
+                        speakerSwatch(entry.speaker),
+                      )}
+                    >
+                      {entry.speaker}
+                    </span>
+                    <p
+                      className={cn(
+                        'flex-1 text-sm leading-relaxed cursor-pointer',
+                        isActive ? 'text-gray-900' : 'text-gray-700',
+                      )}
+                      onClick={() => onSeek(offsetSec)}
+                    >
+                      {highlightMatch(entry.text, search.trim())}
+                    </p>
+                    {onAddCommentAt && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity h-7 px-2 text-xs"
+                        onClick={() => onAddCommentAt(offsetSec)}
+                        title="Comment on this moment"
+                      >
+                        <MessageSquarePlus className="h-3.5 w-3.5 mr-1" />
+                        Comment
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+})

--- a/src/components/sessions/transcript-pane.tsx
+++ b/src/components/sessions/transcript-pane.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   forwardRef,
 } from 'react'
-import { Search, X, MessageSquarePlus } from 'lucide-react'
+import { Search, X, MessageSquarePlus, Crosshair } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
@@ -30,6 +30,7 @@ export interface TranscriptPaneEntry {
 
 export type TranscriptPaneHandle = {
   focusSearch: () => void
+  scrollToActive: () => void
 }
 
 interface TranscriptPaneProps {
@@ -95,14 +96,7 @@ export const TranscriptPane = forwardRef<
   const [matchIndex, setMatchIndex] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
-  const lastManualScrollRef = useRef<number>(0)
   const rowRefs = useRef<Record<string, HTMLDivElement | null>>({})
-
-  useImperativeHandle(
-    ref,
-    () => ({ focusSearch: () => searchRef.current?.focus() }),
-    [],
-  )
 
   const getTimestamp = useCallback((e: TranscriptPaneEntry) => e.timestamp, [])
 
@@ -112,6 +106,29 @@ export const TranscriptPane = forwardRef<
     currentTimeSec,
     getTimestamp,
   })
+
+  // Center the active row inside the transcript's own scroll container.
+  // Container-scoped (no scrollIntoView) so the page itself never scrolls.
+  const scrollToActive = useCallback(() => {
+    const container = containerRef.current
+    if (!container || activeIndex < 0) return
+    const activeEntry = entries[activeIndex]
+    if (!activeEntry) return
+    const node = rowRefs.current[activeEntry.entry.id]
+    if (!node) return
+    const target =
+      node.offsetTop - container.clientHeight / 2 + node.clientHeight / 2
+    container.scrollTo({ top: Math.max(0, target), behavior: 'smooth' })
+  }, [activeIndex, entries])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focusSearch: () => searchRef.current?.focus(),
+      scrollToActive,
+    }),
+    [scrollToActive],
+  )
 
   const matches = useMemo(() => {
     if (!search.trim()) return [] as number[]
@@ -149,22 +166,6 @@ export const TranscriptPane = forwardRef<
     [entries, matches, matchIndex, onSeek],
   )
 
-  // Track manual scroll so we can pause auto-scroll for 3 seconds.
-  const handleScroll = useCallback(() => {
-    lastManualScrollRef.current = Date.now()
-  }, [])
-
-  // Auto-scroll to active row.
-  useEffect(() => {
-    if (activeIndex < 0) return
-    const since = Date.now() - lastManualScrollRef.current
-    if (since < 3000) return
-    const activeEntry = entries[activeIndex]
-    if (!activeEntry) return
-    const node = rowRefs.current[activeEntry.entry.id]
-    node?.scrollIntoView({ block: 'center', behavior: 'smooth' })
-  }, [activeIndex, entries])
-
   const visibleMatchSet = useMemo(() => new Set(matches), [matches])
 
   return (
@@ -174,9 +175,24 @@ export const TranscriptPane = forwardRef<
           <CardTitle className="text-base font-semibold text-gray-900">
             Transcript
           </CardTitle>
-          <Badge variant="secondary" className="text-xs">
-            {entries.length} {entries.length === 1 ? 'line' : 'lines'}
-          </Badge>
+          <div className="flex items-center gap-2">
+            {activeIndex >= 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={scrollToActive}
+                title="Scroll the transcript to where the video is"
+                className="h-7 px-2 text-xs text-indigo-600 hover:bg-indigo-50 hover:text-indigo-700"
+              >
+                <Crosshair className="h-3.5 w-3.5 mr-1" />
+                Jump to current
+              </Button>
+            )}
+            <Badge variant="secondary" className="text-xs">
+              {entries.length} {entries.length === 1 ? 'line' : 'lines'}
+            </Badge>
+          </div>
         </div>
         <div className="relative mt-2">
           <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
@@ -215,7 +231,6 @@ export const TranscriptPane = forwardRef<
         ) : (
           <div
             ref={containerRef}
-            onScroll={handleScroll}
             className="max-h-[28rem] overflow-y-auto divide-y divide-gray-100"
             role="list"
             aria-label="Transcript synced with video"

--- a/src/components/sessions/video-player.tsx
+++ b/src/components/sessions/video-player.tsx
@@ -1,180 +1,360 @@
 'use client'
 
-import React, { useState, useRef } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Video, RefreshCw, AlertCircle, Loader2, VideoOff } from 'lucide-react'
 import { cn } from '@/lib/utils'
+
+export type VideoPlayerHandle = {
+  seekTo: (seconds: number, options?: { play?: boolean }) => void
+  getCurrentTime: () => number
+  play: () => Promise<void>
+  pause: () => void
+  isPlaying: () => boolean
+  getDuration: () => number
+}
+
+export type VideoPlayerMarker = {
+  id: string
+  offsetSec: number
+  tone?: 'comment' | 'mine'
+  label?: string
+}
 
 interface VideoPlayerProps {
   videoUrl: string | null | undefined
   sessionId: string
   onRefresh: () => Promise<void>
   className?: string
+  onTimeUpdate?: (currentTimeSec: number) => void
+  onDurationChange?: (durationSec: number) => void
+  markers?: VideoPlayerMarker[]
+  onMarkerClick?: (markerId: string) => void
+  /**
+   * When true, the recording is permanently unavailable (Recall.ai's media
+   * TTL elapsed before we copied it to S3). Renders a terminal empty state
+   * with no Refresh button — clicking it would just 404 again.
+   */
+  videoUnavailable?: boolean
 }
 
-export function VideoPlayer({
-  videoUrl,
-  sessionId: _sessionId,
-  onRefresh,
-  className,
-}: VideoPlayerProps) {
-  const [error, setError] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false)
-  const videoRef = useRef<HTMLVideoElement>(null)
+const TIME_UPDATE_INTERVAL_MS = 250
 
-  const handleVideoError = () => {
-    setError(true)
-    setLoading(false)
-  }
+function formatClock(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  if (h > 0)
+    return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
 
-  const handleVideoLoad = () => {
-    setLoading(false)
-    setError(false)
-  }
+export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
+  function VideoPlayer(
+    {
+      videoUrl,
+      sessionId: _sessionId,
+      onRefresh,
+      className,
+      onTimeUpdate,
+      onDurationChange,
+      markers,
+      onMarkerClick,
+      videoUnavailable = false,
+    },
+    ref,
+  ) {
+    const [error, setError] = useState(false)
+    const [loading, setLoading] = useState(true)
+    const [refreshing, setRefreshing] = useState(false)
+    const [duration, setDuration] = useState(0)
+    const videoRef = useRef<HTMLVideoElement>(null)
+    const lastEmittedRef = useRef<number>(0)
 
-  const handleRefresh = async () => {
-    setRefreshing(true)
-    setError(false)
-    try {
-      await onRefresh()
-      // After refresh, reset loading state to show video again
-      setLoading(true)
-    } catch (err) {
-      console.error('Failed to refresh video URL:', err)
-      setError(true)
-    } finally {
-      setRefreshing(false)
-    }
-  }
-
-  // No video URL available
-  if (!videoUrl) {
-    return (
-      <Card className={cn('border-gray-200', className)}>
-        <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <Video className="h-5 w-5" />
-            Session Recording
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <VideoOff className="h-12 w-12 text-gray-300 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
-              No Recording Available
-            </h3>
-            <p className="text-gray-500 max-w-md">
-              This session does not have a video recording. Recordings are only
-              available for sessions conducted with the meeting bot.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+    useImperativeHandle(
+      ref,
+      (): VideoPlayerHandle => ({
+        seekTo: (seconds, opts) => {
+          const v = videoRef.current
+          if (!v) return
+          v.currentTime = Math.max(0, seconds)
+          if (opts?.play) {
+            v.play().catch(() => {
+              /* user gesture probably required */
+            })
+          }
+        },
+        getCurrentTime: () => videoRef.current?.currentTime ?? 0,
+        play: async () => {
+          const v = videoRef.current
+          if (v) await v.play()
+        },
+        pause: () => videoRef.current?.pause(),
+        isPlaying: () => {
+          const v = videoRef.current
+          return !!v && !v.paused && !v.ended
+        },
+        getDuration: () => videoRef.current?.duration ?? 0,
+      }),
+      [],
     )
-  }
 
-  // Error state (expired URL or other error)
-  if (error && !refreshing) {
+    const handleVideoError = useCallback(() => {
+      setError(true)
+      setLoading(false)
+    }, [])
+
+    const handleVideoLoad = useCallback(() => {
+      setLoading(false)
+      setError(false)
+    }, [])
+
+    const handleLoadedMetadata = useCallback(() => {
+      const v = videoRef.current
+      if (v && Number.isFinite(v.duration)) {
+        setDuration(v.duration)
+        onDurationChange?.(v.duration)
+      }
+    }, [onDurationChange])
+
+    const handleTimeUpdate = useCallback(() => {
+      if (!onTimeUpdate) return
+      const v = videoRef.current
+      if (!v) return
+      const now = performance.now()
+      if (now - lastEmittedRef.current < TIME_UPDATE_INTERVAL_MS) return
+      lastEmittedRef.current = now
+      onTimeUpdate(v.currentTime)
+    }, [onTimeUpdate])
+
+    const handleSeeked = useCallback(() => {
+      const v = videoRef.current
+      if (v && onTimeUpdate) onTimeUpdate(v.currentTime)
+    }, [onTimeUpdate])
+
+    const handleRefresh = useCallback(async () => {
+      setRefreshing(true)
+      setError(false)
+      try {
+        await onRefresh()
+        setLoading(true)
+      } catch (err) {
+        console.error('Failed to refresh video URL:', err)
+        setError(true)
+      } finally {
+        setRefreshing(false)
+      }
+    }, [onRefresh])
+
+    // Reset emit timer when video URL changes
+    useEffect(() => {
+      lastEmittedRef.current = 0
+    }, [videoUrl])
+
+    const visibleMarkers = useMemo(() => {
+      if (!markers || duration <= 0) return []
+      return markers
+        .filter(
+          m =>
+            Number.isFinite(m.offsetSec) &&
+            m.offsetSec >= 0 &&
+            m.offsetSec <= duration,
+        )
+        .map(m => ({
+          ...m,
+          leftPercent: Math.min(100, (m.offsetSec / duration) * 100),
+        }))
+    }, [markers, duration])
+
+    if (videoUnavailable) {
+      return (
+        <Card className={cn('border-gray-200', className)}>
+          <CardHeader className="pb-4">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Video className="h-5 w-5" />
+              Session Recording
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <VideoOff className="h-12 w-12 text-amber-500 mb-4" />
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                Recording no longer available
+              </h3>
+              <p className="text-gray-500 max-w-md">
+                This session was recorded, but the video file expired before it
+                could be archived. The transcript and analysis are still
+                available below.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )
+    }
+
+    if (!videoUrl) {
+      return (
+        <Card className={cn('border-gray-200', className)}>
+          <CardHeader className="pb-4">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Video className="h-5 w-5" />
+              Session Recording
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <VideoOff className="h-12 w-12 text-gray-300 mb-4" />
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                No Recording Available
+              </h3>
+              <p className="text-gray-500 max-w-md">
+                This session does not have a video recording. Recordings are
+                only available for sessions conducted with the meeting bot.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )
+    }
+
+    if (error && !refreshing) {
+      return (
+        <Card className={cn('border-gray-200', className)}>
+          <CardHeader className="pb-4">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Video className="h-5 w-5" />
+              Session Recording
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <AlertCircle className="h-12 w-12 text-amber-500 mb-4" />
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                Video URL Expired
+              </h3>
+              <p className="text-gray-500 mb-6 max-w-md">
+                The video link has expired. Click the button below to get a
+                fresh link.
+              </p>
+              <Button
+                onClick={handleRefresh}
+                disabled={refreshing}
+                className="bg-black hover:bg-gray-800 text-white"
+              >
+                {refreshing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Refreshing...
+                  </>
+                ) : (
+                  <>
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    Refresh Video Link
+                  </>
+                )}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )
+    }
+
     return (
       <Card className={cn('border-gray-200', className)}>
         <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <Video className="h-5 w-5" />
-            Session Recording
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <AlertCircle className="h-12 w-12 text-amber-500 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
-              Video URL Expired
-            </h3>
-            <p className="text-gray-500 mb-6 max-w-md">
-              The video link has expired. Click the button below to get a fresh
-              link.
-            </p>
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Video className="h-5 w-5" />
+              Session Recording
+            </CardTitle>
             <Button
+              variant="outline"
+              size="sm"
               onClick={handleRefresh}
               disabled={refreshing}
-              className="bg-black hover:bg-gray-800 text-white"
+              className="border-gray-300 hover:bg-gray-50"
             >
               {refreshing ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Refreshing...
-                </>
+                <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                <>
-                  <RefreshCw className="h-4 w-4 mr-2" />
-                  Refresh Video Link
-                </>
+                <RefreshCw className="h-4 w-4" />
               )}
             </Button>
           </div>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  return (
-    <Card className={cn('border-gray-200', className)}>
-      <CardHeader className="pb-4">
-        <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <Video className="h-5 w-5" />
-            Session Recording
-          </CardTitle>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleRefresh}
-            disabled={refreshing}
-            className="border-gray-300 hover:bg-gray-50"
-          >
-            {refreshing ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="relative rounded-lg overflow-hidden bg-black">
+            {loading && (
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-900 z-10">
+                <div className="flex flex-col items-center">
+                  <Loader2 className="h-8 w-8 text-white animate-spin mb-2" />
+                  <p className="text-white text-sm">Loading video...</p>
+                </div>
+              </div>
             )}
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="relative rounded-lg overflow-hidden bg-black">
-          {/* Loading overlay */}
-          {loading && (
-            <div className="absolute inset-0 flex items-center justify-center bg-gray-900 z-10">
-              <div className="flex flex-col items-center">
-                <Loader2 className="h-8 w-8 text-white animate-spin mb-2" />
-                <p className="text-white text-sm">Loading video...</p>
+
+            <video
+              ref={videoRef}
+              src={videoUrl}
+              controls
+              controlsList="nodownload"
+              className="w-full aspect-video"
+              onError={handleVideoError}
+              onLoadedData={handleVideoLoad}
+              onCanPlay={handleVideoLoad}
+              onLoadedMetadata={handleLoadedMetadata}
+              onTimeUpdate={handleTimeUpdate}
+              onSeeked={handleSeeked}
+              preload="metadata"
+            >
+              <source src={videoUrl} type="video/mp4" />
+              Your browser does not support the video tag.
+            </video>
+          </div>
+
+          {visibleMarkers.length > 0 && (
+            <div className="mt-2">
+              <div className="relative h-3 w-full rounded bg-gray-100">
+                {visibleMarkers.map(m => (
+                  <button
+                    key={m.id}
+                    type="button"
+                    onClick={() => onMarkerClick?.(m.id)}
+                    title={`${formatClock(m.offsetSec)}${m.label ? ` — ${m.label}` : ''}`}
+                    className={cn(
+                      'absolute top-1/2 -translate-x-1/2 -translate-y-1/2 h-2.5 w-2.5 rounded-full transition-transform hover:scale-150',
+                      m.tone === 'mine'
+                        ? 'bg-indigo-500 ring-1 ring-indigo-200'
+                        : 'bg-amber-500 ring-1 ring-amber-200',
+                    )}
+                    style={{ left: `${m.leftPercent}%` }}
+                  />
+                ))}
+              </div>
+              <div className="mt-1 flex items-center justify-between text-[11px] text-gray-400">
+                <span>0:00</span>
+                <span>{formatClock(duration)}</span>
               </div>
             </div>
           )}
 
-          {/* Video element */}
-          <video
-            ref={videoRef}
-            src={videoUrl}
-            controls
-            controlsList="nodownload"
-            className="w-full aspect-video"
-            onError={handleVideoError}
-            onLoadedData={handleVideoLoad}
-            onCanPlay={handleVideoLoad}
-            preload="metadata"
-          >
-            <source src={videoUrl} type="video/mp4" />
-            Your browser does not support the video tag.
-          </video>
-        </div>
-
-        <p className="text-xs text-gray-500 mt-3 text-center">
-          Video links expire periodically. If playback fails, click the refresh
-          button to get a new link.
-        </p>
-      </CardContent>
-    </Card>
-  )
-}
+          <p className="text-xs text-gray-500 mt-3 text-center">
+            Video links expire periodically. If playback fails, click the
+            refresh button to get a new link.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  },
+)

--- a/src/components/sessions/video-review-panel.tsx
+++ b/src/components/sessions/video-review-panel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { Share2, Keyboard } from 'lucide-react'
+import { Share2, Keyboard, ChevronDown, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -43,6 +43,9 @@ interface VideoReviewPanelProps {
   transcript: TranscriptPaneEntry[]
   isOwner: boolean
   onRefreshVideoUrl?: () => Promise<void>
+  /** When true, the transcript section starts collapsed and renders as a
+   *  toggleable disclosure. Used on /review where video focus matters most. */
+  transcriptCollapsedByDefault?: boolean
   className?: string
 }
 
@@ -54,6 +57,7 @@ export function VideoReviewPanel({
   transcript,
   isOwner,
   onRefreshVideoUrl,
+  transcriptCollapsedByDefault = false,
   className,
 }: VideoReviewPanelProps) {
   const { userId } = useAuth()
@@ -68,6 +72,9 @@ export function VideoReviewPanel({
   const [currentTime, setCurrentTime] = useState(0)
   const [shareOpen, setShareOpen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
+  const [transcriptOpen, setTranscriptOpen] = useState(
+    !transcriptCollapsedByDefault,
+  )
 
   const commentsQuery = useVideoComments(sessionId)
   const createCommentMut = useCreateVideoComment(sessionId)
@@ -261,7 +268,48 @@ export function VideoReviewPanel({
         <div className="hidden lg:block">{commentsPane}</div>
       </div>
 
-      <div className="hidden lg:block">{transcriptPane}</div>
+      <div className="hidden lg:block">
+        {transcriptCollapsedByDefault ? (
+          transcriptOpen ? (
+            <div className="space-y-2">
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setTranscriptOpen(false)}
+                  className="h-7 px-2 text-xs text-gray-600 hover:text-gray-900"
+                >
+                  <ChevronDown className="h-3.5 w-3.5 mr-1" />
+                  Hide transcript
+                </Button>
+              </div>
+              {transcriptPane}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setTranscriptOpen(true)}
+              className="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-left hover:bg-gray-50"
+              aria-expanded={false}
+            >
+              <div className="flex items-center gap-2">
+                <ChevronRight className="h-4 w-4 text-gray-500" />
+                <span className="text-sm font-semibold text-gray-900">
+                  Transcript
+                </span>
+                <span className="text-xs text-gray-500">
+                  {transcript.length}{' '}
+                  {transcript.length === 1 ? 'line' : 'lines'}
+                </span>
+              </div>
+              <span className="text-xs text-indigo-600">Show</span>
+            </button>
+          )
+        ) : (
+          transcriptPane
+        )}
+      </div>
 
       <div className="lg:hidden">
         <Tabs defaultValue="transcript">

--- a/src/components/sessions/video-review-panel.tsx
+++ b/src/components/sessions/video-review-panel.tsx
@@ -1,0 +1,323 @@
+'use client'
+
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { Share2, Keyboard } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useAuth } from '@/contexts/auth-context'
+import { usePermissions } from '@/contexts/permission-context'
+import {
+  VideoPlayer,
+  VideoPlayerHandle,
+  VideoPlayerMarker,
+} from './video-player'
+import {
+  TranscriptPane,
+  TranscriptPaneEntry,
+  TranscriptPaneHandle,
+} from './transcript-pane'
+import { CommentsSidebar, CommentsSidebarHandle } from './comments-sidebar'
+import { ShareSessionDialog } from './share-session-dialog'
+import { useVideoComments } from '@/hooks/queries/use-video-comments'
+import {
+  useCreateVideoComment,
+  useDeleteVideoComment,
+  useUpdateVideoComment,
+} from '@/hooks/mutations/use-video-comment-mutations'
+import { useVideoReviewShortcuts } from '@/hooks/use-video-review-shortcuts'
+import { cn } from '@/lib/utils'
+
+interface VideoReviewPanelProps {
+  sessionId: string
+  videoUrl: string | null | undefined
+  videoUnavailable?: boolean
+  /** Wall-clock time of video t=0 — typically `metadata.recording_started_at`. */
+  videoAnchorAt: string | null | undefined
+  transcript: TranscriptPaneEntry[]
+  isOwner: boolean
+  onRefreshVideoUrl?: () => Promise<void>
+  className?: string
+}
+
+export function VideoReviewPanel({
+  sessionId,
+  videoUrl,
+  videoUnavailable = false,
+  videoAnchorAt,
+  transcript,
+  isOwner,
+  onRefreshVideoUrl,
+  className,
+}: VideoReviewPanelProps) {
+  const { userId } = useAuth()
+  const permissions = usePermissions()
+  const isAdmin = permissions.isAdmin()
+
+  const playerRef = useRef<VideoPlayerHandle>(null)
+  const transcriptRef = useRef<TranscriptPaneHandle>(null)
+  const commentsRef = useRef<CommentsSidebarHandle>(null)
+  const isPlayingRef = useRef<boolean>(false)
+
+  const [currentTime, setCurrentTime] = useState(0)
+  const [shareOpen, setShareOpen] = useState(false)
+  const [helpOpen, setHelpOpen] = useState(false)
+
+  const commentsQuery = useVideoComments(sessionId)
+  const createCommentMut = useCreateVideoComment(sessionId)
+  const updateCommentMut = useUpdateVideoComment(sessionId)
+  const deleteCommentMut = useDeleteVideoComment(sessionId)
+
+  const comments = commentsQuery.data ?? []
+
+  // Replies inherit their parent's offset and don't get their own scrubber
+  // dot or J/K stop. Filter once and reuse for markers + navigation.
+  const topLevelComments = useMemo(
+    () => comments.filter(c => !c.parent_id),
+    [comments],
+  )
+  const replyCountByParent = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const c of comments) {
+      if (c.parent_id) {
+        map.set(c.parent_id, (map.get(c.parent_id) ?? 0) + 1)
+      }
+    }
+    return map
+  }, [comments])
+
+  const handleSeek = useCallback((offsetSec: number) => {
+    playerRef.current?.seekTo(offsetSec, { play: true })
+    isPlayingRef.current = true
+  }, [])
+
+  const handleAddCommentAt = useCallback((offsetSec: number) => {
+    commentsRef.current?.focusComposer(offsetSec)
+  }, [])
+
+  const markers = useMemo<VideoPlayerMarker[]>(() => {
+    return topLevelComments.map(c => {
+      const replies = replyCountByParent.get(c.id) ?? 0
+      const author = c.author_name || c.author_email || 'Coach'
+      const tail = replies > 0 ? ` (+${replies})` : ''
+      return {
+        id: c.id,
+        offsetSec: c.video_offset_seconds,
+        tone: c.author_id === userId ? 'mine' : 'comment',
+        label: `${author}: ${c.content.slice(0, 80)}${tail}`,
+      }
+    })
+  }, [topLevelComments, replyCountByParent, userId])
+
+  const handleMarkerClick = useCallback(
+    (id: string) => {
+      const c = topLevelComments.find(x => x.id === id)
+      if (c) handleSeek(c.video_offset_seconds)
+    },
+    [topLevelComments, handleSeek],
+  )
+
+  const togglePlay = useCallback(() => {
+    const p = playerRef.current
+    if (!p) return
+    if (p.isPlaying()) p.pause()
+    else void p.play()
+    isPlayingRef.current = p.isPlaying()
+  }, [])
+
+  const seekRelative = useCallback((delta: number) => {
+    const p = playerRef.current
+    if (!p) return
+    p.seekTo(Math.max(0, p.getCurrentTime() + delta))
+  }, [])
+
+  const jumpToPrevComment = useCallback(() => {
+    const t = playerRef.current?.getCurrentTime() ?? 0
+    const sorted = [...topLevelComments].sort(
+      (a, b) => a.video_offset_seconds - b.video_offset_seconds,
+    )
+    let target = sorted.filter(c => c.video_offset_seconds < t - 0.5).pop()
+    if (!target && sorted.length > 0) target = sorted[0]
+    if (target) handleSeek(target.video_offset_seconds)
+  }, [topLevelComments, handleSeek])
+
+  const jumpToNextComment = useCallback(() => {
+    const t = playerRef.current?.getCurrentTime() ?? 0
+    const sorted = [...topLevelComments].sort(
+      (a, b) => a.video_offset_seconds - b.video_offset_seconds,
+    )
+    const target = sorted.find(c => c.video_offset_seconds > t + 0.5)
+    if (target) handleSeek(target.video_offset_seconds)
+  }, [topLevelComments, handleSeek])
+
+  const hasPlayableVideo = !!videoUrl && !videoUnavailable
+
+  useVideoReviewShortcuts({
+    // Always enabled — when there's no playable video, the player ref is
+    // null so togglePlay / seekRelative / jumpTo* short-circuit harmlessly.
+    // We still want C / T / ? available on transcript-only sessions.
+    enabled: true,
+    togglePlay,
+    seekRelative,
+    jumpToPrevComment,
+    jumpToNextComment,
+    focusComposer: () => commentsRef.current?.focusComposer(),
+    focusTranscriptSearch: () => transcriptRef.current?.focusSearch(),
+    showHelp: () => setHelpOpen(true),
+  })
+
+  const playerColumn = (
+    <div className="space-y-3">
+      <VideoPlayer
+        ref={playerRef}
+        sessionId={sessionId}
+        videoUrl={videoUrl}
+        videoUnavailable={videoUnavailable}
+        onRefresh={onRefreshVideoUrl ?? (async () => undefined)}
+        onTimeUpdate={t => {
+          setCurrentTime(t)
+          isPlayingRef.current = !!playerRef.current?.isPlaying()
+        }}
+        markers={markers}
+        onMarkerClick={handleMarkerClick}
+      />
+    </div>
+  )
+
+  const transcriptPane = (
+    <TranscriptPane
+      ref={transcriptRef}
+      transcript={transcript}
+      videoAnchorAt={videoAnchorAt}
+      currentTimeSec={currentTime}
+      onSeek={handleSeek}
+      onAddCommentAt={handleAddCommentAt}
+      className="h-full"
+    />
+  )
+
+  const commentsPane = (
+    <CommentsSidebar
+      ref={commentsRef}
+      sessionId={sessionId}
+      comments={comments}
+      isLoading={commentsQuery.isLoading}
+      currentUserId={userId}
+      isAdmin={isAdmin}
+      currentTimeSec={currentTime}
+      getCurrentTime={() => playerRef.current?.getCurrentTime() ?? 0}
+      hasPlayableVideo={hasPlayableVideo}
+      onSeek={handleSeek}
+      onPause={() => playerRef.current?.pause()}
+      onResume={() => void playerRef.current?.play()}
+      isPlayingRef={isPlayingRef}
+      onCreate={data => createCommentMut.mutateAsync(data)}
+      onUpdate={(commentId, content) =>
+        updateCommentMut.mutateAsync({ commentId, content })
+      }
+      onDelete={commentId => deleteCommentMut.mutateAsync(commentId)}
+      className="h-full"
+    />
+  )
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-base font-semibold text-gray-900">
+          Session review
+        </h3>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setHelpOpen(true)}
+            title="Keyboard shortcuts"
+            className="text-gray-500 hover:text-gray-700"
+          >
+            <Keyboard className="h-4 w-4" />
+          </Button>
+          {(isOwner || isAdmin) && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShareOpen(true)}
+              className="border-indigo-200 text-indigo-700 hover:bg-indigo-50"
+            >
+              <Share2 className="h-4 w-4 mr-1.5" />
+              Share
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="space-y-3">{playerColumn}</div>
+        <div className="hidden lg:block">{commentsPane}</div>
+      </div>
+
+      <div className="hidden lg:block">{transcriptPane}</div>
+
+      <div className="lg:hidden">
+        <Tabs defaultValue="transcript">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="transcript">Transcript</TabsTrigger>
+            <TabsTrigger value="comments">
+              Comments {comments.length > 0 ? `(${comments.length})` : ''}
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="transcript" className="mt-3">
+            {transcriptPane}
+          </TabsContent>
+          <TabsContent value="comments" className="mt-3">
+            {commentsPane}
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      {(isOwner || isAdmin) && (
+        <ShareSessionDialog
+          sessionId={sessionId}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
+
+      <Dialog open={helpOpen} onOpenChange={setHelpOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+            <DialogDescription>
+              Faster navigation while reviewing.
+            </DialogDescription>
+          </DialogHeader>
+          <ul className="space-y-1 text-sm">
+            <ShortcutRow keys="Space" label="Play / pause" />
+            <ShortcutRow keys="← / →" label="Seek ±5 seconds" />
+            <ShortcutRow keys="Shift + ← / →" label="Seek ±15 seconds" />
+            <ShortcutRow keys="J / K" label="Previous / next comment" />
+            <ShortcutRow keys="C" label="Comment at current moment" />
+            <ShortcutRow keys="T" label="Search the transcript" />
+            <ShortcutRow keys="?" label="Show this help" />
+          </ul>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function ShortcutRow({ keys, label }: { keys: string; label: string }) {
+  return (
+    <li className="flex items-center justify-between gap-3 py-1">
+      <span className="text-gray-700">{label}</span>
+      <kbd className="rounded bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-700">
+        {keys}
+      </kbd>
+    </li>
+  )
+}

--- a/src/components/ui/session-row.tsx
+++ b/src/components/ui/session-row.tsx
@@ -1,0 +1,271 @@
+import { ReactNode } from 'react'
+import { ChevronRight, Clock, Lock } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * SessionRow — list-first session primitive.
+ *
+ * The audit's Before/After bet: same compact row template on dashboard,
+ * /sessions, and client detail. ~76px tall vs. ~220px for the legacy
+ * SessionCard. Status uses paired color + dot so it survives grayscale and
+ * is accessible to color-blind users.
+ *
+ * Presentational only — consumers normalize their data shape into these props.
+ */
+
+type SessionStatus =
+  | 'live'
+  | 'completed'
+  | 'error'
+  | 'processing'
+  | 'scheduled'
+  | 'idle'
+
+const STATUS_STYLES: Record<
+  SessionStatus,
+  { dot: string; pillClass: string; defaultLabel: string; ping?: boolean }
+> = {
+  live: {
+    dot: 'bg-forest',
+    pillClass: 'bg-forest-bg text-forest border-forest/20',
+    defaultLabel: 'Live',
+    ping: true,
+  },
+  completed: {
+    dot: 'bg-ink-3',
+    pillClass: 'bg-surface-2 text-ink-2 border-line',
+    defaultLabel: 'Completed',
+  },
+  error: {
+    dot: 'bg-vermillion',
+    pillClass: 'bg-vermillion-bg text-vermillion border-vermillion/20',
+    defaultLabel: 'Error',
+  },
+  processing: {
+    dot: 'bg-amber-token',
+    pillClass: 'bg-amber-token-bg text-amber-token border-amber-token/20',
+    defaultLabel: 'Processing',
+  },
+  scheduled: {
+    dot: 'bg-indigo',
+    pillClass: 'bg-indigo-bg text-indigo border-indigo/20',
+    defaultLabel: 'Scheduled',
+  },
+  idle: {
+    dot: 'bg-ink-4',
+    pillClass: 'bg-surface-2 text-ink-3 border-line',
+    defaultLabel: 'Idle',
+  },
+}
+
+interface SessionRowProps {
+  /** Primary line, e.g. "Maria K. · Q2 strategy review". */
+  title: string
+  /** Mono meta beside the title — usually source: "Zoom" / "Google Meet" / "Teams". */
+  source?: string
+  /** Single-line summary. Will be truncated. Hidden when `restricted` is true. */
+  summary?: string
+  /** Formatted date, e.g. "Apr 22". Rendered in mono. */
+  date?: string
+  /** Relative time, e.g. "8 days ago". Plain text. */
+  relativeTime?: string
+  /** Duration, e.g. "52m". Rendered with a clock icon. */
+  duration?: string
+  /** Avatar — either initials or an image. */
+  avatar?: { initials?: string; src?: string }
+  /** Status drives both the dot color on the avatar and the right-side pill. */
+  status?: SessionStatus
+  /** Override the pill label. Defaults to status's title-case label. */
+  statusLabel?: string
+  /** Inline badges (e.g. group session). Rendered next to the title. */
+  badges?: ReactNode
+  /** Replace the summary line with a "Content restricted" notice (viewer state). */
+  restricted?: boolean
+  restrictedLabel?: string
+  /**
+   * Replace the summary with a live-status line (e.g. "Recording in progress")
+   * when the session is live and has no summary yet. Rendered in forest.
+   */
+  liveLabel?: string
+  /**
+   * Replace the summary with a placeholder when completed but processing.
+   * Rendered in ink-3 italic.
+   */
+  pendingLabel?: string
+  /** Right-aligned actions. Rendered before the chevron. */
+  actions?: ReactNode
+  onClick?: () => void
+  className?: string
+}
+
+export function SessionRow({
+  title,
+  source,
+  summary,
+  date,
+  relativeTime,
+  duration,
+  avatar,
+  status = 'idle',
+  statusLabel,
+  badges,
+  restricted,
+  restrictedLabel = 'Content restricted',
+  liveLabel,
+  pendingLabel,
+  actions,
+  onClick,
+  className,
+}: SessionRowProps) {
+  const styles = STATUS_STYLES[status]
+  const isLive = status === 'live'
+  const interactive = typeof onClick === 'function'
+
+  const showSummary = !restricted && !!summary
+  const showLive = !restricted && !summary && isLive && liveLabel
+  const showPending = !restricted && !summary && !isLive && pendingLabel
+
+  return (
+    <div
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={
+        interactive
+          ? e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onClick?.()
+              }
+            }
+          : undefined
+      }
+      className={cn(
+        'group flex items-start gap-4 px-5 py-4 border-b border-line-2 last:border-b-0 transition-colors',
+        interactive && 'cursor-pointer hover:bg-surface-2/50',
+        className,
+      )}
+    >
+      {/* Avatar with status dot */}
+      <div className="relative shrink-0">
+        <div className="w-10 h-10 rounded-full bg-surface-2 flex items-center justify-center overflow-hidden">
+          {avatar?.src ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={avatar.src}
+              alt=""
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <span className="font-mono text-[11px] font-semibold text-ink-2">
+              {avatar?.initials || '··'}
+            </span>
+          )}
+        </div>
+        <span
+          className={cn(
+            'absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-paper',
+            styles.dot,
+          )}
+        />
+        {styles.ping && (
+          <span
+            className={cn(
+              'absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full animate-ping opacity-60',
+              styles.dot,
+            )}
+          />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <h4 className="font-sans text-[13px] font-semibold text-ink truncate">
+            {title}
+          </h4>
+          {source && (
+            <span className="font-mono text-[11px] text-ink-3">{source}</span>
+          )}
+          {badges}
+        </div>
+
+        {(date || relativeTime || duration) && (
+          <div className="flex items-center gap-2 text-[11px] text-ink-3 mt-1">
+            {date && <span className="font-mono tnum">{date}</span>}
+            {date && (relativeTime || duration) && (
+              <span className="text-ink-4">·</span>
+            )}
+            {relativeTime && <span>{relativeTime}</span>}
+            {(date || relativeTime) && duration && (
+              <span className="text-ink-4">·</span>
+            )}
+            {duration && (
+              <span className="inline-flex items-center gap-1 tnum">
+                <Clock className="h-3 w-3" strokeWidth={1.75} />
+                {duration}
+              </span>
+            )}
+          </div>
+        )}
+
+        {showSummary && (
+          <p className="text-[12px] text-ink-2 mt-1 truncate">{summary}</p>
+        )}
+        {restricted && (
+          <p className="text-[12px] text-ink-3 mt-1 inline-flex items-center gap-1">
+            <Lock className="h-3 w-3" strokeWidth={1.75} />
+            {restrictedLabel}
+          </p>
+        )}
+        {showLive && (
+          <p className="text-[12px] text-forest mt-1 font-medium">
+            {liveLabel}
+          </p>
+        )}
+        {showPending && (
+          <p className="text-[12px] text-ink-3 italic mt-1">{pendingLabel}</p>
+        )}
+      </div>
+
+      {/* Right side: status pill + actions + chevron */}
+      <div className="flex items-center gap-2 shrink-0 self-center">
+        {status !== 'idle' && (
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 h-6 px-2 rounded-sm border text-[11px] font-medium font-sans',
+              styles.pillClass,
+            )}
+          >
+            <span
+              className={cn('w-1.5 h-1.5 rounded-full', styles.dot)}
+              aria-hidden
+            />
+            {statusLabel ?? styles.defaultLabel}
+          </span>
+        )}
+        {actions}
+        {interactive && (
+          <ChevronRight
+            className="h-4 w-4 text-ink-4 opacity-0 group-hover:opacity-100 transition-opacity"
+            strokeWidth={1.75}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function SessionRowSkeleton() {
+  return (
+    <div className="flex items-start gap-4 px-5 py-4 border-b border-line-2 last:border-b-0">
+      <div className="w-10 h-10 rounded-full bg-surface-2 animate-pulse shrink-0" />
+      <div className="flex-1 space-y-2">
+        <div className="h-3.5 bg-surface-2 rounded-sm w-1/3 animate-pulse" />
+        <div className="h-3 bg-surface-2 rounded-sm w-1/2 animate-pulse" />
+      </div>
+    </div>
+  )
+}
+
+export type { SessionRowProps, SessionStatus }

--- a/src/hooks/mutations/use-coach-evaluation-mutations.ts
+++ b/src/hooks/mutations/use-coach-evaluation-mutations.ts
@@ -1,0 +1,95 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import {
+  CoachEvaluation,
+  CoachEvaluationCreatePayload,
+  CoachEvaluationUpdatePayload,
+  CoachEvaluationsService,
+} from '@/services/coach-evaluations-service'
+import { queryKeys } from '@/lib/query-client'
+
+export function useCreateCoachEvaluation(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.coachEvaluations.list(sessionId)
+
+  return useMutation({
+    mutationFn: (payload: CoachEvaluationCreatePayload) =>
+      CoachEvaluationsService.create(sessionId, payload),
+
+    onSuccess: evaluation => {
+      queryClient.setQueryData<CoachEvaluation[]>(key, old => {
+        const others = (old ?? []).filter(e => e.id !== evaluation.id)
+        return [evaluation, ...others]
+      })
+      toast.success('Evaluation submitted')
+    },
+
+    onError: err => {
+      const message = err instanceof Error ? err.message : 'Please try again'
+      toast.error('Failed to submit evaluation', { description: message })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}
+
+export function useUpdateCoachEvaluation(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.coachEvaluations.list(sessionId)
+
+  return useMutation({
+    mutationFn: ({
+      evaluationId,
+      payload,
+    }: {
+      evaluationId: string
+      payload: CoachEvaluationUpdatePayload
+    }) => CoachEvaluationsService.update(sessionId, evaluationId, payload),
+
+    onSuccess: evaluation => {
+      queryClient.setQueryData<CoachEvaluation[]>(key, old =>
+        (old ?? []).map(e => (e.id === evaluation.id ? evaluation : e)),
+      )
+      toast.success('Evaluation updated')
+    },
+
+    onError: err => {
+      toast.error('Failed to update evaluation', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}
+
+export function useDeleteCoachEvaluation(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.coachEvaluations.list(sessionId)
+
+  return useMutation({
+    mutationFn: (evaluationId: string) =>
+      CoachEvaluationsService.delete(sessionId, evaluationId),
+
+    onSuccess: (_data, evaluationId) => {
+      queryClient.setQueryData<CoachEvaluation[]>(key, old =>
+        (old ?? []).filter(e => e.id !== evaluationId),
+      )
+      toast.success('Evaluation deleted')
+    },
+
+    onError: err => {
+      toast.error('Failed to delete evaluation', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}

--- a/src/hooks/mutations/use-session-share-mutations.ts
+++ b/src/hooks/mutations/use-session-share-mutations.ts
@@ -1,0 +1,87 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { SessionSharesService } from '@/services/session-shares-service'
+import { queryKeys } from '@/lib/query-client'
+
+export function useShareSession(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.sessionShares.list(sessionId)
+
+  return useMutation({
+    mutationFn: (userIds: string[]) =>
+      SessionSharesService.add(sessionId, userIds),
+    onSuccess: data => {
+      queryClient.setQueryData(key, data)
+      toast.success(
+        data.shares.length === 1
+          ? 'Shared with 1 coach'
+          : `Shared with ${data.shares.length} coaches`,
+      )
+    },
+    onError: err => {
+      toast.error('Could not share session', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+  })
+}
+
+export function useRevokeShare(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.sessionShares.list(sessionId)
+
+  return useMutation({
+    mutationFn: (shareId: string) =>
+      SessionSharesService.revoke(sessionId, shareId),
+    onMutate: async shareId => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<any>(key)
+      queryClient.setQueryData<any>(key, (old: any) => {
+        if (!old) return old
+        return {
+          ...old,
+          shares: (old.shares ?? []).filter((s: any) => s.id !== shareId),
+        }
+      })
+      return { previous }
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous)
+      toast.error('Could not revoke share', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}
+
+export function useToggleShareWithAll(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.sessionShares.list(sessionId)
+
+  return useMutation({
+    mutationFn: (shareWithAll: boolean) =>
+      SessionSharesService.toggleShareWithAll(sessionId, shareWithAll),
+    onMutate: async shareWithAll => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<any>(key)
+      queryClient.setQueryData<any>(key, (old: any) => {
+        if (!old)
+          return { is_shared_with_all_coaches: shareWithAll, shares: [] }
+        return { ...old, is_shared_with_all_coaches: shareWithAll }
+      })
+      return { previous }
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous)
+      toast.error('Could not change sharing setting', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+    onSuccess: data => {
+      queryClient.setQueryData(key, data)
+    },
+  })
+}

--- a/src/hooks/mutations/use-video-comment-mutations.ts
+++ b/src/hooks/mutations/use-video-comment-mutations.ts
@@ -1,0 +1,123 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import {
+  VideoComment,
+  VideoCommentsService,
+} from '@/services/video-comments-service'
+import { queryKeys } from '@/lib/query-client'
+
+export function useCreateVideoComment(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.videoComments.list(sessionId)
+
+  return useMutation({
+    mutationFn: (data: {
+      content: string
+      video_offset_seconds: number
+      parent_id?: string | null
+    }) => VideoCommentsService.create(sessionId, data),
+
+    onMutate: async data => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<VideoComment[]>(key)
+      const optimistic: VideoComment = {
+        id: `temp-${Date.now()}`,
+        session_id: sessionId,
+        author_id: 'me',
+        author_name: 'You',
+        author_email: null,
+        content: data.content,
+        video_offset_seconds: data.video_offset_seconds,
+        parent_id: data.parent_id ?? null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+      queryClient.setQueryData<VideoComment[]>(key, old => {
+        const next = [...(old ?? []), optimistic]
+        next.sort((a, b) => a.video_offset_seconds - b.video_offset_seconds)
+        return next
+      })
+      return { previous }
+    },
+
+    onError: (err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous)
+      toast.error('Failed to add comment', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}
+
+export function useUpdateVideoComment(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.videoComments.list(sessionId)
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: string
+      content: string
+    }) => VideoCommentsService.update(sessionId, commentId, { content }),
+
+    onMutate: async ({ commentId, content }) => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<VideoComment[]>(key)
+      queryClient.setQueryData<VideoComment[]>(key, old =>
+        (old ?? []).map(c =>
+          c.id === commentId
+            ? { ...c, content, updated_at: new Date().toISOString() }
+            : c,
+        ),
+      )
+      return { previous }
+    },
+
+    onError: (err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous)
+      toast.error('Failed to update comment', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}
+
+export function useDeleteVideoComment(sessionId: string) {
+  const queryClient = useQueryClient()
+  const key = queryKeys.videoComments.list(sessionId)
+
+  return useMutation({
+    mutationFn: (commentId: string) =>
+      VideoCommentsService.delete(sessionId, commentId),
+
+    onMutate: async commentId => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<VideoComment[]>(key)
+      queryClient.setQueryData<VideoComment[]>(key, old =>
+        (old ?? []).filter(c => c.id !== commentId),
+      )
+      return { previous }
+    },
+
+    onError: (err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous)
+      toast.error('Failed to delete comment', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}

--- a/src/hooks/queries/use-coach-evaluations.ts
+++ b/src/hooks/queries/use-coach-evaluations.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  CoachEvaluationsService,
+  CoachEvaluation,
+} from '@/services/coach-evaluations-service'
+import { queryKeys } from '@/lib/query-client'
+
+/**
+ * List evaluations for a session. Owner/admin get all rows; non-owner
+ * reviewers get only their own (server-side filter).
+ */
+export function useCoachEvaluations(
+  sessionId: string | undefined,
+  options?: { enabled?: boolean },
+) {
+  return useQuery<CoachEvaluation[]>({
+    queryKey: queryKeys.coachEvaluations.list(sessionId ?? ''),
+    queryFn: () => CoachEvaluationsService.list(sessionId!),
+    enabled: !!sessionId && (options?.enabled ?? true),
+    staleTime: 30 * 1000,
+  })
+}

--- a/src/hooks/queries/use-session-review.ts
+++ b/src/hooks/queries/use-session-review.ts
@@ -1,0 +1,30 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { SessionService } from '@/services/session-service'
+import { queryKeys } from '@/lib/query-client'
+
+export type SessionReviewResponse = Awaited<
+  ReturnType<typeof SessionService.getSessionReview>
+>
+
+/**
+ * Fetch the narrow "review" payload for a session — video URL + anchor +
+ * transcript + a few flags. No summary, notes, or AI analysis.
+ *
+ * Backed by `GET /sessions/{id}/review`, gated via `can_view_session()`,
+ * so accessible to owner/admin/share recipients/share-with-all-coaches.
+ */
+export function useSessionReview(
+  sessionId: string | undefined,
+  options?: Omit<
+    UseQueryOptions<SessionReviewResponse>,
+    'queryKey' | 'queryFn' | 'enabled'
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.sessions.review(sessionId!),
+    queryFn: () => SessionService.getSessionReview(sessionId!),
+    enabled: !!sessionId,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/hooks/queries/use-session-shares.ts
+++ b/src/hooks/queries/use-session-shares.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { SessionSharesService } from '@/services/session-shares-service'
+import { queryKeys } from '@/lib/query-client'
+
+export function useSessionShares(
+  sessionId: string | null | undefined,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: sessionId
+      ? queryKeys.sessionShares.list(sessionId)
+      : ['session-shares', 'disabled'],
+    queryFn: () => SessionSharesService.list(sessionId as string),
+    enabled: !!sessionId && (options?.enabled ?? true),
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useCoachSearch(query: string, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.coachSearch.query(query),
+    queryFn: () => SessionSharesService.searchCoaches(query),
+    enabled,
+    staleTime: 30 * 1000,
+  })
+}

--- a/src/hooks/queries/use-sessions.ts
+++ b/src/hooks/queries/use-sessions.ts
@@ -33,6 +33,7 @@ export function useSessions(
     client_id?: string
     coach_id?: string
     status?: string
+    scope?: 'mine' | 'shared' | 'all'
   },
   options?: Omit<UseQueryOptions<SessionListResponse>, 'queryKey' | 'queryFn'>,
 ) {

--- a/src/hooks/queries/use-video-comments.ts
+++ b/src/hooks/queries/use-video-comments.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { VideoCommentsService } from '@/services/video-comments-service'
+import { queryKeys } from '@/lib/query-client'
+
+export function useVideoComments(sessionId: string | null | undefined) {
+  return useQuery({
+    queryKey: sessionId
+      ? queryKeys.videoComments.list(sessionId)
+      : ['video-comments', 'disabled'],
+    queryFn: () => VideoCommentsService.list(sessionId as string),
+    enabled: !!sessionId,
+    staleTime: 30 * 1000,
+  })
+}

--- a/src/hooks/use-meeting-history.ts
+++ b/src/hooks/use-meeting-history.ts
@@ -43,6 +43,7 @@ interface MeetingHistoryResponse {
 interface MeetingHistoryFilters {
   client_id?: string | null
   coach_id?: string | null
+  status?: string | null
   page?: number
 }
 
@@ -71,6 +72,7 @@ export function useMeetingHistory(
     per_page: limit,
     ...(filters?.client_id && { client_id: filters.client_id }),
     ...(filters?.coach_id && { coach_id: filters.coach_id }),
+    ...(filters?.status && { status: filters.status }),
   })
 
   // Transform sessions data to expected format

--- a/src/hooks/use-synced-transcript.ts
+++ b/src/hooks/use-synced-transcript.ts
@@ -1,0 +1,120 @@
+'use client'
+
+import { useMemo } from 'react'
+
+export interface SyncedTranscriptEntry<T> {
+  entry: T
+  offsetSec: number
+}
+
+/**
+ * Parse an ISO-ish timestamp, treating tz-naive strings as UTC.
+ *
+ * Backend serializes `transcripts.timestamp` from a naive UTC `DateTime`
+ * column via `.isoformat()`, which omits the offset. ECMAScript parses that
+ * as local time, while wall-clock fields like `recording_started_at` arrive
+ * with `+00:00`. Mixing the two produces an offset equal to the user's UTC
+ * offset, so a transcript a few seconds into the call ends up with a large
+ * negative offset that gets clamped to 0.
+ */
+function parseAsUtc(value: string): number {
+  if (!value) return Number.NaN
+  // Already has a timezone marker (Z or ±HH:MM).
+  if (/Z$|[+-]\d\d:?\d\d$/.test(value)) return Date.parse(value)
+  // Pure date (no time component) — leave to default parsing rules.
+  if (!value.includes('T')) return Date.parse(value)
+  // Tz-naive datetime: pin to UTC.
+  return Date.parse(value + 'Z')
+}
+
+interface UseSyncedTranscriptResult<T> {
+  entries: SyncedTranscriptEntry<T>[]
+  activeIndex: number
+}
+
+interface UseSyncedTranscriptOptions<T> {
+  transcript: T[] | null | undefined
+  /**
+   * Wall-clock time corresponding to t=0 of the video (i.e. when recording
+   * actually started). Prefer `session_metadata.recording_started_at` over
+   * `session.started_at` — the latter is the session row's creation time and
+   * can precede the actual recording by 60-90s, which makes the transcript
+   * appear to lag behind the video.
+   */
+  videoAnchorAt: string | null | undefined
+  currentTimeSec: number
+  getTimestamp: (entry: T) => string | null | undefined
+}
+
+/**
+ * Pre-computes a video offset (in seconds) for each transcript entry by
+ * subtracting the video anchor, then returns the index of the entry that
+ * should be highlighted at `currentTimeSec` (the latest entry whose offset
+ * is <= currentTimeSec). Uses binary search.
+ */
+export function useSyncedTranscript<T>({
+  transcript,
+  videoAnchorAt,
+  currentTimeSec,
+  getTimestamp,
+}: UseSyncedTranscriptOptions<T>): UseSyncedTranscriptResult<T> {
+  const entries = useMemo<SyncedTranscriptEntry<T>[]>(() => {
+    if (!transcript || transcript.length === 0 || !videoAnchorAt) return []
+    const startMs = parseAsUtc(videoAnchorAt)
+    if (Number.isNaN(startMs)) return []
+
+    // Allow a small negative tolerance for transcripts whose timestamps fire
+    // a fraction of a second before the recording marker due to clock skew /
+    // rounding. Anything earlier than that is genuine pre-recording capture
+    // and is dropped — those segments aren't in the video file, so showing
+    // them with a clamped 0:00 offset would make the transcript appear ahead
+    // of the video.
+    const PRE_ANCHOR_TOLERANCE_SEC = 1.5
+
+    const computed: SyncedTranscriptEntry<T>[] = []
+    for (const entry of transcript) {
+      const ts = getTimestamp(entry)
+      if (!ts) continue
+      const tsMs = parseAsUtc(ts)
+      if (Number.isNaN(tsMs)) continue
+      const rawOffsetSec = (tsMs - startMs) / 1000
+      if (rawOffsetSec < -PRE_ANCHOR_TOLERANCE_SEC) continue
+      const offsetSec = Math.max(0, rawOffsetSec)
+      computed.push({ entry, offsetSec })
+    }
+    computed.sort((a, b) => a.offsetSec - b.offsetSec)
+    return computed
+  }, [transcript, videoAnchorAt, getTimestamp])
+
+  const activeIndex = useMemo(() => {
+    if (entries.length === 0) return -1
+    if (currentTimeSec < entries[0].offsetSec) return -1
+
+    let lo = 0
+    let hi = entries.length - 1
+    let answer = -1
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1
+      if (entries[mid].offsetSec <= currentTimeSec) {
+        answer = mid
+        lo = mid + 1
+      } else {
+        hi = mid - 1
+      }
+    }
+    return answer
+  }, [entries, currentTimeSec])
+
+  return { entries, activeIndex }
+}
+
+export function formatVideoOffset(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  if (h > 0)
+    return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+  return `${m}:${s.toString().padStart(2, '0')}`
+}

--- a/src/hooks/use-video-review-shortcuts.ts
+++ b/src/hooks/use-video-review-shortcuts.ts
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface ShortcutHandlers {
+  togglePlay: () => void
+  seekRelative: (deltaSec: number) => void
+  jumpToPrevComment: () => void
+  jumpToNextComment: () => void
+  focusComposer: () => void
+  focusTranscriptSearch: () => void
+  showHelp: () => void
+  enabled?: boolean
+}
+
+function isInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
+/**
+ * Global keyboard shortcuts for the video review surface.
+ * Skips firing when an input/textarea is focused, so typing in the
+ * comment composer or transcript search isn't disrupted.
+ *
+ * Bindings:
+ *   Space         play/pause
+ *   ← / →         seek -5s / +5s
+ *   Shift+←/→     seek -15s / +15s
+ *   J / K         prev / next comment
+ *   C             focus comment composer
+ *   T             focus transcript search
+ *   ?             show shortcuts help
+ */
+export function useVideoReviewShortcuts({
+  togglePlay,
+  seekRelative,
+  jumpToPrevComment,
+  jumpToNextComment,
+  focusComposer,
+  focusTranscriptSearch,
+  showHelp,
+  enabled = true,
+}: ShortcutHandlers) {
+  useEffect(() => {
+    if (!enabled) return
+    const handler = (e: KeyboardEvent) => {
+      if (isInputTarget(e.target)) return
+      // Allow combos with cmd/ctrl/alt to pass through.
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+
+      switch (e.key) {
+        case ' ':
+        case 'Spacebar':
+          e.preventDefault()
+          togglePlay()
+          break
+        case 'ArrowLeft':
+          e.preventDefault()
+          seekRelative(e.shiftKey ? -15 : -5)
+          break
+        case 'ArrowRight':
+          e.preventDefault()
+          seekRelative(e.shiftKey ? 15 : 5)
+          break
+        case 'j':
+        case 'J':
+          e.preventDefault()
+          jumpToPrevComment()
+          break
+        case 'k':
+        case 'K':
+          e.preventDefault()
+          jumpToNextComment()
+          break
+        case 'c':
+        case 'C':
+          e.preventDefault()
+          focusComposer()
+          break
+        case 't':
+        case 'T':
+          e.preventDefault()
+          focusTranscriptSearch()
+          break
+        case '?':
+          e.preventDefault()
+          showHelp()
+          break
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [
+    enabled,
+    togglePlay,
+    seekRelative,
+    jumpToPrevComment,
+    jumpToNextComment,
+    focusComposer,
+    focusTranscriptSearch,
+    showHelp,
+  ])
+}

--- a/src/lib/coach-evaluation-questions.ts
+++ b/src/lib/coach-evaluation-questions.ts
@@ -1,0 +1,126 @@
+export interface EvaluationQuestion {
+  id: string
+  text: string
+}
+
+export const EVALUATION_QUESTIONS: ReadonlyArray<EvaluationQuestion> = [
+  {
+    id: 'q1',
+    text: 'The coach invites the client towards a clear, thrilling, measurable, and potentially transformative vision.',
+  },
+  {
+    id: 'q2',
+    text: 'The coach coaches in a way that max value for the call is clear and the client reports max value being created towards the end of the call.',
+  },
+  {
+    id: 'q3',
+    text: 'The coach expands what the client believes is possible.',
+  },
+  {
+    id: 'q4',
+    text: 'The coach invites client to make commitments not only to keep but to grow and holds space to test commitments before the client commits to them.',
+  },
+  {
+    id: 'q5',
+    text: 'The coach’s key tools are powerful questions and silence.',
+  },
+  {
+    id: 'q6',
+    text: 'The coach demonstrates all three levels of listening, including what the client is saying, noticing facial expressions, body language, and tests their intuition when they have notices.',
+  },
+  {
+    id: 'q7',
+    text: 'The coach invites the client into ownership, and does not enroll in consulting or solving for the client.',
+  },
+  {
+    id: 'q8',
+    text: 'The coach guides the conversation to explore new ways of being to accomplish their stated max value.',
+  },
+  {
+    id: 'q9',
+    text: 'The coach strategically disrupts in ways few other people would in the client’s life. Whatever the response, the coach doesn’t "bail out" but advocates for the client to choose to be resourceful.',
+  },
+  {
+    id: 'q10',
+    text: 'The coach demonstrates ability to intentionally play diverse energies to draw out client’s full participation.',
+  },
+]
+
+export type ScoreValue = number | null
+
+export interface ScoreOption {
+  value: ScoreValue
+  label: string
+  // Tailwind classes for background and text when selected/unselected
+  selectedClass: string
+  unselectedClass: string
+}
+
+export const SCORE_OPTIONS: ReadonlyArray<ScoreOption> = [
+  {
+    value: null,
+    label: 'Not Observed',
+    selectedClass: 'bg-gray-300 text-gray-900 ring-2 ring-gray-500',
+    unselectedClass: 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+  },
+  {
+    value: 1,
+    label: '1',
+    selectedClass: 'bg-pink-300 text-pink-950 ring-2 ring-pink-600',
+    unselectedClass: 'bg-pink-100 text-pink-700 hover:bg-pink-200',
+  },
+  {
+    value: 2,
+    label: '2',
+    selectedClass: 'bg-orange-300 text-orange-950 ring-2 ring-orange-600',
+    unselectedClass: 'bg-orange-100 text-orange-700 hover:bg-orange-200',
+  },
+  {
+    value: 3,
+    label: '3',
+    selectedClass: 'bg-yellow-300 text-yellow-950 ring-2 ring-yellow-600',
+    unselectedClass: 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200',
+  },
+  {
+    value: 4,
+    label: '4',
+    selectedClass: 'bg-green-300 text-green-950 ring-2 ring-green-600',
+    unselectedClass: 'bg-green-100 text-green-700 hover:bg-green-200',
+  },
+]
+
+export function scoreLabel(value: ScoreValue | undefined): string {
+  if (value === null) return 'Not Observed'
+  if (typeof value === 'number') return String(value)
+  return '—'
+}
+
+export function scoreChipClass(value: ScoreValue | undefined): string {
+  switch (value) {
+    case null:
+      return 'bg-gray-200 text-gray-700'
+    case 1:
+      return 'bg-pink-200 text-pink-800'
+    case 2:
+      return 'bg-orange-200 text-orange-800'
+    case 3:
+      return 'bg-yellow-200 text-yellow-800'
+    case 4:
+      return 'bg-green-200 text-green-800'
+    default:
+      return 'bg-gray-100 text-gray-500'
+  }
+}
+
+export function averageScore(
+  evaluations: ReadonlyArray<{ scores: Record<string, number | null> }>,
+): number | null {
+  const numeric: number[] = []
+  for (const e of evaluations) {
+    for (const v of Object.values(e.scores)) {
+      if (typeof v === 'number') numeric.push(v)
+    }
+  }
+  if (numeric.length === 0) return null
+  return numeric.reduce((a, b) => a + b, 0) / numeric.length
+}

--- a/src/lib/presigned-url.ts
+++ b/src/lib/presigned-url.ts
@@ -1,0 +1,53 @@
+/**
+ * Detect whether an AWS-style presigned URL is at or past expiry.
+ *
+ * Handles both common shapes:
+ *  - SigV4 (boto3 default): `X-Amz-Date=YYYYMMDDTHHMMSSZ` + `X-Amz-Expires=<seconds>`
+ *  - SigV2 / classic:       `Expires=<unix-epoch-seconds>`
+ *
+ * `bufferSec` is grace before actual expiry — refresh slightly early to avoid
+ * a race where the player tries to fetch an about-to-expire URL.
+ *
+ * Returns `false` for URLs we can't parse, so callers don't refresh URLs that
+ * weren't presigned to begin with (e.g. plain public URLs).
+ */
+export function isPresignedUrlExpired(
+  url: string | null | undefined,
+  bufferSec = 60,
+): boolean {
+  if (!url) return false
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  const params = parsed.searchParams
+  const nowMs = Date.now()
+  const horizonMs = nowMs + bufferSec * 1000
+
+  // SigV4
+  const amzDate = params.get('X-Amz-Date')
+  const amzExpires = params.get('X-Amz-Expires')
+  if (amzDate && amzExpires) {
+    const m = amzDate.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/)
+    if (!m) return true
+    const [, y, mo, d, h, mi, s] = m
+    const startedMs = Date.parse(`${y}-${mo}-${d}T${h}:${mi}:${s}Z`)
+    if (Number.isNaN(startedMs)) return true
+    const expirySec = parseInt(amzExpires, 10)
+    if (!Number.isFinite(expirySec)) return true
+    return horizonMs >= startedMs + expirySec * 1000
+  }
+
+  // SigV2 / classic
+  const expires = params.get('Expires')
+  if (expires) {
+    const epoch = parseInt(expires, 10)
+    if (!Number.isFinite(epoch)) return true
+    return horizonMs >= epoch * 1000
+  }
+
+  // Not a recognizable presigned URL — leave it alone.
+  return false
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -74,6 +74,8 @@ export const queryKeys = {
       [...queryKeys.sessions.detail(id), 'analysis'] as const,
     transcript: (id: string) =>
       [...queryKeys.sessions.detail(id), 'transcript'] as const,
+    review: (id: string) =>
+      [...queryKeys.sessions.detail(id), 'review'] as const,
     notes: (id: string, clientId?: string) =>
       [
         ...queryKeys.sessions.detail(id),
@@ -117,6 +119,26 @@ export const queryKeys = {
     list: (filters?: Record<string, any>) =>
       [...queryKeys.sprints.lists(), { filters }] as const,
     detail: (id: string) => [...queryKeys.sprints.all, id] as const,
+  },
+
+  // Video comment keys
+  videoComments: {
+    all: ['video-comments'] as const,
+    list: (sessionId: string) =>
+      [...queryKeys.videoComments.all, sessionId] as const,
+  },
+
+  // Session share keys
+  sessionShares: {
+    all: ['session-shares'] as const,
+    list: (sessionId: string) =>
+      [...queryKeys.sessionShares.all, sessionId] as const,
+  },
+
+  // Coach typeahead search
+  coachSearch: {
+    all: ['coach-search'] as const,
+    query: (q: string) => [...queryKeys.coachSearch.all, q] as const,
   },
 
   // Persona keys

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -135,6 +135,13 @@ export const queryKeys = {
       [...queryKeys.sessionShares.all, sessionId] as const,
   },
 
+  // Coach evaluation keys
+  coachEvaluations: {
+    all: ['coach-evaluations'] as const,
+    list: (sessionId: string) =>
+      [...queryKeys.coachEvaluations.all, sessionId] as const,
+  },
+
   // Coach typeahead search
   coachSearch: {
     all: ['coach-search'] as const,

--- a/src/services/coach-evaluations-service.ts
+++ b/src/services/coach-evaluations-service.ts
@@ -1,0 +1,63 @@
+import { ApiClient } from '@/lib/api-client'
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://coach-sidekick-backend-production.up.railway.app/api/v1'
+
+// null encodes "Not Observed"; integers 1-4 are scores.
+export type EvaluationScores = Record<string, number | null>
+
+export interface CoachEvaluation {
+  id: string
+  session_id: string
+  reviewer_id: string
+  reviewer_name: string | null
+  reviewer_email: string | null
+  scores: EvaluationScores
+  feedback: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CoachEvaluationCreatePayload {
+  scores: EvaluationScores
+  feedback?: string | null
+}
+
+export interface CoachEvaluationUpdatePayload {
+  scores?: EvaluationScores
+  feedback?: string | null
+}
+
+export class CoachEvaluationsService {
+  static list(sessionId: string): Promise<CoachEvaluation[]> {
+    return ApiClient.get(`${BACKEND_URL}/sessions/${sessionId}/evaluations`)
+  }
+
+  static create(
+    sessionId: string,
+    payload: CoachEvaluationCreatePayload,
+  ): Promise<CoachEvaluation> {
+    return ApiClient.post(
+      `${BACKEND_URL}/sessions/${sessionId}/evaluations`,
+      payload,
+    )
+  }
+
+  static update(
+    sessionId: string,
+    evaluationId: string,
+    payload: CoachEvaluationUpdatePayload,
+  ): Promise<CoachEvaluation> {
+    return ApiClient.patch(
+      `${BACKEND_URL}/sessions/${sessionId}/evaluations/${evaluationId}`,
+      payload,
+    )
+  }
+
+  static delete(sessionId: string, evaluationId: string): Promise<void> {
+    return ApiClient.delete(
+      `${BACKEND_URL}/sessions/${sessionId}/evaluations/${evaluationId}`,
+    )
+  }
+}

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -51,6 +51,8 @@ interface BackendSession {
   client_name?: string
   is_group_session?: boolean
   participant_count?: number | null
+  video_url?: string | null
+  video_unavailable?: boolean
 }
 
 // Transform backend session to UI format
@@ -62,6 +64,8 @@ function transformSession(backendSession: BackendSession): CoachingSession & {
   coach_id?: string
   coach_name?: string
   client_name?: string
+  video_url?: string | null
+  video_unavailable?: boolean
 } {
   return {
     id: backendSession.id,
@@ -81,6 +85,8 @@ function transformSession(backendSession: BackendSession): CoachingSession & {
     client_name: backendSession.client_name,
     is_group_session: backendSession.is_group_session,
     participant_count: backendSession.participant_count,
+    video_url: backendSession.video_url,
+    video_unavailable: backendSession.video_unavailable,
   }
 }
 
@@ -91,6 +97,7 @@ export class SessionService {
     client_id?: string
     coach_id?: string
     status?: string
+    scope?: 'mine' | 'shared' | 'all'
   }): Promise<SessionListResponse> {
     const queryParams = new URLSearchParams()
     if (params?.page) queryParams.append('page', params.page.toString())
@@ -99,6 +106,7 @@ export class SessionService {
     if (params?.client_id) queryParams.append('client_id', params.client_id)
     if (params?.coach_id) queryParams.append('coach_id', params.coach_id)
     if (params?.status) queryParams.append('status', params.status)
+    if (params?.scope) queryParams.append('scope', params.scope)
 
     const response = await ApiClient.get(
       `${BACKEND_URL}/sessions/?${queryParams}`,
@@ -171,6 +179,29 @@ export class SessionService {
 
   static async getSessionDetails(sessionId: string): Promise<any> {
     return await ApiClient.get(`${BACKEND_URL}/sessions/${sessionId}/details`)
+  }
+
+  static async getSessionReview(sessionId: string): Promise<{
+    id: string
+    title: string | null
+    duration_seconds: number | null
+    started_at: string | null
+    recording_started_at: string | null
+    video_url: string | null
+    video_unavailable: boolean
+    coach_name: string | null
+    is_owner: boolean
+    is_admin: boolean
+    is_shared_with_all_coaches: boolean
+    transcript: Array<{
+      id: string
+      speaker: string
+      text: string
+      timestamp: string
+      confidence: number | null
+    }>
+  }> {
+    return await ApiClient.get(`${BACKEND_URL}/sessions/${sessionId}/review`)
   }
 
   static async deleteSession(sessionId: string): Promise<{

--- a/src/services/session-shares-service.ts
+++ b/src/services/session-shares-service.ts
@@ -1,0 +1,60 @@
+import { ApiClient } from '@/lib/api-client'
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://coach-sidekick-backend-production.up.railway.app/api/v1'
+
+export interface SessionShare {
+  id: string
+  session_id: string
+  shared_with_user_id: string
+  shared_with_name: string | null
+  shared_with_email: string | null
+  created_by_id: string
+  created_at: string
+}
+
+export interface SessionShareList {
+  is_shared_with_all_coaches: boolean
+  shares: SessionShare[]
+}
+
+export interface CoachSearchResult {
+  id: string
+  full_name: string | null
+  email: string
+}
+
+export class SessionSharesService {
+  static list(sessionId: string): Promise<SessionShareList> {
+    return ApiClient.get(`${BACKEND_URL}/sessions/${sessionId}/shares`)
+  }
+
+  static add(sessionId: string, userIds: string[]): Promise<SessionShareList> {
+    return ApiClient.post(`${BACKEND_URL}/sessions/${sessionId}/shares`, {
+      user_ids: userIds,
+    })
+  }
+
+  static revoke(sessionId: string, shareId: string): Promise<void> {
+    return ApiClient.delete(
+      `${BACKEND_URL}/sessions/${sessionId}/shares/${shareId}`,
+    )
+  }
+
+  static toggleShareWithAll(
+    sessionId: string,
+    shareWithAll: boolean,
+  ): Promise<SessionShareList> {
+    return ApiClient.patch(`${BACKEND_URL}/sessions/${sessionId}/shares/all`, {
+      share_with_all: shareWithAll,
+    })
+  }
+
+  static searchCoaches(q: string, limit = 10): Promise<CoachSearchResult[]> {
+    const params = new URLSearchParams()
+    if (q) params.set('q', q)
+    params.set('limit', String(limit))
+    return ApiClient.get(`${BACKEND_URL}/coaches/search?${params.toString()}`)
+  }
+}

--- a/src/services/video-comments-service.ts
+++ b/src/services/video-comments-service.ts
@@ -1,0 +1,61 @@
+import { ApiClient } from '@/lib/api-client'
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://coach-sidekick-backend-production.up.railway.app/api/v1'
+
+export interface VideoComment {
+  id: string
+  session_id: string
+  author_id: string
+  author_name: string | null
+  author_email: string | null
+  content: string
+  video_offset_seconds: number
+  parent_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface VideoCommentCreatePayload {
+  content: string
+  video_offset_seconds: number
+  parent_id?: string | null
+}
+
+export interface VideoCommentUpdatePayload {
+  content: string
+}
+
+export class VideoCommentsService {
+  static list(sessionId: string): Promise<VideoComment[]> {
+    return ApiClient.get(`${BACKEND_URL}/sessions/${sessionId}/comments`)
+  }
+
+  static create(
+    sessionId: string,
+    payload: VideoCommentCreatePayload,
+  ): Promise<VideoComment> {
+    return ApiClient.post(
+      `${BACKEND_URL}/sessions/${sessionId}/comments`,
+      payload,
+    )
+  }
+
+  static update(
+    sessionId: string,
+    commentId: string,
+    payload: VideoCommentUpdatePayload,
+  ): Promise<VideoComment> {
+    return ApiClient.patch(
+      `${BACKEND_URL}/sessions/${sessionId}/comments/${commentId}`,
+      payload,
+    )
+  }
+
+  static delete(sessionId: string, commentId: string): Promise<void> {
+    return ApiClient.delete(
+      `${BACKEND_URL}/sessions/${sessionId}/comments/${commentId}`,
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- **Coach session evaluations** — new `/sessions/{id}/evaluations` flow. Reviewers click an "Evaluate session" button on the review page, fill a stepper-style modal (10 fixed competency questions on a 1–4 scale + optional feedback), and submit. Owner/admin sees all submissions on both `/sessions/[id]/review` and the Recording tab of `/sessions/[id]` — count, cross-reviewer average, expandable per-row Q&A, delete. Re-opens prefilled for edits.
- **Transcript polish on `/review`** — auto-scroll removed (it was hijacking the page scroll and pulling focus off the video). Replaced with a container-scoped `scrollToActive()` exposed via a "Jump to current" button in the transcript header. Transcript starts collapsed on `/review`; the recording-tab inline behavior on `/sessions/[id]` is unchanged.
- **Nav cleanup** — "Shared with me" sidebar item removed; "View Client Portal" button removed from the client detail header. Both are being phased out for the in-app peer-review focus.

## Test plan

- [ ] On `/sessions/[id]/review`: button reads "Evaluate session" pre-submit and "View / edit your evaluation" after; modal stepper auto-advances on selection; ⌘+1–4 / N keyboard shortcuts work; final review step shows mini-chips and the optional feedback box; submit closes the modal and updates the owner-side list.
- [ ] Owner detail Recording tab on `/sessions/[id]` shows the same evaluations list under the player.
- [ ] Transcript no longer auto-scrolls; "Jump to current" centers the active row in the inner pane only — page does not scroll.
- [ ] Sidebar no longer shows "Shared with me"; client detail page no longer shows "View Client Portal" button.