### PR TITLE
Add Thrill Form UI (gated off, hidden in prod)

### DIFF
--- a/src/app/client-meeting/[token]/components/meeting-ended-overlay.tsx
+++ b/src/app/client-meeting/[token]/components/meeting-ended-overlay.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   Target,
   LayoutDashboard,
+  Sparkles,
 } from 'lucide-react'
 import Link from 'next/link'
 
@@ -21,12 +22,14 @@ interface MeetingEndedOverlayProps {
   coachName: string | null
   notesCount: number
   commitmentsCount: number
+  thrillFormToken?: string | null
 }
 
 export function MeetingEndedOverlay({
   coachName,
   notesCount,
   commitmentsCount,
+  thrillFormToken,
 }: MeetingEndedOverlayProps) {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
 
@@ -88,6 +91,28 @@ export function MeetingEndedOverlay({
                   </p>
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Thrill Form CTA — shown above all other actions when available.
+              The form auto-opens in a new tab on session end; this button is
+              the always-available fallback for popup-blocked browsers. */}
+          {thrillFormToken && (
+            <div className="mb-6">
+              <a
+                href={`/questionnaire/${thrillFormToken}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block"
+              >
+                <Button className="w-full" size="lg">
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  Open Thrill Form
+                </Button>
+              </a>
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+                We&apos;ve also emailed you the link.
+              </p>
             </div>
           )}
 

--- a/src/app/client-meeting/[token]/hooks/use-meeting-status.ts
+++ b/src/app/client-meeting/[token]/hooks/use-meeting-status.ts
@@ -15,6 +15,7 @@ interface UseMeetingStatusReturn {
   isEnded: boolean
   durationSeconds: number
   isPolling: boolean
+  thrillFormToken: string | null
 }
 
 const POLL_INTERVAL = 10000 // 10 seconds
@@ -104,6 +105,7 @@ export function useMeetingStatus(meetingToken: string): UseMeetingStatusReturn {
     isEnded,
     durationSeconds,
     isPolling,
+    thrillFormToken: status?.thrill_form_token ?? null,
   }
 }
 

--- a/src/app/client-meeting/[token]/page.tsx
+++ b/src/app/client-meeting/[token]/page.tsx
@@ -6,7 +6,7 @@
 'use client'
 
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import Image from 'next/image'
 import { useLiveMeetingData } from './hooks/use-live-meeting-data'
@@ -17,6 +17,7 @@ import { ClientNotesPanel } from './components/client-notes-panel'
 import { ClientCommitmentPanel } from './components/client-commitment-panel'
 import { MeetingEndedOverlay } from './components/meeting-ended-overlay'
 import { LiveMeetingService } from '@/services/live-meeting-service'
+import { THRILL_FORM_ENABLED } from '@/lib/features'
 
 export default function ClientMeetingPage() {
   const params = useParams()
@@ -35,7 +36,8 @@ export default function ClientMeetingPage() {
     error: _guestError,
   } = useGuestAuth(meetingToken)
 
-  const { isEnded, durationSeconds } = useMeetingStatus(meetingToken)
+  const { isEnded, durationSeconds, thrillFormToken } =
+    useMeetingStatus(meetingToken)
 
   // Track notes and commitments count for the ended overlay
   const [notesCount, setNotesCount] = useState(0)
@@ -44,6 +46,21 @@ export default function ClientMeetingPage() {
   // Refresh key to trigger manual refresh of data
   const [refreshKey, setRefreshKey] = useState(0)
   const handleRefresh = () => setRefreshKey(k => k + 1)
+
+  // Auto-open the Thrill Form in a new tab once when the meeting ends.
+  // The ref guards against React strict-mode / double effect runs and against
+  // the polling cycle delivering the token across multiple renders.
+  const autoOpenedRef = useRef(false)
+  useEffect(() => {
+    if (!THRILL_FORM_ENABLED) return
+    if (!isEnded || !thrillFormToken || autoOpenedRef.current) return
+    autoOpenedRef.current = true
+    window.open(
+      `/questionnaire/${thrillFormToken}`,
+      '_blank',
+      'noopener,noreferrer',
+    )
+  }, [isEnded, thrillFormToken])
 
   // Fetch counts when meeting ends
   useEffect(() => {
@@ -227,6 +244,7 @@ export default function ClientMeetingPage() {
           coachName={sessionInfo.coach_name}
           notesCount={notesCount}
           commitmentsCount={commitmentsCount}
+          thrillFormToken={THRILL_FORM_ENABLED ? thrillFormToken : null}
         />
       )}
     </div>

--- a/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
@@ -9,12 +9,14 @@ interface QuestionnaireCompleteProps {
   clientName: string
   coachName: string
   scheduledFor: string | null
+  kind?: 'pre_session' | 'post_session'
 }
 
 export function QuestionnaireComplete({
   clientName,
   coachName,
   scheduledFor,
+  kind = 'pre_session',
 }: QuestionnaireCompleteProps) {
   const [showCheck, setShowCheck] = useState(false)
   const [showText, setShowText] = useState(false)
@@ -28,9 +30,11 @@ export function QuestionnaireComplete({
     }
   }, [])
 
-  const dateInfo = scheduledFor
-    ? format(new Date(scheduledFor), "EEEE, MMMM d 'at' h:mm a")
-    : null
+  const dateInfo =
+    kind === 'pre_session' && scheduledFor
+      ? format(new Date(scheduledFor), "EEEE, MMMM d 'at' h:mm a")
+      : null
+  const isThrillForm = kind === 'post_session'
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 via-white to-gray-100">
@@ -70,7 +74,9 @@ export function QuestionnaireComplete({
               Thank you, {clientName}!
             </h1>
             <p className="text-gray-500 text-lg leading-relaxed mb-6">
-              Your responses have been shared with {coachName}.
+              {isThrillForm
+                ? `Your Thrill Form has been shared with ${coachName}.`
+                : `Your responses have been shared with ${coachName}.`}
               {dateInfo && (
                 <>
                   <br />

--- a/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { ArrowLeft, ArrowRight, Check, Loader2 } from 'lucide-react'
 import Image from 'next/image'
 import { toast } from 'sonner'
@@ -8,6 +8,7 @@ import { QuestionnaireService } from '@/services/questionnaire-service'
 import type {
   QuestionItem,
   QuestionnaireAnswerItem,
+  QuestionnaireKind,
 } from '@/types/questionnaire'
 
 interface QuestionnaireFlowProps {
@@ -16,6 +17,7 @@ interface QuestionnaireFlowProps {
   existingAnswers: QuestionnaireAnswerItem[]
   clientName: string
   coachName: string
+  kind?: QuestionnaireKind
   onComplete: () => void
 }
 
@@ -48,14 +50,39 @@ function clearStorage(token: string) {
   }
 }
 
+function isQuestionVisible(
+  question: QuestionItem,
+  answers: Record<number, string>,
+): boolean {
+  const cond = question.condition
+  if (!cond) return true
+  const dep = answers[cond.depends_on]
+  if (dep === undefined || dep === null || dep === '') {
+    // Hide conditional questions until the controlling answer exists.
+    return false
+  }
+  if (cond.show_if !== undefined && cond.show_if !== null) {
+    return (
+      String(dep).trim().toLowerCase() === String(cond.show_if).toLowerCase()
+    )
+  }
+  if (cond.show_if_not !== undefined && cond.show_if_not !== null) {
+    return (
+      String(dep).trim().toLowerCase() !==
+      String(cond.show_if_not).toLowerCase()
+    )
+  }
+  return true
+}
+
 export function QuestionnaireFlow({
   token,
   questions,
   existingAnswers,
+  kind = 'pre_session',
   onComplete,
 }: QuestionnaireFlowProps) {
   const [answers, setAnswers] = useState<Record<number, string>>(() => {
-    // Priority: localStorage > existingAnswers from API
     const stored = loadFromStorage(token)
     if (Object.keys(stored).length > 0) return stored
 
@@ -65,10 +92,17 @@ export function QuestionnaireFlow({
     })
     return initial
   })
-  const [currentIndex, setCurrentIndex] = useState(() => {
-    // Resume at the first unanswered question
+
+  // Visible questions update as answers change (conditional skipping).
+  const visibleQuestions = useMemo(
+    () => questions.filter(q => isQuestionVisible(q, answers)),
+    [questions, answers],
+  )
+
+  const [position, setPosition] = useState(() => {
+    // Resume at the first unanswered visible question.
     const stored = loadFromStorage(token)
-    const answeredKeys =
+    const seed =
       Object.keys(stored).length > 0
         ? stored
         : existingAnswers.reduce<Record<number, string>>((acc, a) => {
@@ -76,32 +110,52 @@ export function QuestionnaireFlow({
             return acc
           }, {})
 
-    for (let i = 0; i < questions.length; i++) {
-      if (!answeredKeys[i] || !String(answeredKeys[i]).trim()) return i
+    const visible = questions.filter(q => isQuestionVisible(q, seed))
+    for (let i = 0; i < visible.length; i++) {
+      const ans = seed[visible[i].index]
+      const empty = !ans || !String(ans).trim()
+      if (empty && !visible[i].optional) return i
     }
-    // All answered — go to last question so user can review/submit
-    return Object.keys(answeredKeys).length > 0 ? questions.length - 1 : 0
+    return Math.max(visible.length - 1, 0)
   })
+
   const [direction, setDirection] = useState<'forward' | 'backward'>('forward')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const currentQuestion = questions[currentIndex]
-  const currentAnswer = answers[currentIndex] || ''
-  const isFirst = currentIndex === 0
-  const isLast = currentIndex === questions.length - 1
-  const progress = ((currentIndex + 1) / questions.length) * 100
-
-  // Auto-focus textarea
+  // Clamp position when conditional skipping changes the visible list length.
   useEffect(() => {
-    const timer = setTimeout(() => {
-      textareaRef.current?.focus()
-    }, 400)
-    return () => clearTimeout(timer)
-  }, [currentIndex])
+    if (position > visibleQuestions.length - 1) {
+      setPosition(Math.max(visibleQuestions.length - 1, 0))
+    }
+  }, [visibleQuestions.length, position])
 
-  // Auto-resize textarea
+  const currentQuestion = visibleQuestions[position]
+  const currentAnswer = currentQuestion
+    ? answers[currentQuestion.index] || ''
+    : ''
+  const isFirst = position === 0
+  const isLast = position === visibleQuestions.length - 1
+  const progress =
+    visibleQuestions.length > 0
+      ? ((position + 1) / visibleQuestions.length) * 100
+      : 0
+
+  // Auto-focus textarea (only relevant for text questions).
+  useEffect(() => {
+    if (
+      currentQuestion?.type !== 'scale' &&
+      currentQuestion?.type !== 'yes_no'
+    ) {
+      const timer = setTimeout(() => {
+        textareaRef.current?.focus()
+      }, 400)
+      return () => clearTimeout(timer)
+    }
+  }, [position, currentQuestion?.type])
+
+  // Auto-resize textarea.
   useEffect(() => {
     const textarea = textareaRef.current
     if (textarea) {
@@ -111,19 +165,29 @@ export function QuestionnaireFlow({
   }, [currentAnswer])
 
   const updateAnswer = (value: string) => {
-    const updated = { ...answers, [currentIndex]: value }
+    if (!currentQuestion) return
+    const updated = { ...answers, [currentQuestion.index]: value }
     setAnswers(updated)
     saveToStorage(token, updated)
   }
 
+  const canAdvance = (() => {
+    if (!currentQuestion) return false
+    if (currentQuestion.optional) return true
+    return currentAnswer.trim().length > 0
+  })()
+
   const goNext = async () => {
-    if (isAnimating) return
+    if (isAnimating || !currentQuestion) return
 
     if (isLast) {
-      // Submit all answers in one API call
       setIsSubmitting(true)
       try {
+        // Only submit answers for currently-visible questions; conditional
+        // branches that the user routed around shouldn't carry stale text.
+        const visibleIndexes = new Set(visibleQuestions.map(q => q.index))
         const allAnswers = questions
+          .filter(q => visibleIndexes.has(q.index))
           .map(q => ({
             question_index: q.index,
             answer: (answers[q.index] || '').trim(),
@@ -140,11 +204,10 @@ export function QuestionnaireFlow({
       return
     }
 
-    // Instant navigation — no API call
     setDirection('forward')
     setIsAnimating(true)
     setTimeout(() => {
-      setCurrentIndex(prev => prev + 1)
+      setPosition(prev => prev + 1)
       setIsAnimating(false)
     }, 300)
   }
@@ -155,7 +218,7 @@ export function QuestionnaireFlow({
     setDirection('backward')
     setIsAnimating(true)
     setTimeout(() => {
-      setCurrentIndex(prev => prev - 1)
+      setPosition(prev => prev - 1)
       setIsAnimating(false)
     }, 300)
   }
@@ -166,6 +229,9 @@ export function QuestionnaireFlow({
       goNext()
     }
   }
+
+  const headerCaption =
+    kind === 'post_session' ? 'Thrill Form' : 'Pre-Session Questionnaire'
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 via-white to-gray-100">
@@ -190,14 +256,13 @@ export function QuestionnaireFlow({
           priority
         />
         <p className="text-xs uppercase tracking-widest text-gray-400 font-medium">
-          Pre-Session Questionnaire
+          {headerCaption}
         </p>
       </div>
 
       {/* Main Content */}
       <div className="flex-1 flex items-center justify-center px-6 py-12">
         <div className="w-full max-w-2xl">
-          {/* Question (counter + text + input all animate together) */}
           <div
             className={`transition-all duration-300 ease-out ${
               isAnimating
@@ -210,8 +275,10 @@ export function QuestionnaireFlow({
             {/* Question Counter */}
             <div className="mb-8">
               <span className="text-sm text-gray-400 font-medium">
-                {currentIndex + 1}{' '}
-                <span className="text-gray-300">/ {questions.length}</span>
+                {position + 1}{' '}
+                <span className="text-gray-300">
+                  / {visibleQuestions.length}
+                </span>
               </span>
             </div>
 
@@ -219,17 +286,36 @@ export function QuestionnaireFlow({
               {currentQuestion?.text}
             </h2>
 
-            {/* Answer Input */}
-            <textarea
-              ref={textareaRef}
-              value={currentAnswer}
-              onChange={e => updateAnswer(e.target.value)}
-              onKeyDown={handleKeyDown}
-              disabled={isSubmitting}
-              placeholder="Type your answer here..."
-              className="w-full bg-transparent border-0 border-b-2 border-gray-200 focus:border-gray-900 text-lg text-gray-800 placeholder-gray-300 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
-              rows={3}
-            />
+            {/* Answer Input — switches by question type */}
+            {currentQuestion?.type === 'scale' ? (
+              <ScaleInput
+                question={currentQuestion}
+                value={currentAnswer}
+                onChange={updateAnswer}
+                disabled={isSubmitting}
+              />
+            ) : currentQuestion?.type === 'yes_no' ? (
+              <YesNoInput
+                value={currentAnswer}
+                onChange={updateAnswer}
+                disabled={isSubmitting}
+              />
+            ) : (
+              <textarea
+                ref={textareaRef}
+                value={currentAnswer}
+                onChange={e => updateAnswer(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={isSubmitting}
+                placeholder={
+                  currentQuestion?.optional
+                    ? 'Optional — leave blank if you have nothing to add'
+                    : 'Type your answer here...'
+                }
+                className="w-full bg-transparent border-0 border-b-2 border-gray-200 focus:border-gray-900 text-lg text-gray-800 placeholder-gray-300 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
+                rows={3}
+              />
+            )}
           </div>
 
           {/* Navigation */}
@@ -249,9 +335,9 @@ export function QuestionnaireFlow({
 
             <button
               onClick={goNext}
-              disabled={!currentAnswer.trim() || isAnimating || isSubmitting}
+              disabled={!canAdvance || isAnimating || isSubmitting}
               className={`flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded-lg transition-all ${
-                currentAnswer.trim()
+                canAdvance
                   ? 'bg-gray-900 text-white hover:bg-gray-800 shadow-sm'
                   : 'bg-gray-100 text-gray-400 cursor-not-allowed'
               }`}
@@ -277,24 +363,29 @@ export function QuestionnaireFlow({
                     : 'hidden'
                 }
               >
-                Next
+                {currentQuestion?.optional && !currentAnswer.trim()
+                  ? 'Skip'
+                  : 'Next'}
                 <ArrowRight className="h-4 w-4" />
               </span>
             </button>
           </div>
 
-          {/* Keyboard hint */}
-          <p className="text-center text-xs text-gray-300 mt-8">
-            Press{' '}
-            <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
-              ⌘
-            </kbd>{' '}
-            +{' '}
-            <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
-              Enter
-            </kbd>{' '}
-            to continue
-          </p>
+          {/* Keyboard hint — only useful for text inputs */}
+          {currentQuestion?.type !== 'scale' &&
+            currentQuestion?.type !== 'yes_no' && (
+              <p className="text-center text-xs text-gray-300 mt-8">
+                Press{' '}
+                <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
+                  ⌘
+                </kbd>{' '}
+                +{' '}
+                <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
+                  Enter
+                </kbd>{' '}
+                to continue
+              </p>
+            )}
         </div>
       </div>
 
@@ -302,6 +393,94 @@ export function QuestionnaireFlow({
       <div className="pb-6 text-center">
         <p className="text-xs text-gray-300">Powered by Novus Global</p>
       </div>
+    </div>
+  )
+}
+
+// ---------- Sub-components ----------
+
+interface ScaleInputProps {
+  question: QuestionItem
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+function ScaleInput({ question, value, onChange, disabled }: ScaleInputProps) {
+  const min = question.scale_min ?? 1
+  const max = question.scale_max ?? 10
+  const numbers = Array.from({ length: max - min + 1 }, (_, i) => min + i)
+  const selected = value ? Number(value) : null
+
+  return (
+    <div>
+      <div className="grid grid-cols-5 sm:grid-cols-10 gap-2 sm:gap-3">
+        {numbers.map(n => {
+          const isSelected = selected === n
+          return (
+            <button
+              key={n}
+              type="button"
+              disabled={disabled}
+              onClick={() => onChange(String(n))}
+              className={`aspect-square min-h-[44px] flex items-center justify-center rounded-lg border-2 text-base sm:text-lg font-semibold transition-all ${
+                isSelected
+                  ? 'bg-gray-900 text-white border-gray-900 shadow-sm scale-105'
+                  : 'bg-white text-gray-700 border-gray-200 hover:border-gray-400 hover:text-gray-900'
+              } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+              aria-label={`Rate ${n}`}
+              aria-pressed={isSelected}
+            >
+              {n}
+            </button>
+          )
+        })}
+      </div>
+      {(question.scale_min_label || question.scale_max_label) && (
+        <div className="flex justify-between mt-3 text-xs text-gray-400">
+          <span>
+            {min}
+            {question.scale_min_label ? ` — ${question.scale_min_label}` : ''}
+          </span>
+          <span>
+            {max}
+            {question.scale_max_label ? ` — ${question.scale_max_label}` : ''}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface YesNoInputProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+function YesNoInput({ value, onChange, disabled }: YesNoInputProps) {
+  const normalized = value.trim().toLowerCase()
+  return (
+    <div className="flex gap-3 sm:gap-4">
+      {(['yes', 'no'] as const).map(opt => {
+        const isSelected = normalized === opt
+        return (
+          <button
+            key={opt}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(opt)}
+            className={`flex-1 py-4 sm:py-5 rounded-lg border-2 text-base sm:text-lg font-semibold transition-all capitalize ${
+              isSelected
+                ? 'bg-gray-900 text-white border-gray-900 shadow-sm'
+                : 'bg-white text-gray-700 border-gray-200 hover:border-gray-400 hover:text-gray-900'
+            } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            aria-pressed={isSelected}
+          >
+            {opt}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/app/questionnaire/[token]/page.tsx
+++ b/src/app/questionnaire/[token]/page.tsx
@@ -67,6 +67,7 @@ export default function QuestionnairePage() {
         clientName={data.client_name}
         coachName={data.coach_name}
         scheduledFor={data.scheduled_for}
+        kind={data.kind}
       />
     )
   }
@@ -79,6 +80,7 @@ export default function QuestionnairePage() {
         existingAnswers={data.existing_answers}
         clientName={data.client_name}
         coachName={data.coach_name}
+        kind={data.kind}
         onComplete={() => setState('complete')}
       />
     )

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -29,6 +29,8 @@ import { SessionNotesCompact } from './session-notes-compact'
 import { SessionResourcesCompact } from './session-resources-compact'
 import { SessionWins } from '@/components/wins/session-wins'
 import { PreSessionResponses } from './pre-session-responses'
+import { ThrillFormResponses } from './thrill-form-responses'
+import { THRILL_FORM_ENABLED } from '@/lib/features'
 import TranscriptViewer from './transcript-viewer'
 
 interface TranscriptEntry {
@@ -135,6 +137,11 @@ export function SessionOverviewTab({
     <div className="space-y-6">
       {/* Pre-Session Questionnaire Responses */}
       <PreSessionResponses sessionId={sessionId} clientId={clientId} />
+
+      {/* Thrill Form (post-session reflection) Responses */}
+      {THRILL_FORM_ENABLED && (
+        <ThrillFormResponses sessionId={sessionId} clientId={clientId} />
+      )}
 
       {/* Per-Client Analysis Pending State */}
       {isGroupSession && selectedClientId && !clientAnalysis && (

--- a/src/app/sessions/[sessionId]/components/thrill-form-responses.tsx
+++ b/src/app/sessions/[sessionId]/components/thrill-form-responses.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { Sparkles, CheckCircle2, Clock } from 'lucide-react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { useThrillFormResponses } from '@/hooks/queries/use-questionnaire'
+import { format } from 'date-fns'
+
+interface ThrillFormResponsesProps {
+  sessionId: string
+  clientId?: string
+}
+
+function formatAnswer(questionText: string, answer: string) {
+  // Scale questions originate as a single 1–10 number string. Show "8 / 10"
+  // so the rating is unmistakable in the coach view.
+  const trimmed = answer.trim()
+  if (/^([1-9]|10)$/.test(trimmed)) {
+    return `${trimmed} / 10`
+  }
+  // Yes / no — render as a small badge inline.
+  if (trimmed.toLowerCase() === 'yes' || trimmed.toLowerCase() === 'no') {
+    return trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase()
+  }
+  return answer
+}
+
+function isShortAnswer(answer: string) {
+  const trimmed = answer.trim()
+  return (
+    /^([1-9]|10)$/.test(trimmed) ||
+    trimmed.toLowerCase() === 'yes' ||
+    trimmed.toLowerCase() === 'no'
+  )
+}
+
+export function ThrillFormResponses({
+  sessionId,
+  clientId,
+}: ThrillFormResponsesProps) {
+  const { data: responses, isLoading } = useThrillFormResponses(
+    sessionId,
+    clientId,
+  )
+
+  if (isLoading || !responses || responses.length === 0) return null
+
+  const response = responses[0]
+  const isCompleted = response.status === 'completed'
+
+  return (
+    <Card className="border-app-border shadow-sm">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-app-secondary" />
+            <h3 className="text-sm font-semibold text-app-primary">
+              Thrill Form
+            </h3>
+          </div>
+          {isCompleted ? (
+            <Badge
+              variant="secondary"
+              className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-xs"
+            >
+              <CheckCircle2 className="h-3 w-3 mr-1" />
+              Completed
+              {response.completed_at &&
+                ` ${format(new Date(response.completed_at), 'MMM d')}`}
+            </Badge>
+          ) : (
+            <Badge
+              variant="secondary"
+              className="bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800 text-xs"
+            >
+              <Clock className="h-3 w-3 mr-1" />
+              In Progress
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="space-y-4">
+          {response.responses.map((qa, idx) => {
+            const formatted = formatAnswer(qa.question_text, qa.answer)
+            const compact = isShortAnswer(qa.answer)
+            return (
+              <div key={idx}>
+                <p className="text-xs font-medium text-app-secondary uppercase tracking-wider mb-1.5">
+                  {qa.question_text}
+                </p>
+                {compact ? (
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-semibold bg-gray-100 dark:bg-gray-800 text-app-primary">
+                    {formatted}
+                  </span>
+                ) : (
+                  <p className="text-sm text-app-primary leading-relaxed">
+                    {formatted}
+                  </p>
+                )}
+                {idx < response.responses.length - 1 && (
+                  <div className="border-b border-app-border mt-4" />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/hooks/mutations/use-questionnaire-mutations.ts
+++ b/src/hooks/mutations/use-questionnaire-mutations.ts
@@ -76,6 +76,32 @@ export function useRescheduleSession() {
   })
 }
 
+export function useSendThrillForm() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      clientId,
+    }: {
+      sessionId: string
+      clientId: string
+    }) => QuestionnaireService.sendThrillForm(sessionId, clientId),
+    onSuccess: (_data, { sessionId }) => {
+      queryClient.invalidateQueries({
+        predicate: query =>
+          query.queryKey[0] === 'questionnaire' &&
+          query.queryKey[1] === 'thrill-form-responses' &&
+          query.queryKey[2] === sessionId,
+      })
+      toast.success('Thrill Form sent')
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to send Thrill Form')
+    },
+  })
+}
+
 export function useStartSessionBot() {
   return useMutation({
     mutationFn: ({

--- a/src/hooks/queries/use-questionnaire.ts
+++ b/src/hooks/queries/use-questionnaire.ts
@@ -10,6 +10,8 @@ export const questionnaireKeys = {
     ['questionnaire', 'upcoming', clientId] as const,
   responses: (sessionId: string, clientId?: string) =>
     ['questionnaire', 'responses', sessionId, clientId] as const,
+  thrillFormResponses: (sessionId: string, clientId?: string) =>
+    ['questionnaire', 'thrill-form-responses', sessionId, clientId] as const,
 }
 
 export function useUpcomingSessions(clientId?: string) {
@@ -26,8 +28,22 @@ export function useQuestionnaireResponses(
 ) {
   return useQuery<QuestionnaireResponseView[]>({
     queryKey: questionnaireKeys.responses(sessionId || '', clientId),
-    queryFn: () => QuestionnaireService.getResponses(sessionId!, clientId),
+    queryFn: () =>
+      QuestionnaireService.getResponses(sessionId!, clientId, 'pre_session'),
     enabled: !!sessionId,
     staleTime: 60 * 1000, // 1 minute
+  })
+}
+
+export function useThrillFormResponses(
+  sessionId: string | undefined,
+  clientId?: string,
+) {
+  return useQuery<QuestionnaireResponseView[]>({
+    queryKey: questionnaireKeys.thrillFormResponses(sessionId || '', clientId),
+    queryFn: () =>
+      QuestionnaireService.getResponses(sessionId!, clientId, 'post_session'),
+    enabled: !!sessionId,
+    staleTime: 60 * 1000,
   })
 }

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,5 @@
+// Feature flag: when false, the Thrill Form is dormant in the UI — the
+// auto-open new tab on meeting end, the "Open Thrill Form" overlay button,
+// and the Thrill Form responses card on the session overview tab are all
+// hidden. Flip to true (and deploy) to release.
+export const THRILL_FORM_ENABLED = false

--- a/src/services/live-meeting-service.ts
+++ b/src/services/live-meeting-service.ts
@@ -25,6 +25,7 @@ export interface SessionStatus {
   is_ended: boolean
   duration_seconds: number | null
   ended_at: string | null
+  thrill_form_token: string | null
 }
 
 export interface GuestIdentifier {

--- a/src/services/questionnaire-service.ts
+++ b/src/services/questionnaire-service.ts
@@ -48,13 +48,27 @@ export class QuestionnaireService {
     })
   }
 
+  static async sendThrillForm(
+    sessionId: string,
+    clientId: string,
+  ): Promise<QuestionnaireTokenResponse> {
+    return ApiClient.post(
+      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/send-thrill-form`,
+      { session_id: sessionId, client_id: clientId },
+    )
+  }
+
   static async getResponses(
     sessionId: string,
     clientId?: string,
+    kind?: 'pre_session' | 'post_session',
   ): Promise<QuestionnaireResponseView[]> {
-    const params = clientId ? `?client_id=${clientId}` : ''
+    const search = new URLSearchParams()
+    if (clientId) search.set('client_id', clientId)
+    if (kind) search.set('kind', kind)
+    const qs = search.toString()
     return ApiClient.get(
-      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/responses${params}`,
+      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/responses${qs ? `?${qs}` : ''}`,
     )
   }
 

--- a/src/types/questionnaire.ts
+++ b/src/types/questionnaire.ts
@@ -21,8 +21,18 @@ export interface ScheduledSession {
   google_calendar_event_id?: string | null
 }
 
+export type QuestionnaireKind = 'pre_session' | 'post_session'
+export type QuestionType = 'text' | 'scale' | 'yes_no'
+
+export interface QuestionCondition {
+  depends_on: number
+  show_if?: string
+  show_if_not?: string
+}
+
 export interface QuestionnaireValidation {
   valid: boolean
+  kind?: QuestionnaireKind
   client_name: string
   coach_name: string
   session_title: string | null
@@ -34,6 +44,13 @@ export interface QuestionnaireValidation {
 export interface QuestionItem {
   index: number
   text: string
+  type?: QuestionType
+  optional?: boolean
+  scale_min?: number | null
+  scale_max?: number | null
+  scale_min_label?: string | null
+  scale_max_label?: string | null
+  condition?: QuestionCondition | null
 }
 
 export interface QuestionnaireAnswerItem {


### PR DESCRIPTION
## Summary

- Adds the client-facing Thrill Form flow alongside the existing pre-session questionnaire. The shared \`QuestionnaireFlow\` is now type-aware (1–10 scale tiles, yes/no toggles, plain text) and auto-skips conditional questions based on prior answers.
- New \`ThrillFormResponses\` card on the session overview tab. Client meeting page auto-opens the form in a new tab on session end and shows an "Open Thrill Form" fallback button on the ended overlay.
- **Feature flag**: \`THRILL_FORM_ENABLED = false\` in \`src/lib/features.ts\`. With the flag off, the auto-open \`useEffect\`, the overlay button (\`thrillFormToken\` is forced to \`null\` at the prop boundary), and the responses card on the overview tab are all hidden. The backend ships a matching flag so no Thrill Form email is sent either.

## Test plan
- [ ] Existing pre-session questionnaire flow unchanged
- [ ] After a 1-on-1 session ends: no new tab opens, no overlay button, no responses card
- [ ] Session overview tab shows the pre-session card only
- [ ] When flags flip to \`true\` and both apps redeploy, Thrill Form fires end-to-end