### PR TITLE
Let users check off past commitments during a live call

### DIFF
--- a/src/components/commitments/commitment-panel.tsx
+++ b/src/components/commitments/commitment-panel.tsx
@@ -842,13 +842,41 @@ export function CommitmentPanel({
             </div>
             <div className="space-y-2 pl-3 border-l-2 border-gray-100 dark:border-gray-700">
               {(group.commitments || []).map(commitment => (
-                <div key={commitment.id} className="flex items-start gap-2">
-                  {commitment.status === 'completed' ? (
-                    <CheckCircle2 className="h-4 w-4 text-green-500 flex-shrink-0 mt-0.5" />
-                  ) : commitment.status === 'abandoned' ? (
+                <div
+                  key={commitment.id}
+                  className={cn(
+                    'flex items-start gap-2 rounded px-1 -mx-1',
+                    onOpenFull &&
+                      'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                  )}
+                  onClick={() => onOpenFull?.(commitment)}
+                >
+                  {commitment.status === 'abandoned' ? (
                     <X className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
                   ) : (
-                    <Circle className="h-4 w-4 text-gray-300 dark:text-gray-500 flex-shrink-0 mt-0.5" />
+                    <button
+                      onClick={e => {
+                        e.stopPropagation()
+                        onToggleComplete(commitment)
+                      }}
+                      className={cn(
+                        'mt-0.5 flex-shrink-0 transition-colors',
+                        commitment.status === 'completed'
+                          ? 'text-green-500'
+                          : 'text-gray-300 dark:text-gray-500 hover:text-green-500',
+                      )}
+                      title={
+                        commitment.status === 'completed'
+                          ? 'Mark as active'
+                          : 'Mark as completed'
+                      }
+                    >
+                      {commitment.status === 'completed' ? (
+                        <CheckCircle2 className="h-4 w-4" />
+                      ) : (
+                        <Circle className="h-4 w-4" />
+                      )}
+                    </button>
                   )}
                   <div className="flex-1 min-w-0">
                     <p


### PR DESCRIPTION
## Summary
- The "Past" tab in the in-call `CommitmentPanel` was a read-only timeline — clients/coaches couldn't mark off prior-session commitments without leaving the meeting.
- Swapped the static status icon for the same toggle `<button>` the session list already uses, and made the row clickable to open the detail panel via the existing `onOpenFull` handler.
- `abandoned` stays a non-interactive `X` so a coach-closed commitment can't be accidentally un-abandoned.
- Both panel callers (`quick-commitment.tsx` coach, `client-commitment-panel.tsx` client) already pass `onToggleComplete` + `onOpenFull`, so the change lights up symmetrically with no caller edits.

## Test plan
- [ ] On a live meeting page (coach view), open the "Past" tab, click an `active` commitment's circle → flips to green check, persists after refresh.
- [ ] Click the green check on a `completed` past commitment → flips back to circle/`active`.
- [ ] Click an `abandoned` past commitment's `X` → stays static (no toggle).
- [ ] Click anywhere on a past commitment row (not the icon) → detail panel opens.
- [ ] Repeat the same checks on the client live-meeting page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)