### PR TITLE
Auto-sync browser timezone to coach profile

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -2,8 +2,30 @@
 
 import { createContext, useContext, useEffect, useState } from 'react'
 import authService from '@/services/auth-service'
+import axios from '@/lib/axios-config'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner' // NEW: Add Sonner toasts
+
+const TZ_SYNCED_FLAG = 'tz_synced'
+
+async function syncBrowserTimezone() {
+  // Fire-and-forget: tell the backend the browser-detected IANA zone so
+  // session emails render with the recipient's local wall-clock time. Runs
+  // at most once per browser session; safe to call when current value
+  // already matches (backend no-ops). Failures are silent — this is a
+  // background nicety, not a critical-path call.
+  if (typeof window === 'undefined') return
+  if (sessionStorage.getItem(TZ_SYNCED_FLAG) === '1') return
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+    if (!tz) return
+    sessionStorage.setItem(TZ_SYNCED_FLAG, '1')
+    await axios.put('/auth/me', { timezone: tz })
+  } catch (err) {
+    sessionStorage.removeItem(TZ_SYNCED_FLAG)
+    console.warn('Timezone auto-sync failed (non-fatal):', err)
+  }
+}
 
 interface AuthContextType {
   isAuthenticated: boolean
@@ -79,6 +101,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setRoles(userRoles)
         setClientAccess(userClientAccess)
         setOwnClientId(userClientId) // NEW
+
+        // Sync browser tz to backend so session emails render in the
+        // recipient's local zone. Fire-and-forget.
+        void syncBrowserTimezone()
       }
 
       setLoading(false)
@@ -130,6 +156,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setClientAccess(authService.getClientAccess())
       setOwnClientId(authService.getOwnClientId())
 
+      // Sync browser tz to backend so session emails render in the
+      // recipient's local zone. Fire-and-forget.
+      void syncBrowserTimezone()
+
       // NEW: Success toast
       toast.success('Welcome Back!', {
         description: `Logged in as ${fullName || email}`,
@@ -173,6 +203,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setRoles([])
       setClientAccess([])
       setOwnClientId(null)
+      if (typeof window !== 'undefined') {
+        sessionStorage.removeItem(TZ_SYNCED_FLAG)
+      }
 
       // NEW: Success toast
       toast.success('Logged Out', {


### PR DESCRIPTION
## Summary
- Once per browser session, the auth context fires-and-forgets `PUT /auth/me` with the browser-detected IANA zone (`Intl.DateTimeFormat().resolvedOptions().timeZone`). Runs on both existing-session restore and fresh login; cleared on signout so the next user on the same browser re-syncs.
- Solves the systemic root cause of today's wrong-time-on-emails incident: without a profile UI, `coach.timezone` sat NULL for all 256 rows, forcing the email path to fall back to UTC. Auto-detect populates the field with zero clicks — first time each coach loads the app, the backend gets their actual zone.
- An explicit picker is still TBD as a follow-up; this MVP unblocks the email fix today.

## Trade-offs
- The PUT is unconditional. If a coach travels, their saved zone follows the browser. Acceptable because tz is purely a display preference for emails, not a scheduling primitive (sessions are stored as UTC TIMESTAMPTZ regardless).
- Failures are silent and don't block any UX path; sessionStorage flag is cleared on error so the next page load retries.

## Test plan
- [ ] Post-deploy: log in fresh; confirm browser DevTools shows a `PUT /auth/me` with the right `timezone` and a 200 response.
- [ ] Reload the page; confirm no second PUT fires (sessionStorage flag holds).
- [ ] Sign out, sign back in; confirm a fresh PUT fires.
- [ ] Hit DB and verify the row updated.