### PR TITLE
Enable Thrill Form + add delete-client action

### DIFF
--- a/src/app/clients/components/client-card.tsx
+++ b/src/app/clients/components/client-card.tsx
@@ -13,12 +13,14 @@ import {
   UserCheck,
   MoreHorizontal,
   XCircle,
+  Trash2,
 } from 'lucide-react'
 import { formatDate } from '@/lib/date-utils'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
@@ -30,6 +32,7 @@ interface ClientCardProps {
   onEdit: () => void
   onInvite: () => void
   onCancelInvite?: () => void
+  onDelete: () => void
 }
 
 export default function ClientCard({
@@ -40,6 +43,7 @@ export default function ClientCard({
   onEdit,
   onInvite,
   onCancelInvite,
+  onDelete,
 }: ClientCardProps) {
   const stats = client.client_session_stats?.[0]
 
@@ -198,6 +202,17 @@ export default function ClientCard({
                           Cancel Invitation
                         </DropdownMenuItem>
                       )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={e => {
+                        e.stopPropagation()
+                        onDelete()
+                      }}
+                      className="text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/30"
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Delete Client
+                    </DropdownMenuItem>
                   </>
                 )}
               </DropdownMenuContent>

--- a/src/app/clients/components/clients-list.tsx
+++ b/src/app/clients/components/clients-list.tsx
@@ -18,6 +18,7 @@ interface ClientsListProps {
   onEditClient: (client: Client) => void
   onInviteClient: (client: Client) => void
   onCancelInvitation?: (client: Client) => void
+  onDeleteClient: (client: Client) => void
   onCreateClient: () => void
 }
 
@@ -33,6 +34,7 @@ export default function ClientsList({
   onEditClient,
   onInviteClient,
   onCancelInvitation,
+  onDeleteClient,
   onCreateClient,
 }: ClientsListProps) {
   // Loading skeleton
@@ -135,6 +137,7 @@ export default function ClientsList({
                 onEdit={() => onEditClient(client)}
                 onInvite={() => onInviteClient(client)}
                 onCancelInvite={() => onCancelInvitation?.(client)}
+                onDelete={() => onDeleteClient(client)}
               />
             ))}
           </div>
@@ -163,6 +166,7 @@ export default function ClientsList({
                 onEdit={() => onEditClient(client)}
                 onInvite={() => onInviteClient(client)}
                 onCancelInvite={() => onCancelInvitation?.(client)}
+                onDelete={() => onDeleteClient(client)}
               />
             ))}
           </div>

--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -48,6 +48,8 @@ export default function ClientsPage() {
   const [selectedClient, setSelectedClient] = useState<Client | null>(null)
   const [showCancelInviteDialog, setShowCancelInviteDialog] = useState(false)
   const [isCancellingInvite, setIsCancellingInvite] = useState(false)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
 
   // Use the data hook
   const {
@@ -109,6 +111,33 @@ export default function ClientsPage() {
   const openCancelInvitationDialog = (client: Client) => {
     setSelectedClient(client)
     setShowCancelInviteDialog(true)
+  }
+
+  const openDeleteDialog = (client: Client) => {
+    setSelectedClient(client)
+    setShowDeleteDialog(true)
+  }
+
+  const handleDeleteClient = async () => {
+    if (!selectedClient) return
+    setIsDeleting(true)
+    try {
+      await ClientService.deleteClient(selectedClient.id)
+      toast.success('Client deleted', {
+        description: `${selectedClient.name} has been permanently deleted.`,
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.clients.all })
+      setShowDeleteDialog(false)
+      setSelectedClient(null)
+    } catch (error) {
+      console.error('Error deleting client:', error)
+      toast.error('Failed to delete client', {
+        description:
+          error instanceof Error ? error.message : 'Please try again later',
+      })
+    } finally {
+      setIsDeleting(false)
+    }
   }
 
   const handleCancelInvitation = async () => {
@@ -264,6 +293,7 @@ export default function ClientsPage() {
               onEditClient={openEditModal}
               onInviteClient={openInviteModal}
               onCancelInvitation={openCancelInvitationDialog}
+              onDeleteClient={openDeleteDialog}
               onCreateClient={() => setIsCreateModalOpen(true)}
             />
           </div>
@@ -319,6 +349,21 @@ export default function ClientsPage() {
           }
           variant="destructive"
           onConfirm={handleCancelInvitation}
+        />
+
+        {/* Delete Client Dialog */}
+        <ConfirmationDialog
+          open={showDeleteDialog}
+          onOpenChange={open => {
+            if (!isDeleting) {
+              setShowDeleteDialog(open)
+            }
+          }}
+          title="Delete Client"
+          description={`Permanently delete ${selectedClient?.name}? This will also delete all sessions, transcripts, insights, sprints, commitments, tasks, and portal access for this client. This cannot be undone.`}
+          confirmText={isDeleting ? 'Deleting...' : 'Delete Client'}
+          variant="destructive"
+          onConfirm={handleDeleteClient}
         />
       </PageLayout>
     </ProtectedRoute>

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -2,4 +2,4 @@
 // auto-open new tab on meeting end, the "Open Thrill Form" overlay button,
 // and the Thrill Form responses card on the session overview tab are all
 // hidden. Flip to true (and deploy) to release.
-export const THRILL_FORM_ENABLED = false
+export const THRILL_FORM_ENABLED = true


### PR DESCRIPTION
## Summary

- Flip `THRILL_FORM_ENABLED` to `true` in `src/lib/features.ts`. Frontend changes that depend on it (auto-open Thrill Form tab on meeting end at `client-meeting/[token]/page.tsx`, the "Open Thrill Form" fallback button on the meeting-ended overlay, and the Thrill Form responses card on the coach's session overview tab) are already shipped behind the flag. Backend flag flip is in coach-sidekick-backend PR #40.
- Add a "Delete Client" action to the clients page: new `Trash2` dropdown item in `ClientCard` opens a confirmation dialog, hits `ClientService.deleteClient`, toasts on success, and invalidates the clients query.

## Test plan

- [ ] Open a live client meeting, end the session → Thrill Form tab auto-opens; if blocked, the overlay "Open Thrill Form" button works
- [ ] Coach session detail page shows the Thrill Form responses card next to the pre-session card after a 1-on-1 session completes
- [ ] Group session does NOT trigger a Thrill Form (backend skips by design)
- [ ] Click delete on a client card → confirmation dialog appears → confirm → client removed from list, toast shown