### PR TITLE
Collapse upcoming sessions beyond 3 on dashboard

### DIFF
--- a/src/components/dashboard/upcoming-sessions.tsx
+++ b/src/components/dashboard/upcoming-sessions.tsx
@@ -14,6 +14,8 @@ import {
   Pencil,
   Loader2,
   RotateCw,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -39,7 +41,9 @@ export function UpcomingSessions() {
   const [openCalendarId, setOpenCalendarId] = useState<string | null>(null)
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null)
   const [editingTitle, setEditingTitle] = useState('')
+  const [expanded, setExpanded] = useState(false)
   const titleInputRef = useRef<HTMLInputElement>(null)
+  const COLLAPSE_THRESHOLD = 3
 
   useEffect(() => {
     if (editingTitleId && titleInputRef.current) {
@@ -87,108 +91,131 @@ export function UpcomingSessions() {
       </div>
 
       <div className="space-y-2">
-        {sessions.map(session => {
-          const scheduledDate = session.scheduled_for
-            ? new Date(session.scheduled_for)
-            : null
-          const isOverdue = scheduledDate ? isPast(scheduledDate) : false
+        {(expanded ? sessions : sessions.slice(0, COLLAPSE_THRESHOLD)).map(
+          session => {
+            const scheduledDate = session.scheduled_for
+              ? new Date(session.scheduled_for)
+              : null
+            const isOverdue = scheduledDate ? isPast(scheduledDate) : false
 
-          return (
-            <div
-              key={session.id}
-              className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
-            >
-              {/* Title (editable) */}
-              <div className="flex-1 min-w-0">
-                {editingTitleId === session.id ? (
-                  <input
-                    ref={titleInputRef}
-                    value={editingTitle}
-                    onChange={e => setEditingTitle(e.target.value)}
-                    onBlur={() => handleTitleSave(session.id)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') handleTitleSave(session.id)
-                      if (e.key === 'Escape') setEditingTitleId(null)
-                    }}
-                    className="w-full text-sm font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-0.5 outline-none focus:border-gray-900 dark:focus:border-white"
-                  />
-                ) : (
-                  <button
-                    onClick={() => startEditingTitle(session)}
-                    className="text-sm font-medium text-gray-900 dark:text-white truncate block text-left hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    title="Click to edit title"
-                  >
-                    {session.client_name && session.title
-                      ? session.title
-                      : session.client_name ||
-                        session.title ||
-                        'Scheduled Session'}
-                    <Pencil className="h-2.5 w-2.5 ml-1.5 inline opacity-0 group-hover:opacity-40 transition-opacity" />
-                    {session.google_calendar_event_id && (
-                      <span
-                        title="Synced from Google Calendar"
-                        className="ml-1.5 inline-flex items-center rounded-sm border border-gray-200 dark:border-gray-700 px-1 py-[1px] text-[10px] font-normal text-gray-500 dark:text-gray-400 align-middle"
-                      >
-                        Calendar
-                      </span>
-                    )}
-                  </button>
-                )}
-              </div>
-
-              {/* Date (reschedule) */}
-              <Popover
-                open={openCalendarId === session.id}
-                onOpenChange={open =>
-                  setOpenCalendarId(open ? session.id : null)
-                }
+            return (
+              <div
+                key={session.id}
+                className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
               >
-                <PopoverTrigger asChild>
-                  <button
-                    className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
-                      isOverdue
-                        ? 'text-red-500'
-                        : 'text-gray-500 dark:text-gray-400'
-                    }`}
-                    title="Click to reschedule"
-                  >
-                    <Clock className="h-3 w-3" />
-                    {scheduledDate
-                      ? `${format(scheduledDate, 'MMM d, h:mm a')} (${formatDistanceToNow(scheduledDate, { addSuffix: true })})`
-                      : 'No date'}
-                    <CalendarIcon className="h-2.5 w-2.5 opacity-0 group-hover:opacity-50 transition-opacity" />
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="end">
-                  <Calendar
-                    mode="single"
-                    selected={scheduledDate || undefined}
-                    onSelect={date => handleReschedule(session.id, date)}
-                    disabled={date => date < startOfDay(new Date())}
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
+                {/* Title (editable) */}
+                <div className="flex-1 min-w-0">
+                  {editingTitleId === session.id ? (
+                    <input
+                      ref={titleInputRef}
+                      value={editingTitle}
+                      onChange={e => setEditingTitle(e.target.value)}
+                      onBlur={() => handleTitleSave(session.id)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter') handleTitleSave(session.id)
+                        if (e.key === 'Escape') setEditingTitleId(null)
+                      }}
+                      className="w-full text-sm font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-0.5 outline-none focus:border-gray-900 dark:focus:border-white"
+                    />
+                  ) : (
+                    <button
+                      onClick={() => startEditingTitle(session)}
+                      className="text-sm font-medium text-gray-900 dark:text-white truncate block text-left hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                      title="Click to edit title"
+                    >
+                      {session.client_name && session.title
+                        ? session.title
+                        : session.client_name ||
+                          session.title ||
+                          'Scheduled Session'}
+                      <Pencil className="h-2.5 w-2.5 ml-1.5 inline opacity-0 group-hover:opacity-40 transition-opacity" />
+                      {session.google_calendar_event_id && (
+                        <span
+                          title="Synced from Google Calendar"
+                          className="ml-1.5 inline-flex items-center rounded-sm border border-gray-200 dark:border-gray-700 px-1 py-[1px] text-[10px] font-normal text-gray-500 dark:text-gray-400 align-middle"
+                        >
+                          Calendar
+                        </span>
+                      )}
+                    </button>
+                  )}
+                </div>
 
-              {/* Q&A status + resend */}
-              <div className="flex items-center gap-1.5 shrink-0">
-                {session.questionnaire_completed ? (
-                  <Badge
-                    variant="secondary"
-                    className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-[10px] px-1.5 py-0 h-5"
-                  >
-                    <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
-                    Answered
-                  </Badge>
-                ) : session.questionnaire_sent ? (
-                  <>
+                {/* Date (reschedule) */}
+                <Popover
+                  open={openCalendarId === session.id}
+                  onOpenChange={open =>
+                    setOpenCalendarId(open ? session.id : null)
+                  }
+                >
+                  <PopoverTrigger asChild>
+                    <button
+                      className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
+                        isOverdue
+                          ? 'text-red-500'
+                          : 'text-gray-500 dark:text-gray-400'
+                      }`}
+                      title="Click to reschedule"
+                    >
+                      <Clock className="h-3 w-3" />
+                      {scheduledDate
+                        ? `${format(scheduledDate, 'MMM d, h:mm a')} (${formatDistanceToNow(scheduledDate, { addSuffix: true })})`
+                        : 'No date'}
+                      <CalendarIcon className="h-2.5 w-2.5 opacity-0 group-hover:opacity-50 transition-opacity" />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="end">
+                    <Calendar
+                      mode="single"
+                      selected={scheduledDate || undefined}
+                      onSelect={date => handleReschedule(session.id, date)}
+                      disabled={date => date < startOfDay(new Date())}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+
+                {/* Q&A status + resend */}
+                <div className="flex items-center gap-1.5 shrink-0">
+                  {session.questionnaire_completed ? (
                     <Badge
                       variant="secondary"
-                      className="bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 text-[10px] px-1.5 py-0 h-5"
+                      className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-[10px] px-1.5 py-0 h-5"
                     >
-                      <Mail className="h-2.5 w-2.5 mr-0.5" />
-                      Sent
+                      <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
+                      Answered
                     </Badge>
+                  ) : session.questionnaire_sent ? (
+                    <>
+                      <Badge
+                        variant="secondary"
+                        className="bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 text-[10px] px-1.5 py-0 h-5"
+                      >
+                        <Mail className="h-2.5 w-2.5 mr-0.5" />
+                        Sent
+                      </Badge>
+                      <button
+                        onClick={e => {
+                          e.stopPropagation()
+                          if (session.client_id) {
+                            sendQuestionnaire.mutate({
+                              sessionId: session.id,
+                              clientId: session.client_id,
+                            })
+                          }
+                        }}
+                        disabled={sendQuestionnaire.isPending}
+                        className="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                        title="Resend questionnaire"
+                      >
+                        {sendQuestionnaire.isPending ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <RotateCw className="h-3 w-3" />
+                        )}
+                      </button>
+                    </>
+                  ) : (
                     <button
                       onClick={e => {
                         e.stopPropagation()
@@ -200,50 +227,48 @@ export function UpcomingSessions() {
                         }
                       }}
                       disabled={sendQuestionnaire.isPending}
-                      className="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
-                      title="Resend questionnaire"
+                      className="flex items-center gap-1 text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
                     >
-                      {sendQuestionnaire.isPending ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <RotateCw className="h-3 w-3" />
-                      )}
+                      <Send className="h-2.5 w-2.5" />
+                      Send Q&A
                     </button>
-                  </>
-                ) : (
-                  <button
-                    onClick={e => {
-                      e.stopPropagation()
-                      if (session.client_id) {
-                        sendQuestionnaire.mutate({
-                          sessionId: session.id,
-                          clientId: session.client_id,
-                        })
-                      }
-                    }}
-                    disabled={sendQuestionnaire.isPending}
-                    className="flex items-center gap-1 text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
-                  >
-                    <Send className="h-2.5 w-2.5" />
-                    Send Q&A
-                  </button>
-                )}
-              </div>
+                  )}
+                </div>
 
-              {/* Open */}
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 text-xs px-2 shrink-0 text-gray-500 hover:text-gray-900 dark:hover:text-white"
-                onClick={() => router.push(`/sessions/${session.id}`)}
-              >
-                Open
-                <ArrowRight className="h-3 w-3 ml-1" />
-              </Button>
-            </div>
-          )
-        })}
+                {/* Open */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs px-2 shrink-0 text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                  onClick={() => router.push(`/sessions/${session.id}`)}
+                >
+                  Open
+                  <ArrowRight className="h-3 w-3 ml-1" />
+                </Button>
+              </div>
+            )
+          },
+        )}
       </div>
+
+      {sessions.length > COLLAPSE_THRESHOLD && (
+        <button
+          onClick={() => setExpanded(v => !v)}
+          className="mt-2 flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="h-3 w-3" />
+              Show less
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-3 w-3" />
+              Show {sessions.length - COLLAPSE_THRESHOLD} more
+            </>
+          )}
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

When a coach has many pre-scheduled sessions, the Upcoming Sessions section dominates the dashboard. Now: first 3 always visible; if there are more, a single \`Show N more\` toggle expands the rest. Toggle flips to \`Show less\` when expanded.

- Threshold: \`COLLAPSE_THRESHOLD = 3\` (constant at the top of the component for easy tuning).
- ≤3 sessions: no toggle, all visible (current behavior).
- >3 sessions: first 3 visible by default, toggle below.

## Test plan

- [ ] Dashboard with 3 sessions: shows all, no toggle
- [ ] Dashboard with 5 sessions: shows 3, "Show 2 more" toggle below
- [ ] Click toggle: all 5 shown, label flips to "Show less"