### PR TITLE
Invalidate session detail cache after meeting redirect

### DIFF
--- a/src/app/meeting/[botId]/page.tsx
+++ b/src/app/meeting/[botId]/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from 'react'
 import { useParams } from 'next/navigation'
 import { useRouter } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query-client'
 import { Toast, useToast } from '@/components/ui/toast'
 import { MeetingLoading } from '@/components/meeting/meeting-loading'
 import { MeetingError } from '@/components/meeting/meeting-error'
@@ -14,6 +16,7 @@ import MeetingPanels from './components/meeting-panels'
 export default function MeetingPage() {
   const params = useParams()
   const router = useRouter()
+  const queryClient = useQueryClient()
   const botId = params.botId as string
   const { toast, showToast, closeToast } = useToast()
   const hasShownProcessingToast = useRef(false)
@@ -73,6 +76,9 @@ export default function MeetingPage() {
         const redirectSessionId =
           completedSessionIdRef.current || sessionIdRef.current
         if (redirectSessionId) {
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.sessions.detail(redirectSessionId),
+          })
           if (isGroupSession) {
             router.replace(`/sessions/group/${redirectSessionId}`)
           } else {
@@ -100,6 +106,9 @@ export default function MeetingPage() {
           // Navigate to session details page if sessionId exists, otherwise go to dashboard
           // Use replace() so the meeting page is not in the history stack
           if (sessionId) {
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.sessions.detail(sessionId),
+            })
             if (isGroupSession) {
               router.replace(`/sessions/group/${sessionId}`)
             } else {


### PR DESCRIPTION
## Summary

- Coaches reported having to hard-refresh after a meeting to see the analysis. Backend was already doing the right thing (`tasks.py:410 auto_trigger_analysis` runs inside the post-meeting chain before the `session:completed` WS event fires, so DB has status=completed + Analysis row before the frontend hears about it).
- Root cause: `useSessionDetails` (`src/hooks/queries/use-session-details.ts:29`) caches with `staleTime: 24h`. The snapshot a coach hydrated by clicking the upcoming session card stuck around through the call. After redirect from `/meeting/[botId]`, the detail page returned the 24h-stale `status='scheduled'` snapshot instantly; the auto-trigger guard's `isSessionComplete` check failed, so the page never called `getAnalysis` for the row sitting in the DB. Hard refresh worked because Next.js full reload drops the cache.
- Fix: invalidate `queryKeys.sessions.detail(sessionId)` at both meeting-page redirect sites (auto-complete on `session:completed`, manual Stop Bot). Prefix-match covers `full-details` plus sibling detail queries. 24h staleTime preserved for cold revisits to old sessions.

## Test plan

- [ ] Open an upcoming session's detail page, leave the tab open
- [ ] Join the meeting via the live link → short call → end it
- [ ] On auto-redirect, confirm post-session UI (status=completed, summary, analysis) appears without a hard refresh
- [ ] Manual Stop Bot path: same fresh-fetch behavior on redirect
- [ ] Group session: redirect through `/sessions/group/{id}` → `/sessions/{id}` also lands on fresh data
- [ ] Regression — cold revisit to an old completed session still loads instantly from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)