### PR TITLE
Allow creating outcomes without linking a vision

### DIFF
--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -501,6 +501,7 @@ export default function ClientDashboard() {
               setOutcomeModalOpen(open)
               if (!open) setEditingOutcome(null)
             }}
+            clientId={clientId ?? ''}
             sprintId={sprints[0]?.id}
             goals={goals.map((g: any) => ({ id: g.id, title: g.title }))}
             target={editingOutcome}

--- a/src/app/clients/[clientId]/components/client-modals.tsx
+++ b/src/app/clients/[clientId]/components/client-modals.tsx
@@ -202,6 +202,7 @@ export function ClientModals({
           setIsOutcomeModalOpen(open)
           if (!open) setEditingOutcome(null)
         }}
+        clientId={client.id}
         sprintId={sprints[0]?.id}
         goals={goals.map((g: any) => ({ id: g.id, title: g.title }))}
         target={editingOutcome}

--- a/src/app/clients/[clientId]/components/unified-creation-modal.tsx
+++ b/src/app/clients/[clientId]/components/unified-creation-modal.tsx
@@ -146,6 +146,7 @@ export function UnifiedCreationModal({
           onOpenChange={open => {
             if (!open) handleClose()
           }}
+          clientId={clientId}
           sprintId={sprints[0]?.id || ''}
           goals={goals.map((g: any) => ({ id: g.id, title: g.title }))}
           onSuccess={handleSuccess}

--- a/src/components/sprints/target-form-modal.tsx
+++ b/src/components/sprints/target-form-modal.tsx
@@ -24,9 +24,9 @@ import { queryKeys } from '@/lib/query-client'
 interface TargetFormModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  clientId: string
   sprintId?: string
   goals?: Array<{ id: string; title: string }>
-  clientId?: string
   onSuccess?: () => void
   target?: any
   mode?: 'create' | 'edit'
@@ -35,9 +35,9 @@ interface TargetFormModalProps {
 export function TargetFormModal({
   open,
   onOpenChange,
+  clientId,
   sprintId,
   goals = [],
-  clientId: _clientId,
   onSuccess,
   target,
   mode = 'create',
@@ -82,11 +82,6 @@ export function TargetFormModal({
       return
     }
 
-    if (selectedGoalIds.length === 0) {
-      toast.error('Please select at least one vision for this outcome')
-      return
-    }
-
     setLoading(true)
 
     try {
@@ -113,6 +108,7 @@ export function TargetFormModal({
         const optimisticId = `temp-${Date.now()}`
 
         const targetData: TargetCreate = {
+          client_id: clientId,
           goal_ids: selectedGoalIds,
           sprint_ids: sprintId ? [sprintId] : [],
           title: formData.title,
@@ -142,7 +138,10 @@ export function TargetFormModal({
         // Close modal and show immediately
         onOpenChange(false)
         toast.success('Outcome Created', {
-          description: `The outcome has been linked to ${selectedGoalIds.length} vision(s)`,
+          description:
+            selectedGoalIds.length > 0
+              ? `The outcome has been linked to ${selectedGoalIds.length} vision(s)`
+              : undefined,
         })
 
         // Actual API call
@@ -195,7 +194,7 @@ export function TargetFormModal({
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
             <div className="space-y-3">
-              <Label>Link to Vision * (select one or more)</Label>
+              <Label>Link to Vision (optional)</Label>
               {goals.length > 0 ? (
                 <div className="flex flex-wrap gap-2">
                   {goals.map(goal => {

--- a/src/types/sprint.ts
+++ b/src/types/sprint.ts
@@ -55,7 +55,8 @@ export interface TargetBase {
 }
 
 export interface TargetCreate extends TargetBase {
-  goal_ids: string[] // Many-to-many with goals
+  client_id: string
+  goal_ids: string[] // Many-to-many with goals (optional — can be empty)
   sprint_ids: string[] // Many-to-many with sprints
   status?: TargetStatus
 }
@@ -72,7 +73,8 @@ export interface TargetUpdate {
 
 export interface Target extends TargetBase {
   id: string
-  goal_ids: string[] // All linked goals (many-to-many)
+  client_id: string
+  goal_ids: string[] // All linked goals (many-to-many, may be empty)
   sprint_ids: string[] // All linked sprints (many-to-many)
   status: TargetStatus
   progress_percentage: number


### PR DESCRIPTION
## Summary
- Removes the "select at least one vision" guard on the outcome creation form
- Vision picker becomes optional (label `Link to Vision (optional)`)
- Sends the new required `client_id` field; three callsites that weren't forwarding it now do
- Success toast omits the "linked to N vision(s)" line when no vision is selected

Pairs with backend PR adding `targets.client_id` and dropping the matching server-side guard.

## Test plan
- [ ] On a client with **no** active visions, open the outcome creation modal → fill title → submit → expect success and the outcome to appear
- [ ] On a client **with** visions, create an outcome with one or more visions selected (regression)
- [ ] Edit a vision-less outcome → expect no "Target has no associated goals" error
- [ ] Client portal dashboard: create an outcome flow still works