### PR TITLE
Scope outcome lists by client_id instead of goal-join

### DIFF
--- a/src/app/clients/[clientId]/components/goals-tree-view.tsx
+++ b/src/app/clients/[clientId]/components/goals-tree-view.tsx
@@ -327,7 +327,9 @@ export function GoalsTreeView({
 
   // Fetch all data
   const { data: goals = [], isLoading: goalsLoading } = useGoals(clientId)
-  const { data: allTargets = [], isLoading: targetsLoading } = useTargets()
+  const { data: clientTargets = [], isLoading: targetsLoading } = useTargets({
+    client_id: clientId,
+  })
   const { data: allSprints = [], isLoading: sprintsLoading } = useSprints({
     client_id: clientId,
   })
@@ -339,15 +341,6 @@ export function GoalsTreeView({
   const allCommitments = commitmentsData?.commitments || []
   const isLoading =
     goalsLoading || targetsLoading || sprintsLoading || commitmentsLoading
-
-  // Filter targets by client (through goals)
-  const clientTargets = useMemo(() => {
-    const goalIds = goals.map((g: any) => g.id)
-    return allTargets.filter((t: any) =>
-      // Check if any of the target's goals match client goals
-      t.goal_ids?.some((gid: string) => goalIds.includes(gid)),
-    )
-  }, [allTargets, goals])
 
   // Filter out completed items when toggle is on
   const visibleGoals = useMemo(() => {

--- a/src/app/clients/[clientId]/components/overview-tab.tsx
+++ b/src/app/clients/[clientId]/components/overview-tab.tsx
@@ -75,18 +75,13 @@ export function OverviewTab({
   })
 
   const { data: goalsData } = useGoals(client.id)
-  const { data: allTargets = [] } = useTargets()
+  const { data: clientTargets = [] } = useTargets({ client_id: client.id })
 
   // Fetch client-specific resources for the compact card
   const { data: clientResourcesData } = useResources({
     client_id: client.id,
     limit: 3,
   })
-
-  // Filter targets by client's goals
-  const clientTargets = allTargets.filter((t: any) =>
-    goalsData?.some((g: any) => t.goal_ids?.includes(g.id)),
-  )
 
   // Filter commitments based on selection
   const filteredCommitments = useMemo(() => {

--- a/src/components/commitments/commitment-create-panel.tsx
+++ b/src/components/commitments/commitment-create-panel.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useRef } from 'react'
 import { format } from 'date-fns'
 import { formatDate } from '@/lib/date-utils'
 import { useCreateCommitment } from '@/hooks/mutations/use-commitment-mutations'
-import { useGoals } from '@/hooks/queries/use-goals'
 import { useSprints } from '@/hooks/queries/use-sprints'
 import { useTargets } from '@/hooks/queries/use-targets'
 import { useAuth } from '@/contexts/auth-context'
@@ -64,15 +63,9 @@ export function CommitmentCreatePanel({
   const [selectedSprintIds, setSelectedSprintIds] = useState<string[]>([])
   const [dueDateOpen, setDueDateOpen] = useState(false)
 
-  // Fetch goals, sprints, and targets for linking
-  const { data: goals = [] } = useGoals(clientId)
+  // Fetch sprints and targets for linking
   const { data: allSprints = [] } = useSprints({ client_id: clientId })
-  const { data: allTargets = [] } = useTargets()
-
-  // Filter targets by client's goals
-  const clientTargets = allTargets.filter((t: any) =>
-    goals.some((g: any) => t.goal_ids?.includes(g.id)),
-  )
+  const { data: clientTargets = [] } = useTargets({ client_id: clientId })
 
   // Reset form when panel opens
   useEffect(() => {

--- a/src/components/sprints/sprint-form-modal.tsx
+++ b/src/components/sprints/sprint-form-modal.tsx
@@ -28,7 +28,6 @@ import { CalendarIcon, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { queryKeys } from '@/lib/query-client'
 import { useTargets } from '@/hooks/queries/use-targets'
-import { useGoals } from '@/hooks/queries/use-goals'
 
 interface SprintFormModalProps {
   open: boolean
@@ -79,14 +78,8 @@ export function SprintFormModal({
     }
   }, [open, isEdit, sprint])
 
-  // Fetch goals and targets for the client
-  const { data: goals = [] } = useGoals(clientId)
-  const { data: allTargets = [] } = useTargets()
-
-  // Filter targets that belong to this client (via goals)
-  const clientTargets = allTargets.filter((t: any) =>
-    t.goal_ids?.some((gid: string) => goals.some((g: any) => g.id === gid)),
-  )
+  // Fetch targets for the client
+  const { data: clientTargets = [] } = useTargets({ client_id: clientId })
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/hooks/queries/use-outcomes-grouped.ts
+++ b/src/hooks/queries/use-outcomes-grouped.ts
@@ -32,7 +32,9 @@ export function useOutcomesGroupedByGoal(
   clientId: string | undefined,
 ): GroupedOutcomesResult {
   const { data: goals = [], isLoading: goalsLoading } = useGoals(clientId)
-  const { data: allTargets = [], isLoading: targetsLoading } = useTargets()
+  const { data: clientTargets = [], isLoading: targetsLoading } = useTargets({
+    client_id: clientId,
+  })
   const { data: allSprints = [], isLoading: sprintsLoading } = useSprints({
     client_id: clientId,
   })
@@ -40,7 +42,7 @@ export function useOutcomesGroupedByGoal(
   const isLoading = goalsLoading || targetsLoading || sprintsLoading
 
   const { groupedOutcomes, ungroupedOutcomes, clientOutcomes } = useMemo(() => {
-    if (!clientId || goals.length === 0) {
+    if (!clientId) {
       return {
         groupedOutcomes: [],
         ungroupedOutcomes: [],
@@ -48,15 +50,10 @@ export function useOutcomesGroupedByGoal(
       }
     }
 
-    // Get goal IDs for this client
     const goalIds = new Set(goals.map(g => g.id))
 
-    // Filter targets that belong to this client (via goals)
-    const clientTargets = allTargets.filter((t: Target) =>
-      t.goal_ids?.some((gid: string) => goalIds.has(gid)),
-    )
-
-    // Group by first linked goal (primary goal)
+    // Group by first linked goal (primary goal). Outcomes with no vision
+    // or whose primary vision belongs to another client land in ungrouped.
     const grouped: Map<string, Target[]> = new Map()
     const ungrouped: Target[] = []
 
@@ -74,7 +71,6 @@ export function useOutcomesGroupedByGoal(
       }
     }
 
-    // Convert to array of OutcomeGroup
     const result: OutcomeGroup[] = goals
       .map(goal => ({
         goal,
@@ -87,7 +83,7 @@ export function useOutcomesGroupedByGoal(
       ungroupedOutcomes: ungrouped,
       clientOutcomes: clientTargets,
     }
-  }, [clientId, goals, allTargets])
+  }, [clientId, goals, clientTargets])
 
   return {
     groupedOutcomes,


### PR DESCRIPTION
## Summary
Five frontend callsites were doing client-side filtering of outcomes by joining through `goal_ids`. After the backend switched to scoping outcomes by `Target.client_id`, that client-side filter silently drops any vision-less outcome — even though the API returns it correctly.

Replaced the `useTargets()` + manual filter with `useTargets({ client_id })` in:
- `goals-tree-view.tsx` (the tree view showing META PERFORMANCE OUTCOMES)
- `overview-tab.tsx`
- `commitment-create-panel.tsx`
- `sprint-form-modal.tsx`
- `use-outcomes-grouped.ts`

This was the user-visible bug after the prior PR landed: outcomes existed in the DB with `client_id` set but no goal links, and the tree view showed them as empty.

## Test plan
- [ ] On a client with vision-less outcomes, the META PERFORMANCE OUTCOMES section now lists them
- [ ] On a client with vision-linked outcomes (regression), tree view + sprint modal + commitment panel still show them
- [ ] Outcome creation modal flow unchanged