### PR TITLE
Design system migration + client portal redesign + hotfixes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,16 +9,41 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 })
 
+// Design-system guardrail: ban raw Tailwind palette utilities and gradient
+// utilities. All color must flow through the DS tokens (ink/paper/surface/line
+// + forest/vermillion/amber-token/indigo/ds-accent). See globals.css.
+const DS_PALETTE_REGEX =
+  String.raw`\b(?:bg|text|border|ring|from|to|via|divide|outline|placeholder|fill|stroke|caret|accent|decoration)-(?:gray|neutral|zinc|slate|stone|red|orange|amber|yellow|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+\b`
+const DS_GRADIENT_REGEX = String.raw`\bbg-gradient-to-[a-z]+\b`
+
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': ['error', { 
+      '@typescript-eslint/no-unused-vars': ['error', {
         'argsIgnorePattern': '^_',
         'varsIgnorePattern': '^_'
       }],
       'react-hooks/exhaustive-deps': 'warn',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: `Literal[value=/${DS_PALETTE_REGEX}/]`,
+          message:
+            'Use a DS token (bg-ink, text-ink-3, bg-forest, bg-forest-bg, etc.) instead of a raw Tailwind palette utility. See src/app/globals.css.',
+        },
+        {
+          selector: `TemplateElement[value.raw=/${DS_PALETTE_REGEX}/]`,
+          message:
+            'Use a DS token (bg-ink, text-ink-3, bg-forest, bg-forest-bg, etc.) instead of a raw Tailwind palette utility. See src/app/globals.css.',
+        },
+        {
+          selector: `Literal[value=/${DS_GRADIENT_REGEX}/]`,
+          message:
+            'Gradients are forbidden by the design system. Replace with a solid surface + colored dot/icon.',
+        },
+      ],
     },
   },
 ]

--- a/src/app/admin/access/components/client-access-view.tsx
+++ b/src/app/admin/access/components/client-access-view.tsx
@@ -164,15 +164,15 @@ export default function ClientAccessView({
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'super_admin':
-        return 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800'
+        return 'bg-vermillion-bg text-vermillion border-vermillion '
       case 'admin':
-        return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent '
       case 'coach':
-        return 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+        return 'bg-forest-bg text-forest border-forest '
       case 'viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 

--- a/src/app/admin/access/components/coach-delegation-view.tsx
+++ b/src/app/admin/access/components/coach-delegation-view.tsx
@@ -332,7 +332,7 @@ export default function CoachDelegationView({
                 <div className="flex items-start justify-between">
                   <div className="flex items-center gap-3">
                     <Avatar className="h-12 w-12">
-                      <AvatarFallback className="bg-blue-100 dark:bg-blue-900/30">
+                      <AvatarFallback className="bg-ds-accent-bg ">
                         {getUserInitials(
                           assignment.coach.email,
                           assignment.coach.full_name,
@@ -382,7 +382,7 @@ export default function CoachDelegationView({
                           >
                             <div className="flex items-center gap-2">
                               <Avatar className="h-8 w-8">
-                                <AvatarFallback className="text-xs bg-purple-100 dark:bg-purple-900/30">
+                                <AvatarFallback className="text-xs bg-indigo-bg ">
                                   {getUserInitials(
                                     admin.email,
                                     admin.full_name,
@@ -429,7 +429,7 @@ export default function CoachDelegationView({
                 <div className="flex items-start justify-between">
                   <div className="flex items-center gap-3">
                     <Avatar className="h-12 w-12">
-                      <AvatarFallback className="bg-purple-100 dark:bg-purple-900/30">
+                      <AvatarFallback className="bg-indigo-bg ">
                         {getUserInitials(
                           assignment.admin.email,
                           assignment.admin.full_name,
@@ -490,7 +490,7 @@ export default function CoachDelegationView({
                           >
                             <div className="flex items-center gap-2">
                               <Avatar className="h-8 w-8">
-                                <AvatarFallback className="text-xs bg-blue-100 dark:bg-blue-900/30">
+                                <AvatarFallback className="text-xs bg-ds-accent-bg ">
                                   {getUserInitials(
                                     coach.email,
                                     coach.full_name,

--- a/src/app/admin/access/components/hierarchy-view.tsx
+++ b/src/app/admin/access/components/hierarchy-view.tsx
@@ -376,13 +376,13 @@ export default function HierarchyView({
   const getNodeColor = (type: string) => {
     switch (type) {
       case 'admin':
-        return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+        return 'bg-indigo-bg text-indigo '
       case 'coach':
-        return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+        return 'bg-ds-accent-bg text-ds-accent '
       case 'client':
-        return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+        return 'bg-forest-bg text-forest '
       default:
-        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
+        return 'bg-surface-3 text-ink-2 '
     }
   }
 
@@ -422,7 +422,7 @@ export default function HierarchyView({
         <div
           className={`flex items-center gap-3 p-3 rounded-lg transition-all ${
             matchesSearch
-              ? 'bg-yellow-50 border-2 border-yellow-300 dark:bg-yellow-900/30 dark:border-yellow-700'
+              ? 'bg-amber-token-bg border-2 border-amber-token '
               : 'hover:bg-muted/50 border-2 border-transparent'
           }`}
         >

--- a/src/app/admin/access/components/list-view.tsx
+++ b/src/app/admin/access/components/list-view.tsx
@@ -149,15 +149,15 @@ export default function ListView({
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'super_admin':
-        return 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800'
+        return 'bg-vermillion-bg text-vermillion border-vermillion '
       case 'admin':
-        return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent '
       case 'coach':
-        return 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+        return 'bg-forest-bg text-forest border-forest '
       case 'viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 

--- a/src/app/admin/client-access/page.tsx
+++ b/src/app/admin/client-access/page.tsx
@@ -373,15 +373,15 @@ export default function ClientAccessPage() {
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'super_admin':
-        return 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800'
+        return 'bg-vermillion-bg text-vermillion border-vermillion '
       case 'admin':
-        return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent '
       case 'coach':
-        return 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+        return 'bg-forest-bg text-forest border-forest '
       case 'viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 
@@ -408,13 +408,13 @@ export default function ClientAccessPage() {
   const getNodeColor = (type: string) => {
     switch (type) {
       case 'admin':
-        return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+        return 'bg-indigo-bg text-indigo '
       case 'coach':
-        return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+        return 'bg-ds-accent-bg text-ds-accent '
       case 'client':
-        return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+        return 'bg-forest-bg text-forest '
       default:
-        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
+        return 'bg-surface-3 text-ink-2 '
     }
   }
 
@@ -423,19 +423,15 @@ export default function ClientAccessPage() {
 
     return (
       <div key={node.id} className={`${level > 0 ? 'ml-8' : ''}`}>
-        <div className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+        <div className="flex items-center gap-3 p-3 rounded-lg hover:bg-paper transition-colors">
           <div className={`p-2 rounded-lg ${getNodeColor(node.type)}`}>
             {getNodeIcon(node.type)}
           </div>
           <div className="flex-1">
             <div className="flex items-center gap-2">
-              <span className="font-medium text-gray-900 dark:text-white">
-                {node.name}
-              </span>
+              <span className="font-medium text-ink ">{node.name}</span>
               {node.email && (
-                <span className="text-xs text-gray-500 dark:text-gray-400">
-                  ({node.email})
-                </span>
+                <span className="text-xs text-ink-3 ">({node.email})</span>
               )}
               {isSuper && (
                 <Badge variant="destructive" className="text-xs">
@@ -453,8 +449,8 @@ export default function ClientAccessPage() {
                   className={cn(
                     'text-xs',
                     node.access_level === 'full'
-                      ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
-                      : 'bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800',
+                      ? 'bg-forest-bg text-forest border-forest '
+                      : 'bg-amber-token-bg text-amber-token border-amber-token ',
                   )}
                 >
                   {node.access_level === 'full' ? 'Full Access' : 'Read Only'}
@@ -462,20 +458,18 @@ export default function ClientAccessPage() {
               )}
             </div>
             {node.type === 'client' && (
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                Client Account
-              </p>
+              <p className="text-xs text-ink-3 mt-0.5">Client Account</p>
             )}
           </div>
           {node.children.length > 0 && (
-            <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-1 text-xs text-ink-3 ">
               <Network className="h-3 w-3" />
               <span>{node.children.length}</span>
             </div>
           )}
         </div>
         {node.children.length > 0 && (
-          <div className="ml-4 border-l-2 border-gray-200 dark:border-gray-700 pl-4 mt-2">
+          <div className="ml-4 border-l-2 border-line pl-4 mt-2">
             {node.children.map(child => renderHierarchyNode(child, level + 1))}
           </div>
         )}
@@ -488,12 +482,8 @@ export default function ClientAccessPage() {
       {/* Page Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-            Client Access
-          </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-2">
-            Manage client access assignments
-          </p>
+          <h1 className="text-3xl font-bold text-ink ">Client Access</h1>
+          <p className="text-ink-3 mt-2">Manage client access assignments</p>
         </div>
         <div className="flex gap-2">
           <Button
@@ -530,7 +520,7 @@ export default function ClientAccessPage() {
               </TabsList>
             </Tabs>
             <div className="relative w-64">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
               <Input
                 placeholder="Search..."
                 value={searchQuery}
@@ -561,10 +551,8 @@ export default function ClientAccessPage() {
               </div>
             ) : hierarchyData.length === 0 ? (
               <div className="text-center py-12">
-                <Building className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-                <p className="text-gray-500 dark:text-gray-400">
-                  No hierarchy data available
-                </p>
+                <Building className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+                <p className="text-ink-3 ">No hierarchy data available</p>
               </div>
             ) : (
               <div className="space-y-2">
@@ -616,14 +604,14 @@ export default function ClientAccessPage() {
                 <TableRow key={client.client_id}>
                   <TableCell>
                     <div className="flex items-center gap-2">
-                      <div className="h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-                        <Users className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+                      <div className="h-10 w-10 rounded-full bg-surface-3 flex items-center justify-center">
+                        <Users className="h-5 w-5 text-ink-3 " />
                       </div>
                       <div>
-                        <p className="font-medium text-gray-900 dark:text-white">
+                        <p className="font-medium text-ink ">
                           {client.client_name}
                         </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                        <p className="text-xs text-ink-3 ">
                           ID: {client.client_id}
                         </p>
                       </div>
@@ -639,11 +627,11 @@ export default function ClientAccessPage() {
                           >
                             <div className="flex items-center gap-2">
                               <div>
-                                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                                <p className="text-sm font-medium text-ink ">
                                   {user.email}
                                 </p>
                                 {user.full_name && (
-                                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                                  <p className="text-xs text-ink-3 ">
                                     {user.full_name}
                                   </p>
                                 )}
@@ -667,8 +655,8 @@ export default function ClientAccessPage() {
                                 className={cn(
                                   'text-xs',
                                   user.access_level === 'full'
-                                    ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
-                                    : 'bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800',
+                                    ? 'bg-forest-bg text-forest border-forest '
+                                    : 'bg-amber-token-bg text-amber-token border-amber-token ',
                                 )}
                               >
                                 {user.access_level === 'full' ? (
@@ -691,15 +679,13 @@ export default function ClientAccessPage() {
                                 )
                               }
                             >
-                              <UserMinus className="h-4 w-4 text-red-600" />
+                              <UserMinus className="h-4 w-4 text-vermillion" />
                             </Button>
                           </div>
                         ))}
                       </div>
                     ) : (
-                      <p className="text-sm text-gray-400 dark:text-gray-500">
-                        No users assigned
-                      </p>
+                      <p className="text-sm text-ink-4 ">No users assigned</p>
                     )}
                   </TableCell>
                   <TableCell className="text-right">
@@ -735,9 +721,9 @@ export default function ClientAccessPage() {
             <div>
               <Label htmlFor="client">Client</Label>
               {selectedClient ? (
-                <div className="mt-2 p-2 bg-gray-50 dark:bg-gray-800 rounded">
+                <div className="mt-2 p-2 bg-paper rounded">
                   <p className="font-medium">{selectedClient.client_name}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <p className="text-xs text-ink-3 ">
                     ID: {selectedClient.client_id}
                   </p>
                 </div>
@@ -894,7 +880,7 @@ export default function ClientAccessPage() {
                   {accessMatrix.map(client => (
                     <div
                       key={client.client_id}
-                      className="flex items-center space-x-2 p-2 hover:bg-gray-50 dark:hover:bg-gray-800 rounded"
+                      className="flex items-center space-x-2 p-2 hover:bg-paper rounded"
                     >
                       <Checkbox
                         id={`client-${client.client_id}`}
@@ -926,7 +912,7 @@ export default function ClientAccessPage() {
                       >
                         {client.client_name}
                         {client.assigned_users.length > 0 && (
-                          <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+                          <span className="text-xs text-ink-3 ml-2">
                             ({client.assigned_users.length} users assigned)
                           </span>
                         )}
@@ -935,7 +921,7 @@ export default function ClientAccessPage() {
                   ))}
                 </div>
               </div>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+              <p className="text-xs text-ink-3 mt-2">
                 {bulkAssignForm.client_ids.length} clients selected
               </p>
             </div>

--- a/src/app/admin/clients/import/page.tsx
+++ b/src/app/admin/clients/import/page.tsx
@@ -268,10 +268,10 @@ export default function ImportClientsPage() {
       </div>
 
       <div>
-        <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400 bg-clip-text text-transparent">
+        <h1 className="text-3xl font-bold  bg-clip-text text-transparent">
           Import Clients
         </h1>
-        <p className="text-gray-500 dark:text-gray-400 mt-2">
+        <p className="text-ink-3 mt-2">
           Upload a CSV file to bulk import clients
         </p>
       </div>
@@ -283,11 +283,11 @@ export default function ImportClientsPage() {
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
                 step === s
-                  ? 'bg-blue-600 text-white'
+                  ? 'bg-ds-accent text-ink-on-dark'
                   : ['upload', 'mapping', 'preview', 'result'].indexOf(step) >
                       index
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
+                    ? 'bg-forest text-ink-on-dark'
+                    : 'bg-surface-3 text-ink-3 '
               }`}
             >
               {['upload', 'mapping', 'preview', 'result'].indexOf(step) >
@@ -301,7 +301,7 @@ export default function ImportClientsPage() {
               {s}
             </span>
             {index < 3 && (
-              <div className="w-12 h-0.5 bg-gray-200 dark:bg-gray-700 mx-4 hidden sm:block" />
+              <div className="w-12 h-0.5 bg-surface-3 mx-4 hidden sm:block" />
             )}
           </div>
         ))}
@@ -314,9 +314,9 @@ export default function ImportClientsPage() {
             <CardTitle>Upload CSV File</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-12 text-center">
-              <FileSpreadsheet className="h-12 w-12 text-gray-400 dark:text-gray-500 mx-auto mb-4" />
-              <p className="text-gray-600 dark:text-gray-400 mb-4">
+            <div className="border-2 border-dashed border-line-strong rounded-lg p-12 text-center">
+              <FileSpreadsheet className="h-12 w-12 text-ink-4 mx-auto mb-4" />
+              <p className="text-ink-3 mb-4">
                 Drag and drop a CSV file here, or click to browse
               </p>
               <input
@@ -332,7 +332,7 @@ export default function ImportClientsPage() {
                   Choose File
                 </label>
               </Button>
-              <p className="text-sm text-gray-400 dark:text-gray-500 mt-4">
+              <p className="text-sm text-ink-4 mt-4">
                 CSV should have headers in the first row. Supported columns:
                 Name (required), Email, Phone, Notes, Tags, Coach Email
               </p>
@@ -348,7 +348,7 @@ export default function ImportClientsPage() {
             <CardTitle>Map Columns</CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-ink-3 ">
               Map each CSV column to a client field. At minimum, you must map
               the Name field.
             </p>
@@ -365,7 +365,7 @@ export default function ImportClientsPage() {
                 {csvColumns.map(col => (
                   <TableRow key={col.header}>
                     <TableCell className="font-medium">{col.header}</TableCell>
-                    <TableCell className="text-sm text-gray-500 dark:text-gray-400">
+                    <TableCell className="text-sm text-ink-3 ">
                       {col.sampleValues.slice(0, 2).join(', ')}
                     </TableCell>
                     <TableCell>
@@ -433,7 +433,7 @@ export default function ImportClientsPage() {
             <CardTitle>Preview Import</CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-ink-3 ">
               Review the first 10 rows before importing. Total rows to import:{' '}
               <strong>{csvData.length - 1}</strong>
             </p>
@@ -453,7 +453,7 @@ export default function ImportClientsPage() {
                   <TableRow key={index}>
                     <TableCell className="font-medium">
                       {row.name || (
-                        <span className="text-red-500">Missing</span>
+                        <span className="text-vermillion">Missing</span>
                       )}
                     </TableCell>
                     <TableCell>{row.email || '-'}</TableCell>
@@ -495,32 +495,30 @@ export default function ImportClientsPage() {
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="flex gap-4">
-              <div className="flex-1 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4 text-center">
-                <div className="text-3xl font-bold text-green-600 dark:text-green-400">
+              <div className="flex-1 bg-forest-bg border border-forest rounded-lg p-4 text-center">
+                <div className="text-3xl font-bold text-forest ">
                   {importResult.success_count}
                 </div>
-                <div className="text-sm text-green-700 dark:text-green-400">
+                <div className="text-sm text-forest ">
                   Imported Successfully
                 </div>
               </div>
-              <div className="flex-1 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4 text-center">
-                <div className="text-3xl font-bold text-red-600 dark:text-red-400">
+              <div className="flex-1 bg-vermillion-bg border border-vermillion rounded-lg p-4 text-center">
+                <div className="text-3xl font-bold text-vermillion ">
                   {importResult.failed_count}
                 </div>
-                <div className="text-sm text-red-700 dark:text-red-400">
-                  Failed
-                </div>
+                <div className="text-sm text-vermillion ">Failed</div>
               </div>
             </div>
 
             {importResult.errors.length > 0 && (
               <div>
                 <h3 className="font-medium mb-2">Errors:</h3>
-                <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4 max-h-60 overflow-y-auto">
+                <div className="bg-vermillion-bg border border-vermillion rounded-lg p-4 max-h-60 overflow-y-auto">
                   {importResult.errors.map((err, index) => (
                     <div key={index} className="flex items-start gap-2 mb-2">
-                      <AlertCircle className="h-4 w-4 text-red-500 dark:text-red-400 mt-0.5" />
-                      <span className="text-sm text-red-700 dark:text-red-400">
+                      <AlertCircle className="h-4 w-4 text-vermillion mt-0.5" />
+                      <span className="text-sm text-vermillion ">
                         Row {err.row}: {err.error}
                       </span>
                     </div>

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -244,10 +244,10 @@ export default function AdminClientsPage() {
       <div>
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400 bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold  bg-clip-text text-transparent">
               Client Management
             </h1>
-            <p className="text-gray-500 dark:text-gray-400 mt-2">
+            <p className="text-ink-3 mt-2">
               View and manage all clients across the organization
             </p>
           </div>
@@ -279,10 +279,10 @@ export default function AdminClientsPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Total Clients
                 </CardTitle>
-                <Users className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <Users className="h-4 w-4 text-ink-4 " />
               </div>
             </CardHeader>
             <CardContent>
@@ -298,17 +298,17 @@ export default function AdminClientsPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   With Portal Access
                 </CardTitle>
-                <CheckCircle className="h-4 w-4 text-green-500" />
+                <CheckCircle className="h-4 w-4 text-forest" />
               </div>
             </CardHeader>
             <CardContent>
               {loadingStats ? (
                 <Skeleton className="h-8 w-16" />
               ) : (
-                <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+                <div className="text-2xl font-bold text-forest ">
                   {stats?.total_with_portal_access || 0}
                 </div>
               )}
@@ -317,17 +317,17 @@ export default function AdminClientsPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Total Sessions
                 </CardTitle>
-                <Calendar className="h-4 w-4 text-blue-500" />
+                <Calendar className="h-4 w-4 text-ds-accent" />
               </div>
             </CardHeader>
             <CardContent>
               {loadingStats ? (
                 <Skeleton className="h-8 w-16" />
               ) : (
-                <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+                <div className="text-2xl font-bold text-ds-accent ">
                   {stats?.total_sessions || 0}
                 </div>
               )}
@@ -336,17 +336,17 @@ export default function AdminClientsPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Coaches
                 </CardTitle>
-                <UserCheck className="h-4 w-4 text-purple-500" />
+                <UserCheck className="h-4 w-4 text-indigo" />
               </div>
             </CardHeader>
             <CardContent>
               {loadingStats ? (
                 <Skeleton className="h-8 w-16" />
               ) : (
-                <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+                <div className="text-2xl font-bold text-indigo ">
                   {stats?.by_coach?.length || 0}
                 </div>
               )}
@@ -360,7 +360,7 @@ export default function AdminClientsPage() {
         <CardHeader className="pb-3">
           <div className="flex items-center gap-4 flex-wrap">
             <div className="relative flex-1 min-w-[200px] max-w-md">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
               <Input
                 placeholder="Search by name or email..."
                 value={searchQuery}
@@ -416,18 +416,18 @@ export default function AdminClientsPage() {
 
       {/* Bulk Action Bar */}
       {selectedClients.size > 0 && (
-        <Card className="bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-800">
+        <Card className="bg-ds-accent-bg border-ds-accent ">
           <CardContent className="py-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-4">
-                <span className="text-sm font-medium text-blue-700 dark:text-blue-400">
+                <span className="text-sm font-medium text-ds-accent ">
                   {selectedClients.size} client(s) selected
                 </span>
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={clearSelection}
-                  className="text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
+                  className="text-ds-accent hover:text-ds-accent "
                 >
                   Clear selection
                 </Button>
@@ -473,11 +473,9 @@ export default function AdminClientsPage() {
             </div>
           ) : clients.length === 0 ? (
             <div className="text-center py-12">
-              <Users className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-              <p className="text-gray-500 dark:text-gray-400">
-                No clients found
-              </p>
-              <p className="text-gray-400 dark:text-gray-500 text-sm mt-1">
+              <Users className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+              <p className="text-ink-3 ">No clients found</p>
+              <p className="text-ink-4 text-sm mt-1">
                 Try adjusting your filters
               </p>
             </div>
@@ -515,7 +513,7 @@ export default function AdminClientsPage() {
                       <div>
                         <div className="font-medium">{client.name}</div>
                         {client.email && (
-                          <div className="text-sm text-gray-500 dark:text-gray-400">
+                          <div className="text-sm text-ink-3 ">
                             {client.email}
                           </div>
                         )}
@@ -526,17 +524,13 @@ export default function AdminClientsPage() {
                         <div className="font-medium">
                           {client.coach_name || 'Unknown'}
                         </div>
-                        <div className="text-gray-500 dark:text-gray-400">
-                          {client.coach_email}
-                        </div>
+                        <div className="text-ink-3 ">{client.coach_email}</div>
                       </div>
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-wrap gap-1">
                         {client.programs.length === 0 ? (
-                          <span className="text-gray-400 dark:text-gray-500 text-sm">
-                            None
-                          </span>
+                          <span className="text-ink-4 text-sm">None</span>
                         ) : (
                           client.programs.slice(0, 2).map(program => (
                             <Badge
@@ -567,12 +561,12 @@ export default function AdminClientsPage() {
                     </TableCell>
                     <TableCell className="text-center">
                       {client.has_portal_access ? (
-                        <CheckCircle className="h-4 w-4 text-green-500 mx-auto" />
+                        <CheckCircle className="h-4 w-4 text-forest mx-auto" />
                       ) : (
-                        <XCircle className="h-4 w-4 text-gray-300 dark:text-gray-600 mx-auto" />
+                        <XCircle className="h-4 w-4 text-ink-2 mx-auto" />
                       )}
                     </TableCell>
-                    <TableCell className="text-sm text-gray-500 dark:text-gray-400">
+                    <TableCell className="text-sm text-ink-3 ">
                       {formatDateValue(client.last_session_date)}
                     </TableCell>
                     <TableCell>
@@ -594,7 +588,7 @@ export default function AdminClientsPage() {
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
                             onClick={() => openDeleteDialog(client)}
-                            className="text-red-600 dark:text-red-400"
+                            className="text-vermillion "
                           >
                             <Trash2 className="h-4 w-4 mr-2" />
                             Delete
@@ -612,7 +606,7 @@ export default function AdminClientsPage() {
 
       {/* Pagination info */}
       {clientsData && (
-        <div className="text-sm text-gray-500 dark:text-gray-400 text-center">
+        <div className="text-sm text-ink-3 text-center">
           Showing {clients.length} of {clientsData.total} clients
         </div>
       )}

--- a/src/app/admin/coach-access/page.tsx
+++ b/src/app/admin/coach-access/page.tsx
@@ -170,10 +170,10 @@ export default function CoachAccessPage() {
       {/* Page Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
+          <h1 className="text-3xl font-bold  bg-clip-text text-transparent">
             Coach Access Management
           </h1>
-          <p className="text-gray-500 mt-2">
+          <p className="text-ink-3 mt-2">
             Manage admin access to coaches and their clients
           </p>
         </div>
@@ -190,10 +190,10 @@ export default function CoachAccessPage() {
         <Card>
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-medium text-gray-600">
+              <CardTitle className="text-sm font-medium text-ink-3">
                 Total Coaches
               </CardTitle>
-              <UserCheck className="h-4 w-4 text-blue-500" />
+              <UserCheck className="h-4 w-4 text-ds-accent" />
             </div>
           </CardHeader>
           <CardContent>
@@ -203,10 +203,10 @@ export default function CoachAccessPage() {
         <Card>
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-medium text-gray-600">
+              <CardTitle className="text-sm font-medium text-ink-3">
                 Total Admins
               </CardTitle>
-              <Shield className="h-4 w-4 text-purple-500" />
+              <Shield className="h-4 w-4 text-indigo" />
             </div>
           </CardHeader>
           <CardContent>
@@ -216,10 +216,10 @@ export default function CoachAccessPage() {
         <Card>
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-medium text-gray-600">
+              <CardTitle className="text-sm font-medium text-ink-3">
                 Assigned
               </CardTitle>
-              <Link2 className="h-4 w-4 text-green-500" />
+              <Link2 className="h-4 w-4 text-forest" />
             </div>
           </CardHeader>
           <CardContent>
@@ -234,10 +234,10 @@ export default function CoachAccessPage() {
         <Card>
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-medium text-gray-600">
+              <CardTitle className="text-sm font-medium text-ink-3">
                 Unassigned
               </CardTitle>
-              <Unlink className="h-4 w-4 text-gray-400" />
+              <Unlink className="h-4 w-4 text-ink-4" />
             </div>
           </CardHeader>
           <CardContent>
@@ -256,7 +256,7 @@ export default function CoachAccessPage() {
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="flex bg-gray-100 rounded-lg p-1">
+              <div className="flex bg-surface-3 rounded-lg p-1">
                 <Button
                   variant={viewMode === 'coaches' ? 'default' : 'ghost'}
                   size="sm"
@@ -278,7 +278,7 @@ export default function CoachAccessPage() {
               </div>
             </div>
             <div className="relative w-64">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4" />
               <Input
                 placeholder="Search..."
                 value={searchQuery}
@@ -317,7 +317,7 @@ export default function CoachAccessPage() {
                       <AvatarImage
                         src={`https://api.dicebear.com/7.x/initials/svg?seed=${assignment.coach.email}`}
                       />
-                      <AvatarFallback className="bg-gradient-to-br from-blue-100 to-blue-200">
+                      <AvatarFallback className=" ">
                         {getUserInitials(
                           assignment.coach.email,
                           assignment.coach.full_name,
@@ -325,11 +325,11 @@ export default function CoachAccessPage() {
                       </AvatarFallback>
                     </Avatar>
                     <div>
-                      <h3 className="font-semibold text-gray-900">
+                      <h3 className="font-semibold text-ink">
                         {assignment.coach.full_name || assignment.coach.email}
                       </h3>
                       {assignment.coach.full_name && (
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-ink-3">
                           {assignment.coach.email}
                         </p>
                       )}
@@ -340,7 +340,7 @@ export default function CoachAccessPage() {
               <CardContent>
                 <div className="space-y-4">
                   <div className="flex items-center justify-between text-sm">
-                    <span className="text-gray-500">Clients</span>
+                    <span className="text-ink-3">Clients</span>
                     <Badge variant="secondary">
                       <Briefcase className="h-3 w-3 mr-1" />
                       {assignment.clientCount}
@@ -349,7 +349,7 @@ export default function CoachAccessPage() {
 
                   <div>
                     <div className="flex items-center justify-between mb-2">
-                      <span className="text-sm font-medium text-gray-700">
+                      <span className="text-sm font-medium text-ink-2">
                         Assigned Admins
                       </span>
                       {assignment.assignedAdmins.length === 0 && (
@@ -363,11 +363,11 @@ export default function CoachAccessPage() {
                         {assignment.assignedAdmins.map(admin => (
                           <div
                             key={admin.id}
-                            className="flex items-center justify-between p-2 bg-gray-50 rounded-lg"
+                            className="flex items-center justify-between p-2 bg-paper rounded-lg"
                           >
                             <div className="flex items-center gap-2">
                               <Avatar className="h-8 w-8">
-                                <AvatarFallback className="text-xs bg-purple-100">
+                                <AvatarFallback className="text-xs bg-indigo-bg">
                                   {getUserInitials(
                                     admin.email,
                                     admin.full_name,
@@ -393,7 +393,7 @@ export default function CoachAccessPage() {
                         ))}
                       </div>
                     ) : (
-                      <div className="text-center py-4 text-gray-400 text-sm">
+                      <div className="text-center py-4 text-ink-4 text-sm">
                         No admins assigned
                       </div>
                     )}
@@ -417,7 +417,7 @@ export default function CoachAccessPage() {
                       <AvatarImage
                         src={`https://api.dicebear.com/7.x/initials/svg?seed=${assignment.admin.email}`}
                       />
-                      <AvatarFallback className="bg-gradient-to-br from-purple-100 to-purple-200">
+                      <AvatarFallback className=" ">
                         {getUserInitials(
                           assignment.admin.email,
                           assignment.admin.full_name,
@@ -425,11 +425,11 @@ export default function CoachAccessPage() {
                       </AvatarFallback>
                     </Avatar>
                     <div>
-                      <h3 className="font-semibold text-gray-900">
+                      <h3 className="font-semibold text-ink">
                         {assignment.admin.full_name || assignment.admin.email}
                       </h3>
                       {assignment.admin.full_name && (
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-ink-3">
                           {assignment.admin.email}
                         </p>
                       )}
@@ -453,7 +453,7 @@ export default function CoachAccessPage() {
               <CardContent>
                 <div className="space-y-4">
                   <div className="flex items-center justify-between text-sm">
-                    <span className="text-gray-500">Total Clients</span>
+                    <span className="text-ink-3">Total Clients</span>
                     <Badge variant="secondary">
                       <Briefcase className="h-3 w-3 mr-1" />
                       {assignment.totalClients}
@@ -462,7 +462,7 @@ export default function CoachAccessPage() {
 
                   <div>
                     <div className="flex items-center justify-between mb-2">
-                      <span className="text-sm font-medium text-gray-700">
+                      <span className="text-sm font-medium text-ink-2">
                         Assigned Coaches
                       </span>
                       <Badge variant="outline" className="text-xs">
@@ -474,11 +474,11 @@ export default function CoachAccessPage() {
                         {assignment.assignedCoaches.map(coach => (
                           <div
                             key={coach.id}
-                            className="flex items-center justify-between p-2 bg-gray-50 rounded-lg"
+                            className="flex items-center justify-between p-2 bg-paper rounded-lg"
                           >
                             <div className="flex items-center gap-2">
                               <Avatar className="h-8 w-8">
-                                <AvatarFallback className="text-xs bg-blue-100">
+                                <AvatarFallback className="text-xs bg-ds-accent-bg">
                                   {getUserInitials(
                                     coach.email,
                                     coach.full_name,
@@ -504,7 +504,7 @@ export default function CoachAccessPage() {
                         ))}
                       </div>
                     ) : (
-                      <div className="text-center py-4 text-gray-400 text-sm">
+                      <div className="text-center py-4 text-ink-4 text-sm">
                         No coaches assigned
                       </div>
                     )}
@@ -527,7 +527,7 @@ export default function CoachAccessPage() {
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-gray-700">
+              <label className="text-sm font-medium text-ink-2">
                 Select Coach
               </label>
               <Select
@@ -558,7 +558,7 @@ export default function CoachAccessPage() {
             </div>
 
             <div>
-              <label className="text-sm font-medium text-gray-700">
+              <label className="text-sm font-medium text-ink-2">
                 Select Admin
               </label>
               <Select

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -54,27 +54,21 @@ function StatCard({
       onClick={onClick}
     >
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+        <CardTitle className="text-sm font-medium text-ink-3 ">
           {title}
         </CardTitle>
-        <div className="h-10 w-10 rounded-full bg-gray-50 dark:bg-gray-800 flex items-center justify-center">
+        <div className="h-10 w-10 rounded-full bg-paper flex items-center justify-center">
           {icon}
         </div>
       </CardHeader>
       <CardContent>
-        <div className="text-3xl font-bold text-gray-900 dark:text-white">
-          {value}
-        </div>
+        <div className="text-3xl font-bold text-ink ">{value}</div>
         <div className="flex items-center justify-between mt-2">
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            {description}
-          </p>
+          <p className="text-xs text-ink-3 ">{description}</p>
           {trend && (
             <div
               className={`flex items-center gap-1 text-xs font-medium ${
-                trend.isPositive
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                trend.isPositive ? 'text-forest ' : 'text-vermillion '
               }`}
             >
               {trend.isPositive ? (
@@ -87,7 +81,7 @@ function StatCard({
           )}
         </div>
       </CardContent>
-      <div className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-600" />
+      <div className="absolute inset-x-0 bottom-0 h-1  " />
     </Card>
   )
 }
@@ -152,10 +146,10 @@ export default function AdminDashboard() {
       <div className="space-y-8">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400 bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold  bg-clip-text text-transparent">
               Admin Dashboard
             </h1>
-            <p className="text-gray-500 dark:text-gray-400 mt-2">
+            <p className="text-ink-3 mt-2">
               Welcome back, let&apos;s see how things are going
             </p>
           </div>
@@ -201,10 +195,10 @@ export default function AdminDashboard() {
       {/* Page Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400 bg-clip-text text-transparent">
+          <h1 className="text-3xl font-bold  bg-clip-text text-transparent">
             Admin Dashboard
           </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-2">
+          <p className="text-ink-3 mt-2">
             Welcome back, let&apos;s see how things are going
           </p>
         </div>
@@ -216,25 +210,21 @@ export default function AdminDashboard() {
           title="Total Users"
           value={stats.totalUsers}
           description={`${stats.activeUsers} active users`}
-          icon={<Users className="h-5 w-5 text-blue-600 dark:text-blue-400" />}
+          icon={<Users className="h-5 w-5 text-ds-accent " />}
           onClick={() => router.push('/admin/users')}
         />
         <StatCard
           title="Total Clients"
           value={stats.totalClients}
           description={`${stats.assignedClients} assigned`}
-          icon={
-            <UserCheck className="h-5 w-5 text-green-600 dark:text-green-400" />
-          }
+          icon={<UserCheck className="h-5 w-5 text-forest " />}
           onClick={() => router.push('/admin/access')}
         />
         <StatCard
           title="Active Coaches"
           value={stats.roleDistribution.coach + stats.roleDistribution.trainee}
           description="Coaching users"
-          icon={
-            <TrendingUp className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-          }
+          icon={<TrendingUp className="h-5 w-5 text-indigo " />}
           onClick={() => router.push('/admin/roles')}
         />
         <StatCard
@@ -243,9 +233,7 @@ export default function AdminDashboard() {
             stats.roleDistribution.admin + stats.roleDistribution.super_admin
           }
           description="System admins"
-          icon={
-            <Shield className="h-5 w-5 text-orange-600 dark:text-orange-400" />
-          }
+          icon={<Shield className="h-5 w-5 text-amber-token " />}
           onClick={() => router.push('/admin/roles')}
         />
       </div>
@@ -257,7 +245,7 @@ export default function AdminDashboard() {
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               <span>Role Distribution</span>
-              <BarChart3 className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+              <BarChart3 className="h-5 w-5 text-ink-4 " />
             </CardTitle>
             <CardDescription>User roles breakdown</CardDescription>
           </CardHeader>
@@ -274,25 +262,23 @@ export default function AdminDashboard() {
                       <div
                         className={`h-2 w-2 rounded-full ${
                           role === 'super_admin'
-                            ? 'bg-red-500'
+                            ? 'bg-vermillion'
                             : role === 'admin'
-                              ? 'bg-blue-500'
+                              ? 'bg-ds-accent'
                               : role === 'coach'
-                                ? 'bg-green-500'
+                                ? 'bg-forest'
                                 : role === 'trainee'
-                                  ? 'bg-emerald-400'
+                                  ? 'bg-forest'
                                   : role === 'viewer'
-                                    ? 'bg-gray-500'
+                                    ? 'bg-ink-4'
                                     : ''
                         }`}
                       />
-                      <span className="text-sm font-medium text-gray-700 dark:text-gray-300 capitalize">
+                      <span className="text-sm font-medium text-ink-2 capitalize">
                         {role.replace('_', ' ')}
                       </span>
                     </div>
-                    <span className="text-sm font-bold text-gray-900 dark:text-white">
-                      {count}
-                    </span>
+                    <span className="text-sm font-bold text-ink ">{count}</span>
                   </div>
                   <Progress value={percentage} className="h-2" />
                 </div>
@@ -300,10 +286,8 @@ export default function AdminDashboard() {
             })}
             <div className="pt-4 border-t">
               <div className="flex items-center justify-between text-sm">
-                <span className="text-gray-500 dark:text-gray-400">
-                  Total Users with Roles
-                </span>
-                <span className="font-semibold text-gray-900 dark:text-white">
+                <span className="text-ink-3 ">Total Users with Roles</span>
+                <span className="font-semibold text-ink ">
                   {totalRoleUsers}
                 </span>
               </div>
@@ -316,7 +300,7 @@ export default function AdminDashboard() {
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               <span>System Health</span>
-              <Activity className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+              <Activity className="h-5 w-5 text-ink-4 " />
             </CardTitle>
             <CardDescription>
               Current system status and performance
@@ -327,21 +311,21 @@ export default function AdminDashboard() {
               {Object.entries(systemHealth).map(([service, status]) => (
                 <div
                   key={service}
-                  className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800"
+                  className="flex items-center justify-between p-3 rounded-lg bg-paper "
                 >
                   <div className="flex items-center gap-3">
                     <div
                       className={`h-3 w-3 rounded-full ${
                         status === 'operational'
-                          ? 'bg-green-500 animate-pulse'
+                          ? 'bg-forest animate-pulse'
                           : status === 'degraded'
-                            ? 'bg-yellow-500'
+                            ? 'bg-amber-token'
                             : status === 'down'
-                              ? 'bg-red-500'
+                              ? 'bg-vermillion'
                               : ''
                       }`}
                     />
-                    <span className="font-medium capitalize text-gray-700 dark:text-gray-300">
+                    <span className="font-medium capitalize text-ink-2 ">
                       {service} Service
                     </span>
                   </div>
@@ -351,11 +335,11 @@ export default function AdminDashboard() {
                     }
                     className={`${
                       status === 'operational'
-                        ? 'bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-400 dark:hover:bg-green-900/30'
+                        ? 'bg-forest-bg text-forest hover:bg-forest-bg '
                         : status === 'degraded'
-                          ? 'bg-yellow-100 text-yellow-700 hover:bg-yellow-100 dark:bg-yellow-900/30 dark:text-yellow-400 dark:hover:bg-yellow-900/30'
+                          ? 'bg-amber-token-bg text-amber-token hover:bg-amber-token-bg '
                           : status === 'down'
-                            ? 'bg-red-100 text-red-700 hover:bg-red-100 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/30'
+                            ? 'bg-vermillion-bg text-vermillion hover:bg-vermillion-bg '
                             : ''
                     }`}
                   >
@@ -367,9 +351,7 @@ export default function AdminDashboard() {
                 </div>
               ))}
               <div className="pt-4 border-t">
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Last checked: Just now
-                </p>
+                <p className="text-xs text-ink-3 ">Last checked: Just now</p>
               </div>
             </div>
           </CardContent>
@@ -386,41 +368,35 @@ export default function AdminDashboard() {
           <div className="grid grid-cols-3 gap-3">
             <Button
               variant="outline"
-              className="h-auto flex-col gap-2 py-4 hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="h-auto flex-col gap-2 py-4 hover:bg-paper "
               onClick={() => router.push('/admin/users')}
             >
-              <Users className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <Users className="h-5 w-5 text-ink-3 " />
               <div className="text-center">
                 <p className="font-medium text-sm">Manage Users</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Add or edit users
-                </p>
+                <p className="text-xs text-ink-3 ">Add or edit users</p>
               </div>
             </Button>
             <Button
               variant="outline"
-              className="h-auto flex-col gap-2 py-4 hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="h-auto flex-col gap-2 py-4 hover:bg-paper "
               onClick={() => router.push('/admin/access')}
             >
-              <LockKeyhole className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <LockKeyhole className="h-5 w-5 text-ink-3 " />
               <div className="text-center">
                 <p className="font-medium text-sm">Access Control</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Manage permissions
-                </p>
+                <p className="text-xs text-ink-3 ">Manage permissions</p>
               </div>
             </Button>
             <Button
               variant="outline"
-              className="h-auto flex-col gap-2 py-4 hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="h-auto flex-col gap-2 py-4 hover:bg-paper "
               onClick={() => router.push('/admin/roles')}
             >
-              <Shield className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <Shield className="h-5 w-5 text-ink-3 " />
               <div className="text-center">
                 <p className="font-medium text-sm">Role Management</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Assign roles
-                </p>
+                <p className="text-xs text-ink-3 ">Assign roles</p>
               </div>
             </Button>
           </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -11,7 +11,7 @@ export default function AdminLayout({
 }) {
   return (
     <AdminRoute>
-      <div className="flex h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="flex h-screen bg-paper ">
         <AdminSidebar />
         <div className="flex-1 flex flex-col overflow-hidden">
           <AdminHeader />

--- a/src/app/admin/programs/[programId]/dashboard/page.tsx
+++ b/src/app/admin/programs/[programId]/dashboard/page.tsx
@@ -113,11 +113,11 @@ export default function ProgramDashboardPage({
         </Button>
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
-            <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            <AlertCircle className="h-12 w-12 text-vermillion mb-4" />
+            <h3 className="text-lg font-semibold text-ink mb-2">
               Unable to Load Dashboard
             </h3>
-            <p className="text-gray-600 dark:text-gray-400 text-center mb-6">
+            <p className="text-ink-3 text-center mb-6">
               There was an error loading the sandbox dashboard.
             </p>
             <Button onClick={() => router.push('/admin/programs')}>
@@ -190,7 +190,7 @@ export default function ProgramDashboardPage({
         </Button>
 
         {/* Program Title and Compact Stats Bar */}
-        <div className="bg-white dark:bg-gray-900 border rounded-lg p-4 shadow-sm">
+        <div className="bg-surface-1 border rounded-lg p-4 shadow-sm">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
             {/* Program Info */}
             <div className="flex items-center gap-3">
@@ -199,11 +199,11 @@ export default function ProgramDashboardPage({
                 style={{ backgroundColor: dashboard.program_color }}
               />
               <div className="min-w-0">
-                <h1 className="text-2xl font-bold text-gray-900 dark:text-white truncate">
+                <h1 className="text-2xl font-bold text-ink truncate">
                   {dashboard.program_name}
                 </h1>
                 {dashboard.program_description && (
-                  <p className="text-gray-600 dark:text-gray-400 text-sm truncate">
+                  <p className="text-ink-3 text-sm truncate">
                     {dashboard.program_description}
                   </p>
                 )}
@@ -213,42 +213,38 @@ export default function ProgramDashboardPage({
             {/* Compact Stats */}
             <div className="flex items-center gap-6 text-sm">
               <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                <span className="font-semibold text-gray-900 dark:text-white">
+                <Users className="h-4 w-4 text-ink-3 " />
+                <span className="font-semibold text-ink ">
                   {dashboard.total_clients}
                 </span>
-                <span className="text-gray-500 dark:text-gray-400">
-                  Clients
-                </span>
+                <span className="text-ink-3 ">Clients</span>
               </div>
-              <div className="hidden sm:block w-px h-4 bg-gray-200 dark:bg-gray-700" />
+              <div className="hidden sm:block w-px h-4 bg-surface-3 " />
               <div className="flex items-center gap-2">
-                <Calendar className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                <span className="font-semibold text-gray-900 dark:text-white">
+                <Calendar className="h-4 w-4 text-ink-3 " />
+                <span className="font-semibold text-ink ">
                   {dashboard.total_sessions}
                 </span>
-                <span className="text-gray-500 dark:text-gray-400">
-                  Sessions
-                </span>
+                <span className="text-ink-3 ">Sessions</span>
               </div>
-              <div className="hidden sm:block w-px h-4 bg-gray-200 dark:bg-gray-700" />
+              <div className="hidden sm:block w-px h-4 bg-surface-3 " />
               <div className="flex items-center gap-2">
-                <XCircle className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                <span className="font-semibold text-gray-900 dark:text-white">
+                <XCircle className="h-4 w-4 text-ink-3 " />
+                <span className="font-semibold text-ink ">
                   {dashboard.missed_sessions}
                 </span>
-                <span className="text-gray-500 dark:text-gray-400">Missed</span>
+                <span className="text-ink-3 ">Missed</span>
                 {dashboard.missed_sessions > 0 && (
-                  <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                  <span className="w-1.5 h-1.5 rounded-full bg-vermillion" />
                 )}
               </div>
-              <div className="hidden sm:block w-px h-4 bg-gray-200 dark:bg-gray-700" />
+              <div className="hidden sm:block w-px h-4 bg-surface-3 " />
               <div className="flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                <span className="font-semibold text-gray-900 dark:text-white">
+                <TrendingUp className="h-4 w-4 text-ink-3 " />
+                <span className="font-semibold text-ink ">
                   {dashboard.active_this_week}
                 </span>
-                <span className="text-gray-500 dark:text-gray-400">Active</span>
+                <span className="text-ink-3 ">Active</span>
               </div>
             </div>
 
@@ -279,11 +275,11 @@ export default function ProgramDashboardPage({
 
       {/* At-Risk Alert Banner */}
       {statusCounts['at-risk'] > 0 && (
-        <div className="mb-6 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 border-l-4 border-l-red-500 rounded-lg p-4">
+        <div className="mb-6 bg-paper border border-line border-l-4 border-l-red-500 rounded-lg p-4">
           <div className="flex items-start gap-3">
-            <AlertCircle className="h-5 w-5 text-red-500 shrink-0 mt-0.5" />
+            <AlertCircle className="h-5 w-5 text-vermillion shrink-0 mt-0.5" />
             <div className="flex-1 min-w-0">
-              <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+              <h3 className="text-sm font-semibold text-ink ">
                 {statusCounts['at-risk']} client
                 {statusCounts['at-risk'] !== 1 ? 's' : ''} need
                 {statusCounts['at-risk'] === 1 ? 's' : ''} attention
@@ -297,9 +293,9 @@ export default function ProgramDashboardPage({
                       onClick={() =>
                         router.push(`/clients/${client.client_id}`)
                       }
-                      className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                      className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm bg-surface-1 border border-line text-ink-2 hover:bg-surface-3 transition-colors"
                     >
-                      <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                      <span className="w-1.5 h-1.5 rounded-full bg-vermillion" />
                       {client.client_name}
                     </button>
                   ))}
@@ -307,7 +303,7 @@ export default function ProgramDashboardPage({
             </div>
             <button
               onClick={() => setFilterStatus('at-risk')}
-              className="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white shrink-0"
+              className="text-sm font-medium text-ink-3 hover:text-ink shrink-0"
             >
               View all →
             </button>
@@ -317,49 +313,49 @@ export default function ProgramDashboardPage({
 
       {/* Tabbed Interface */}
       <Tabs defaultValue="overview" className="space-y-6">
-        <div className="border-b border-gray-200 dark:border-gray-700">
+        <div className="border-b border-line ">
           <TabsList className="flex w-full bg-transparent p-0 h-auto gap-0">
             <TabsTrigger
               value="overview"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <Users className="h-4 w-4" />
               <span className="hidden sm:inline">Overview</span>
-              <span className="ml-1.5 hidden sm:inline-flex items-center justify-center px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 data-[state=active]:bg-gray-200 data-[state=active]:text-gray-900 dark:bg-gray-800 dark:text-gray-400 dark:data-[state=active]:bg-gray-700 dark:data-[state=active]:text-white">
+              <span className="ml-1.5 hidden sm:inline-flex items-center justify-center px-2 py-0.5 text-xs font-medium rounded-full bg-surface-3 text-ink-3 data-[state=active]:bg-surface-3 data-[state=active]:text-ink dark:data-[state=active]:bg-ink-2 dark:data-[state=active]:text-ink-on-dark">
                 {dashboard.total_clients}
               </span>
             </TabsTrigger>
             <TabsTrigger
               value="trends"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <BarChart3 className="h-4 w-4" />
               <span className="hidden sm:inline">Trends</span>
             </TabsTrigger>
             <TabsTrigger
               value="action-items"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <ListTodo className="h-4 w-4" />
               <span className="hidden sm:inline">Actions</span>
             </TabsTrigger>
             <TabsTrigger
               value="calendar"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <CalendarDays className="h-4 w-4" />
               <span className="hidden sm:inline">Calendar</span>
             </TabsTrigger>
             <TabsTrigger
               value="themes"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <Sparkles className="h-4 w-4" />
               <span className="hidden sm:inline">Themes</span>
             </TabsTrigger>
             <TabsTrigger
               value="outcomes"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <Target className="h-4 w-4" />
               <span className="hidden sm:inline">
@@ -368,14 +364,14 @@ export default function ProgramDashboardPage({
             </TabsTrigger>
             <TabsTrigger
               value="group-sessions"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <Users className="h-4 w-4" />
               <span className="hidden sm:inline">Group Sessions</span>
             </TabsTrigger>
             <TabsTrigger
               value="wins"
-              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border-b-2 border-transparent data-[state=active]:border-gray-900 data-[state=active]:text-gray-900 dark:data-[state=active]:border-white dark:data-[state=active]:text-white rounded-none bg-transparent shadow-none transition-colors"
+              className="relative flex items-center gap-2 px-4 py-3 text-sm font-medium text-ink-3 hover:text-ink-2 border-b-2 border-transparent data-[state=active]:border-line data-[state=active]:text-ink dark:data-[state=active]:border-paper dark:data-[state=active]:text-ink-on-dark rounded-none bg-transparent shadow-none transition-colors"
             >
               <Trophy className="h-4 w-4" />
               <span className="hidden sm:inline">Wins</span>
@@ -393,8 +389,8 @@ export default function ProgramDashboardPage({
                 onClick={() => setFilterStatus('all')}
                 className={`inline-flex items-center px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
                   filterStatus === 'all'
-                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                    : 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    ? 'bg-ink text-ink-on-dark border-line '
+                    : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper '
                 }`}
               >
                 All ({statusCounts.all})
@@ -403,12 +399,12 @@ export default function ProgramDashboardPage({
                 onClick={() => setFilterStatus('at-risk')}
                 className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
                   filterStatus === 'at-risk'
-                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                    : 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    ? 'bg-ink text-ink-on-dark border-line '
+                    : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper '
                 }`}
               >
                 <span
-                  className={`w-2 h-2 rounded-full bg-red-500 ${statusCounts['at-risk'] > 0 ? 'animate-pulse' : ''}`}
+                  className={`w-2 h-2 rounded-full bg-vermillion ${statusCounts['at-risk'] > 0 ? 'animate-pulse' : ''}`}
                 />
                 At Risk ({statusCounts['at-risk']})
               </button>
@@ -416,22 +412,22 @@ export default function ProgramDashboardPage({
                 onClick={() => setFilterStatus('on-track')}
                 className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
                   filterStatus === 'on-track'
-                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                    : 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    ? 'bg-ink text-ink-on-dark border-line '
+                    : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper '
                 }`}
               >
-                <span className="w-2 h-2 rounded-full bg-blue-500" />
+                <span className="w-2 h-2 rounded-full bg-ds-accent" />
                 On Track ({statusCounts['on-track']})
               </button>
               <button
                 onClick={() => setFilterStatus('excelling')}
                 className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
                   filterStatus === 'excelling'
-                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                    : 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    ? 'bg-ink text-ink-on-dark border-line '
+                    : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper '
                 }`}
               >
-                <span className="w-2 h-2 rounded-full bg-green-500" />
+                <span className="w-2 h-2 rounded-full bg-forest" />
                 Excelling ({statusCounts.excelling})
               </button>
             </div>
@@ -452,7 +448,7 @@ export default function ProgramDashboardPage({
                   <SelectItem value="date">Last Session</SelectItem>
                 </SelectContent>
               </Select>
-              <span className="text-sm text-gray-500 dark:text-gray-400">
+              <span className="text-sm text-ink-3 ">
                 {filteredClients.length} client
                 {filteredClients.length !== 1 ? 's' : ''}
               </span>
@@ -463,11 +459,11 @@ export default function ProgramDashboardPage({
           {filteredClients.length === 0 ? (
             <Card>
               <CardContent className="flex flex-col items-center justify-center py-12">
-                <AlertCircle className="h-12 w-12 text-gray-400 dark:text-gray-500 mb-4" />
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                <AlertCircle className="h-12 w-12 text-ink-4 mb-4" />
+                <h3 className="text-lg font-semibold text-ink mb-2">
                   No clients found
                 </h3>
-                <p className="text-gray-600 dark:text-gray-400 text-center">
+                <p className="text-ink-3 text-center">
                   {filterStatus !== 'all'
                     ? 'Try changing the filter to see more clients'
                     : 'Add clients to this sandbox to see them here'}
@@ -569,22 +565,22 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
   const getStatusDotColor = (status: string) => {
     switch (status) {
       case 'at-risk':
-        return 'bg-red-500'
+        return 'bg-vermillion'
       case 'excelling':
-        return 'bg-green-500'
+        return 'bg-forest'
       default:
-        return 'bg-blue-500'
+        return 'bg-ds-accent'
     }
   }
 
   const getStatusBadgeColor = (status: string) => {
     switch (status) {
       case 'at-risk':
-        return 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
       case 'excelling':
-        return 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
       default:
-        return 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 
@@ -592,17 +588,14 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
   const getTrendIndicator = () => {
     if (client.session_streak > 2) {
       return (
-        <span
-          className="flex items-center text-green-600"
-          title="Improving trend"
-        >
+        <span className="flex items-center text-forest" title="Improving trend">
           <TrendingUp className="h-4 w-4" />
         </span>
       )
     } else if (client.session_streak < 0 || client.missed_sessions > 1) {
       return (
         <span
-          className="flex items-center text-red-600"
+          className="flex items-center text-vermillion"
           title="Declining trend"
         >
           <TrendingDown className="h-4 w-4" />
@@ -610,10 +603,7 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
       )
     }
     return (
-      <span
-        className="flex items-center text-gray-400 dark:text-gray-500"
-        title="Stable"
-      >
+      <span className="flex items-center text-ink-4 " title="Stable">
         <Minus className="h-4 w-4" />
       </span>
     )
@@ -621,8 +611,8 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
 
   // Get progress bar color - gray by default, red only for at-risk clients
   const getProgressColor = () => {
-    if (client.status === 'at-risk') return 'bg-red-500'
-    return 'bg-gray-400'
+    if (client.status === 'at-risk') return 'bg-vermillion'
+    return 'bg-line'
   }
 
   return (
@@ -663,14 +653,12 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
         {/* Completion Rate with Progress Bar */}
         <div>
           <div className="flex items-center justify-between mb-1">
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Completion Rate
-            </p>
-            <span className="text-sm font-semibold text-gray-900 dark:text-white">
+            <p className="text-xs text-ink-3 ">Completion Rate</p>
+            <span className="text-sm font-semibold text-ink ">
               {Math.round(client.completion_rate)}%
             </span>
           </div>
-          <div className="h-2 w-full bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+          <div className="h-2 w-full bg-surface-3 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all ${getProgressColor()}`}
               style={{ width: `${Math.min(100, client.completion_rate)}%` }}
@@ -681,14 +669,14 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
         {/* Session Stats */}
         <div className="flex items-center justify-between text-sm">
           <div className="flex items-center gap-4">
-            <span className="text-gray-600 dark:text-gray-400">
-              <span className="font-semibold text-gray-900 dark:text-white">
+            <span className="text-ink-3 ">
+              <span className="font-semibold text-ink ">
                 {client.total_sessions}
               </span>{' '}
               sessions
             </span>
             {client.session_streak > 0 && (
-              <span className="text-green-600 text-xs">
+              <span className="text-forest text-xs">
                 {client.session_streak} streak
               </span>
             )}
@@ -701,9 +689,7 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
             <>
               <div
                 className={`flex items-center gap-2 text-xs mb-1 ${
-                  needsAttention
-                    ? 'text-red-600 font-medium'
-                    : 'text-gray-500 dark:text-gray-400'
+                  needsAttention ? 'text-vermillion font-medium' : 'text-ink-3 '
                 }`}
               >
                 <Clock className="h-3 w-3" />
@@ -712,21 +698,19 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
                 {needsAttention && ' - needs attention'}
               </div>
               {client.last_session_summary && (
-                <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-2">
+                <p className="text-sm text-ink-2 line-clamp-2">
                   {client.last_session_summary}
                 </p>
               )}
             </>
           ) : (
-            <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-              No sessions yet
-            </p>
+            <p className="text-sm text-ink-3 italic">No sessions yet</p>
           )}
         </div>
 
         {/* Missed Sessions Warning */}
         {client.missed_sessions > 0 && (
-          <div className="flex items-center gap-2 text-sm text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/30 p-2 rounded">
+          <div className="flex items-center gap-2 text-sm text-amber-token bg-amber-token-bg p-2 rounded">
             <AlertCircle className="h-4 w-4 shrink-0" />
             {client.missed_sessions} missed session
             {client.missed_sessions > 1 ? 's' : ''}
@@ -736,9 +720,7 @@ function ClientCard({ client }: { client: ClientSessionSummary }) {
         {/* Emerging Themes */}
         {client.emerging_themes.length > 0 && (
           <div className="pt-3 border-t">
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-              Emerging Themes
-            </p>
+            <p className="text-xs text-ink-3 mb-2">Emerging Themes</p>
             <div className="flex flex-wrap gap-1">
               {client.emerging_themes.slice(0, 3).map((theme, index) => (
                 <Badge key={index} variant="secondary" className="text-xs">

--- a/src/app/admin/programs/[programId]/edit/page.tsx
+++ b/src/app/admin/programs/[programId]/edit/page.tsx
@@ -38,11 +38,11 @@ export default function EditProgramPage({
         </Button>
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
-            <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            <AlertCircle className="h-12 w-12 text-vermillion mb-4" />
+            <h3 className="text-lg font-semibold text-ink mb-2">
               Sandbox Not Found
             </h3>
-            <p className="text-gray-600 dark:text-gray-400 text-center mb-6">
+            <p className="text-ink-3 text-center mb-6">
               The sandbox you&apos;re looking for doesn&apos;t exist or you
               don&apos;t have permission to edit it.
             </p>
@@ -62,12 +62,8 @@ export default function EditProgramPage({
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-          Edit Sandbox
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400 mt-1">
-          Update the details for {program.name}
-        </p>
+        <h1 className="text-3xl font-bold text-ink ">Edit Sandbox</h1>
+        <p className="text-ink-3 mt-1">Update the details for {program.name}</p>
       </div>
 
       <ProgramForm mode="edit" program={program} />

--- a/src/app/admin/programs/new/page.tsx
+++ b/src/app/admin/programs/new/page.tsx
@@ -15,10 +15,8 @@ export default function NewProgramPage() {
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-          Create New Sandbox
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400 mt-1">
+        <h1 className="text-3xl font-bold text-ink ">Create New Sandbox</h1>
+        <p className="text-ink-3 mt-1">
           Set up a new coaching sandbox and assign clients
         </p>
       </div>

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -82,10 +82,8 @@ export default function ProgramsListPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-            Sandboxes
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
+          <h1 className="text-3xl font-bold text-ink ">Sandboxes</h1>
+          <p className="text-ink-3 mt-1">
             Manage coaching sandboxes and track client progress
           </p>
         </div>
@@ -98,7 +96,7 @@ export default function ProgramsListPage() {
       {/* Search */}
       <div className="mb-6">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
           <Input
             placeholder="Search sandboxes..."
             value={searchQuery}
@@ -112,11 +110,11 @@ export default function ProgramsListPage() {
       {programs.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
-            <AlertCircle className="h-12 w-12 text-gray-400 dark:text-gray-500 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            <AlertCircle className="h-12 w-12 text-ink-4 mb-4" />
+            <h3 className="text-lg font-semibold text-ink mb-2">
               No sandboxes found
             </h3>
-            <p className="text-gray-600 dark:text-gray-400 text-center mb-6">
+            <p className="text-ink-3 text-center mb-6">
               {searchQuery
                 ? 'Try adjusting your search query'
                 : 'Get started by creating your first sandbox'}
@@ -162,8 +160,8 @@ export default function ProgramsListPage() {
                   {/* Stats */}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                      <span className="text-sm text-gray-600 dark:text-gray-400">
+                      <Users className="h-4 w-4 text-ink-3 " />
+                      <span className="text-sm text-ink-3 ">
                         {program.client_count} client
                         {program.client_count !== 1 ? 's' : ''}
                       </span>
@@ -206,7 +204,7 @@ export default function ProgramsListPage() {
                         setDeleteProgram(program)
                       }}
                     >
-                      <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
+                      <Trash2 className="h-4 w-4 text-vermillion " />
                     </Button>
                   </div>
                 </div>
@@ -234,7 +232,7 @@ export default function ProgramsListPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               Delete Sandbox
             </AlertDialogAction>

--- a/src/app/admin/resources/page.tsx
+++ b/src/app/admin/resources/page.tsx
@@ -252,16 +252,12 @@ export default function AdminResourcesPage() {
 
   const getCategoryBadge = (category: string) => {
     const colors: Record<string, string> = {
-      document:
-        'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-      worksheet:
-        'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-      video:
-        'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
-      template:
-        'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
-      link: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400',
-      general: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
+      document: 'bg-ds-accent-bg text-ds-accent ',
+      worksheet: 'bg-forest-bg text-forest ',
+      video: 'bg-indigo-bg text-indigo ',
+      template: 'bg-amber-token-bg text-amber-token ',
+      link: 'bg-ds-accent-bg text-ds-accent ',
+      general: 'bg-surface-3 text-ink-2 ',
     }
     return colors[category] || colors.general
   }
@@ -279,10 +275,8 @@ export default function AdminResourcesPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Global Resources
-          </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-ink ">Global Resources</h1>
+          <p className="text-sm text-ink-3 mt-1">
             Manage resources available to all coaches
           </p>
         </div>
@@ -304,7 +298,7 @@ export default function AdminResourcesPage() {
 
       {/* Search */}
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-4" />
         <Input
           placeholder="Search global resources..."
           value={searchQuery}
@@ -314,18 +308,18 @@ export default function AdminResourcesPage() {
       </div>
 
       {/* Count */}
-      <p className="text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-ink-3 ">
         {total} global resource{total !== 1 ? 's' : ''}
       </p>
 
       {/* Resources List */}
       {resources.length === 0 ? (
-        <div className="text-center py-16 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
-          <BookOpen className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+        <div className="text-center py-16 border-2 border-dashed border-line-strong rounded-lg">
+          <BookOpen className="h-12 w-12 text-ink-4 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-ink mb-2">
             No Global Resources
           </h3>
-          <p className="text-gray-500 dark:text-gray-400 mb-4">
+          <p className="text-ink-3 mb-4">
             Add resources that will be available to all coaches.
           </p>
           <Button
@@ -339,50 +333,50 @@ export default function AdminResourcesPage() {
           </Button>
         </div>
       ) : (
-        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-gray-800">
+        <div className="border border-line rounded-lg overflow-hidden bg-surface-1 ">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+              <tr className="border-b border-line bg-paper ">
+                <th className="text-left px-4 py-3 text-xs font-medium text-ink-3 uppercase">
                   Title
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-ink-3 uppercase">
                   Category
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-ink-3 uppercase">
                   Type
                 </th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="text-left px-4 py-3 text-xs font-medium text-ink-3 uppercase">
                   Created
                 </th>
-                <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <th className="text-right px-4 py-3 text-xs font-medium text-ink-3 uppercase">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-line ">
               {resources.map(resource => (
                 <tr
                   key={resource.id}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                  className="hover:bg-paper transition-colors"
                 >
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
-                      <div className="h-8 w-8 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+                      <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center flex-shrink-0">
                         {resource.file_url ? (
-                          <FileText className="h-4 w-4 text-gray-500" />
+                          <FileText className="h-4 w-4 text-ink-3" />
                         ) : resource.content_url ? (
-                          <Link2 className="h-4 w-4 text-gray-500" />
+                          <Link2 className="h-4 w-4 text-ink-3" />
                         ) : (
-                          <BookOpen className="h-4 w-4 text-gray-500" />
+                          <BookOpen className="h-4 w-4 text-ink-3" />
                         )}
                       </div>
                       <div className="min-w-0">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <p className="text-sm font-medium text-ink truncate">
                           {resource.title}
                         </p>
                         {resource.description && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-xs">
+                          <p className="text-xs text-ink-3 truncate max-w-xs">
                             {resource.description}
                           </p>
                         )}
@@ -395,7 +389,7 @@ export default function AdminResourcesPage() {
                     </Badge>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-600 dark:text-gray-400 capitalize">
+                    <span className="text-sm text-ink-3 capitalize">
                       {resource.file_url
                         ? 'File'
                         : resource.content_url
@@ -404,7 +398,7 @@ export default function AdminResourcesPage() {
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                    <span className="text-sm text-ink-3 ">
                       {resource.created_at
                         ? formatDate(resource.created_at, 'MMM d, yyyy')
                         : '-'}
@@ -414,7 +408,7 @@ export default function AdminResourcesPage() {
                     <div className="flex items-center justify-end gap-1">
                       <button
                         onClick={() => setViewingResource(resource)}
-                        className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded transition-colors"
+                        className="p-1.5 text-ink-4 hover:text-ink-3 rounded transition-colors"
                         title="View"
                       >
                         <Eye className="h-4 w-4" />
@@ -424,20 +418,20 @@ export default function AdminResourcesPage() {
                           href={resource.file_url || resource.content_url || ''}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded transition-colors"
+                          className="p-1.5 text-ink-4 hover:text-ink-3 rounded transition-colors"
                         >
                           <ExternalLink className="h-4 w-4" />
                         </a>
                       )}
                       <button
                         onClick={() => handleEditOpen(resource)}
-                        className="p-1.5 text-gray-400 hover:text-blue-600 rounded transition-colors"
+                        className="p-1.5 text-ink-4 hover:text-ds-accent rounded transition-colors"
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
                       <button
                         onClick={() => setDeleteTarget(resource)}
-                        className="p-1.5 text-gray-400 hover:text-red-600 rounded transition-colors"
+                        className="p-1.5 text-ink-4 hover:text-vermillion rounded transition-colors"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
@@ -490,8 +484,8 @@ export default function AdminResourcesPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <div className="flex items-center gap-3 mb-2">
-              <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                <AlertTriangle className="h-5 w-5 text-red-600" />
+              <div className="p-2 bg-vermillion-bg rounded-full">
+                <AlertTriangle className="h-5 w-5 text-vermillion" />
               </div>
               <AlertDialogTitle>Delete Global Resource</AlertDialogTitle>
             </div>
@@ -508,7 +502,7 @@ export default function AdminResourcesPage() {
                 handleDelete()
               }}
               disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               {isDeleting ? (
                 <>
@@ -538,17 +532,15 @@ export default function AdminResourcesPage() {
             <DialogTitle>{viewingResource?.title}</DialogTitle>
           </DialogHeader>
           {viewingResource?.description && (
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              {viewingResource.description}
-            </p>
+            <p className="text-sm text-ink-3 ">{viewingResource.description}</p>
           )}
           {viewingResource?.content ? (
-            <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap leading-relaxed max-h-[60vh] overflow-y-auto">
+            <div className="p-4 bg-paper rounded-lg text-sm text-ink-2 whitespace-pre-wrap leading-relaxed max-h-[60vh] overflow-y-auto">
               {viewingResource.content}
             </div>
           ) : viewingResource?.file_url ? (
-            <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-              <FileText className="h-5 w-5 text-gray-500" />
+            <div className="flex items-center gap-3 p-3 bg-paper rounded-lg">
+              <FileText className="h-5 w-5 text-ink-3" />
               <span className="flex-1 text-sm truncate">
                 {viewingResource.file_url}
               </span>
@@ -556,32 +548,32 @@ export default function AdminResourcesPage() {
                 href={viewingResource.file_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 text-sm font-medium hover:underline"
+                className="text-ds-accent text-sm font-medium hover:underline"
               >
                 Open
               </a>
             </div>
           ) : viewingResource?.content_url ? (
-            <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-              <Link2 className="h-5 w-5 text-gray-500" />
-              <span className="flex-1 text-sm text-blue-600 truncate">
+            <div className="flex items-center gap-3 p-3 bg-paper rounded-lg">
+              <Link2 className="h-5 w-5 text-ink-3" />
+              <span className="flex-1 text-sm text-ds-accent truncate">
                 {viewingResource.content_url}
               </span>
               <a
                 href={viewingResource.content_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 text-sm font-medium hover:underline"
+                className="text-ds-accent text-sm font-medium hover:underline"
               >
                 Open
               </a>
             </div>
           ) : (
-            <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-center text-sm text-gray-400">
+            <div className="p-4 bg-paper rounded-lg text-center text-sm text-ink-4">
               No content
             </div>
           )}
-          <div className="flex items-center gap-2 text-xs text-gray-500">
+          <div className="flex items-center gap-2 text-xs text-ink-3">
             <Badge variant="outline" className="text-xs capitalize">
               {viewingResource?.sharing_scope}
             </Badge>

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -40,26 +40,26 @@ const roleInfoMap: Record<string, RoleInfo> = {
     name: 'Super Admin',
     description:
       'Full system access with ability to manage all aspects including other admins',
-    color: 'bg-red-100 text-red-800 border-red-200',
+    color: 'bg-vermillion-bg text-vermillion border-vermillion',
     icon: <Shield className="h-5 w-5" />,
   },
   admin: {
     name: 'Admin',
     description:
       'Can manage users, roles, and client access. Cannot modify super admins',
-    color: 'bg-blue-100 text-blue-800 border-blue-200',
+    color: 'bg-ds-accent-bg text-ds-accent border-ds-accent',
     icon: <Shield className="h-5 w-5" />,
   },
   coach: {
     name: 'Coach',
     description: 'Can access assigned clients and conduct coaching sessions',
-    color: 'bg-green-100 text-green-800 border-green-200',
+    color: 'bg-forest-bg text-forest border-forest',
     icon: <UserCheck className="h-5 w-5" />,
   },
   viewer: {
     name: 'Viewer',
     description: 'Read-only access to assigned clients and session data',
-    color: 'bg-gray-100 text-gray-800 border-gray-200',
+    color: 'bg-surface-3 text-ink-2 border-line',
     icon: <Users className="h-5 w-5" />,
   },
 }
@@ -123,12 +123,8 @@ export default function RolesPage() {
     <div className="space-y-6">
       {/* Page Header */}
       <div>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-          Role Management
-        </h1>
-        <p className="text-gray-500 dark:text-gray-400 mt-2">
-          Manage user roles and permissions
-        </p>
+        <h1 className="text-3xl font-bold text-ink ">Role Management</h1>
+        <p className="text-ink-3 mt-2">Manage user roles and permissions</p>
       </div>
 
       {/* Role Overview Cards */}
@@ -161,12 +157,12 @@ export default function RolesPage() {
             return (
               <Card
                 key={role}
-                className={`cursor-pointer transition-all hover:shadow-md ${isSelected ? 'ring-2 ring-gray-900' : ''}`}
+                className={`cursor-pointer transition-all hover:shadow-md ${isSelected ? 'ring-2 ring-line' : ''}`}
                 onClick={() => setSelectedRole(role)}
               >
                 <CardHeader className="pb-3">
                   <div className="flex items-center justify-between">
-                    <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                    <CardTitle className="text-sm font-medium text-ink-3 ">
                       {info.name}
                     </CardTitle>
                     <Badge
@@ -178,12 +174,8 @@ export default function RolesPage() {
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {count}
-                  </div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                    {info.description}
-                  </p>
+                  <div className="text-2xl font-bold text-ink ">{count}</div>
+                  <p className="text-xs text-ink-3 mt-2">{info.description}</p>
                 </CardContent>
               </Card>
             )
@@ -204,7 +196,7 @@ export default function RolesPage() {
               <div className="space-y-4">
                 {/* Search */}
                 <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
                   <Input
                     placeholder="Search users..."
                     value={searchQuery}
@@ -218,14 +210,14 @@ export default function RolesPage() {
                   {filteredUsers.map(user => (
                     <div
                       key={user.id}
-                      className="flex items-center justify-between p-3 rounded-lg border hover:bg-gray-50 dark:hover:bg-gray-800"
+                      className="flex items-center justify-between p-3 rounded-lg border hover:bg-paper "
                     >
                       <div className="flex-1">
-                        <p className="font-medium text-sm text-gray-900 dark:text-white">
+                        <p className="font-medium text-sm text-ink ">
                           {user.email}
                         </p>
                         {user.full_name && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                          <p className="text-xs text-ink-3 ">
                             {user.full_name}
                           </p>
                         )}
@@ -299,10 +291,10 @@ export default function RolesPage() {
               <CardContent>
                 <div className="space-y-4">
                   {/* Description */}
-                  <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                  <div className="p-3 bg-paper rounded-lg">
                     <div className="flex items-start gap-2">
-                      <Info className="h-4 w-4 text-gray-400 dark:text-gray-500 mt-0.5" />
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                      <Info className="h-4 w-4 text-ink-4 mt-0.5" />
+                      <p className="text-sm text-ink-3 ">
                         {roleInfoMap[selectedRole]?.description}
                       </p>
                     </div>
@@ -310,7 +302,7 @@ export default function RolesPage() {
 
                   {/* Members */}
                   <div>
-                    <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+                    <h3 className="text-sm font-medium text-ink mb-2">
                       Members ({roleUsers.length})
                     </h3>
                     <div className="space-y-2 max-h-64 overflow-y-auto">
@@ -321,11 +313,11 @@ export default function RolesPage() {
                             className="flex items-center justify-between p-2 rounded border"
                           >
                             <div>
-                              <p className="text-sm font-medium text-gray-900 dark:text-white">
+                              <p className="text-sm font-medium text-ink ">
                                 {user.email}
                               </p>
                               {user.full_name && (
-                                <p className="text-xs text-gray-500 dark:text-gray-400">
+                                <p className="text-xs text-ink-3 ">
                                   {user.full_name}
                                 </p>
                               )}
@@ -342,7 +334,7 @@ export default function RolesPage() {
                           </div>
                         ))
                       ) : (
-                        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-4">
+                        <p className="text-sm text-ink-4 text-center py-4">
                           No users with this role
                         </p>
                       )}
@@ -351,7 +343,7 @@ export default function RolesPage() {
 
                   {/* Permissions (could be expanded) */}
                   <div>
-                    <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+                    <h3 className="text-sm font-medium text-ink mb-2">
                       Permissions
                     </h3>
                     <div className="space-y-1">
@@ -399,8 +391,8 @@ export default function RolesPage() {
 
 function PermissionItem({ label }: { label: string }) {
   return (
-    <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-      <div className="h-1.5 w-1.5 rounded-full bg-gray-400 dark:bg-gray-500" />
+    <div className="flex items-center gap-2 text-sm text-ink-3 ">
+      <div className="h-1.5 w-1.5 rounded-full bg-line " />
       {label}
     </div>
   )

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -298,10 +298,10 @@ export default function UsersPage() {
       <div>
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400 bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold  bg-clip-text text-transparent">
               User Management
             </h1>
-            <p className="text-gray-500 dark:text-gray-400 mt-2">
+            <p className="text-ink-3 mt-2">
               Manage user accounts, roles, and permissions
             </p>
           </div>
@@ -329,10 +329,10 @@ export default function UsersPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Total
                 </CardTitle>
-                <Users className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <Users className="h-4 w-4 text-ink-4 " />
               </div>
             </CardHeader>
             <CardContent>
@@ -342,14 +342,14 @@ export default function UsersPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Active
                 </CardTitle>
-                <CheckCircle className="h-4 w-4 text-green-500" />
+                <CheckCircle className="h-4 w-4 text-forest" />
               </div>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+              <div className="text-2xl font-bold text-forest ">
                 {stats.active}
               </div>
             </CardContent>
@@ -357,14 +357,14 @@ export default function UsersPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Inactive
                 </CardTitle>
-                <XCircle className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <XCircle className="h-4 w-4 text-ink-4 " />
               </div>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-gray-400 dark:text-gray-500">
+              <div className="text-2xl font-bold text-ink-4 ">
                 {stats.inactive}
               </div>
             </CardContent>
@@ -372,14 +372,14 @@ export default function UsersPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Deleted
                 </CardTitle>
-                <Archive className="h-4 w-4 text-red-400" />
+                <Archive className="h-4 w-4 text-vermillion" />
               </div>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+              <div className="text-2xl font-bold text-vermillion ">
                 {stats.deleted}
               </div>
             </CardContent>
@@ -387,14 +387,14 @@ export default function UsersPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Admins
                 </CardTitle>
-                <Shield className="h-4 w-4 text-blue-500" />
+                <Shield className="h-4 w-4 text-ds-accent" />
               </div>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              <div className="text-2xl font-bold text-ds-accent ">
                 {stats.admins}
               </div>
             </CardContent>
@@ -402,14 +402,14 @@ export default function UsersPage() {
           <Card>
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                <CardTitle className="text-sm font-medium text-ink-3 ">
                   Coaches
                 </CardTitle>
-                <UserCheck className="h-4 w-4 text-purple-500" />
+                <UserCheck className="h-4 w-4 text-indigo" />
               </div>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+              <div className="text-2xl font-bold text-indigo ">
                 {stats.coaches}
               </div>
             </CardContent>
@@ -423,7 +423,7 @@ export default function UsersPage() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4 flex-1">
               <div className="relative flex-1 max-w-md">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
                 <Input
                   placeholder="Search by name or email..."
                   value={searchQuery}
@@ -459,10 +459,7 @@ export default function UsersPage() {
             </div>
             {/* NEW: Toggle for showing deleted users */}
             <div className="flex items-center gap-2">
-              <Label
-                htmlFor="show-deleted"
-                className="text-sm text-gray-600 dark:text-gray-400"
-              >
+              <Label htmlFor="show-deleted" className="text-sm text-ink-3 ">
                 Show Deleted
               </Label>
               <Switch
@@ -493,9 +490,9 @@ export default function UsersPage() {
             </div>
           ) : users.length === 0 ? (
             <div className="text-center py-12">
-              <Users className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-              <p className="text-gray-500 dark:text-gray-400">No users found</p>
-              <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
+              <Users className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+              <p className="text-ink-3 ">No users found</p>
+              <p className="text-sm text-ink-4 mt-1">
                 Try adjusting your search or filters
               </p>
             </div>
@@ -515,7 +512,7 @@ export default function UsersPage() {
                 {users.map(user => (
                   <TableRow
                     key={user.id}
-                    className={`hover:bg-gray-50 dark:hover:bg-gray-800 ${user.deleted_at ? 'bg-red-50 dark:bg-red-900/30 opacity-60' : ''}`}
+                    className={`hover:bg-paper ${user.deleted_at ? 'bg-vermillion-bg opacity-60' : ''}`}
                   >
                     <TableCell>
                       <div className="flex items-center gap-3">
@@ -525,14 +522,14 @@ export default function UsersPage() {
                           <AvatarImage
                             src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.email}`}
                           />
-                          <AvatarFallback className="bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700 text-gray-700 dark:text-gray-300 font-medium">
+                          <AvatarFallback className=" text-ink-2 font-medium">
                             {getUserInitials(user.email, user.full_name)}
                           </AvatarFallback>
                         </Avatar>
                         <div>
                           <div className="flex items-center gap-2">
                             <p
-                              className={`font-medium ${user.deleted_at ? 'text-gray-500 dark:text-gray-400 line-through' : 'text-gray-900 dark:text-white'}`}
+                              className={`font-medium ${user.deleted_at ? 'text-ink-3 line-through' : 'text-ink '}`}
                             >
                               {user.full_name || user.email}
                             </p>
@@ -543,13 +540,13 @@ export default function UsersPage() {
                             )}
                           </div>
                           {user.full_name && (
-                            <p className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                            <p className="text-sm text-ink-3 flex items-center gap-1">
                               <Mail className="h-3 w-3" />
                               {user.email}
                             </p>
                           )}
                           {user.deleted_at && (
-                            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+                            <p className="text-xs text-vermillion mt-1">
                               Deleted {formatDate(user.deleted_at)}
                             </p>
                           )}
@@ -569,9 +566,7 @@ export default function UsersPage() {
                             </Badge>
                           ))
                         ) : (
-                          <span className="text-sm text-gray-400 dark:text-gray-500">
-                            No roles
-                          </span>
+                          <span className="text-sm text-ink-4 ">No roles</span>
                         )}
                       </div>
                     </TableCell>
@@ -580,24 +575,20 @@ export default function UsersPage() {
                         <span className="text-sm font-medium">
                           {user.client_count}
                         </span>
-                        <span className="text-sm text-gray-500 dark:text-gray-400">
-                          clients
-                        </span>
+                        <span className="text-sm text-ink-3 ">clients</span>
                       </div>
                     </TableCell>
                     <TableCell>
                       <div className="flex items-center gap-2">
                         {user.is_active ? (
                           <>
-                            <div className="h-2 w-2 bg-green-500 rounded-full" />
-                            <span className="text-sm text-green-700 dark:text-green-400">
-                              Active
-                            </span>
+                            <div className="h-2 w-2 bg-forest rounded-full" />
+                            <span className="text-sm text-forest ">Active</span>
                           </>
                         ) : (
                           <>
-                            <div className="h-2 w-2 bg-gray-400 rounded-full" />
-                            <span className="text-sm text-gray-500 dark:text-gray-400">
+                            <div className="h-2 w-2 bg-line rounded-full" />
+                            <span className="text-sm text-ink-3 ">
                               Inactive
                             </span>
                           </>
@@ -605,7 +596,7 @@ export default function UsersPage() {
                       </div>
                     </TableCell>
                     <TableCell>
-                      <div className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+                      <div className="flex items-center gap-1 text-sm text-ink-3 ">
                         <Calendar className="h-3 w-3" />
                         {formatDate(user.created_at, 'MMM d, yyyy')}
                       </div>
@@ -667,7 +658,7 @@ export default function UsersPage() {
                                 onClick={() => {
                                   openDeleteDialog(user)
                                 }}
-                                className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400"
+                                className="text-vermillion focus:text-vermillion "
                               >
                                 <Trash2 className="h-4 w-4 mr-2" />
                                 Delete User
@@ -679,7 +670,7 @@ export default function UsersPage() {
                                 onClick={() => {
                                   openRestoreDialog(user)
                                 }}
-                                className="text-green-600 dark:text-green-400 focus:text-green-600 dark:focus:text-green-400"
+                                className="text-forest focus:text-forest "
                               >
                                 <RotateCcw className="h-4 w-4 mr-2" />
                                 Restore User
@@ -913,7 +904,7 @@ export default function UsersPage() {
                     >
                       {formatRoleName(role)}
                     </Label>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    <p className="text-xs text-ink-3 mt-1">
                       {role === 'super_admin' &&
                         'Full system access and control'}
                       {role === 'admin' && 'User and client management'}
@@ -961,14 +952,14 @@ export default function UsersPage() {
           <DialogHeader>
             <DialogTitle>Delete User</DialogTitle>
             <DialogDescription className="space-y-2">
-              <AlertCircle className="h-12 w-12 text-red-500 mx-auto" />
+              <AlertCircle className="h-12 w-12 text-vermillion mx-auto" />
               <p>Are you sure you want to delete this user?</p>
               <p className="font-semibold">{selectedUser?.email}</p>
-              <p className="text-amber-600 dark:text-amber-400">
+              <p className="text-amber-token ">
                 This will soft delete the user. They will be deactivated and
                 hidden from the user list.
               </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-3 ">
                 You can restore deleted users later from the deleted users view.
               </p>
             </DialogDescription>
@@ -999,10 +990,10 @@ export default function UsersPage() {
           <DialogHeader>
             <DialogTitle>Restore User</DialogTitle>
             <DialogDescription className="space-y-2">
-              <RotateCcw className="h-12 w-12 text-green-500 mx-auto" />
+              <RotateCcw className="h-12 w-12 text-forest mx-auto" />
               <p>Are you sure you want to restore this user?</p>
               <p className="font-semibold">{selectedUser?.email}</p>
-              <p className="text-green-600 dark:text-green-400">
+              <p className="text-forest ">
                 This will reactivate the user and restore their access.
               </p>
             </DialogDescription>
@@ -1016,7 +1007,7 @@ export default function UsersPage() {
               Cancel
             </Button>
             <Button
-              className="bg-green-600 hover:bg-green-700"
+              className="bg-forest hover:bg-forest"
               onClick={handleRestoreUser}
               disabled={isRestoring}
             >

--- a/src/app/auth/coach-signup/page.tsx
+++ b/src/app/auth/coach-signup/page.tsx
@@ -130,7 +130,7 @@ function CoachSignupContent() {
 
   if (isValidating) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen flex items-center justify-center bg-paper ">
         <LoadingSpinner />
       </div>
     )
@@ -138,7 +138,7 @@ function CoachSignupContent() {
 
   if (!invitationInfo?.valid) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="min-h-screen flex items-center justify-center bg-paper p-4">
         <Card className="max-w-md">
           <CardContent className="pt-6">
             <Alert variant="destructive">
@@ -157,59 +157,59 @@ function CoachSignupContent() {
   }
 
   return (
-    <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen flex bg-paper ">
       {/* Left side - Features */}
-      <div className="hidden lg:flex lg:w-1/2 bg-gray-900 text-white p-12 flex-col justify-center">
+      <div className="hidden lg:flex lg:w-1/2 bg-ink text-ink-on-dark p-12 flex-col justify-center">
         <div className="max-w-md mx-auto">
           <h1 className="text-4xl font-bold mb-4">Welcome to Coach Sidekick</h1>
-          <p className="text-gray-400 text-lg mb-12">
+          <p className="text-ink-4 text-lg mb-12">
             Your AI-powered coaching assistant for better sessions and insights.
           </p>
 
           <div className="space-y-8">
             <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-gray-800 rounded-lg flex items-center justify-center flex-shrink-0">
+              <div className="w-10 h-10 bg-ink-2 rounded-lg flex items-center justify-center flex-shrink-0">
                 <Users className="w-5 h-5" />
               </div>
               <div>
                 <h3 className="font-semibold mb-1">Client Management</h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-ink-4 text-sm">
                   Organize and track your coaching clients with ease.
                 </p>
               </div>
             </div>
 
             <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-gray-800 rounded-lg flex items-center justify-center flex-shrink-0">
+              <div className="w-10 h-10 bg-ink-2 rounded-lg flex items-center justify-center flex-shrink-0">
                 <Brain className="w-5 h-5" />
               </div>
               <div>
                 <h3 className="font-semibold mb-1">AI-Powered Insights</h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-ink-4 text-sm">
                   Get real-time coaching suggestions during sessions.
                 </p>
               </div>
             </div>
 
             <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-gray-800 rounded-lg flex items-center justify-center flex-shrink-0">
+              <div className="w-10 h-10 bg-ink-2 rounded-lg flex items-center justify-center flex-shrink-0">
                 <BarChart3 className="w-5 h-5" />
               </div>
               <div>
                 <h3 className="font-semibold mb-1">Progress Tracking</h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-ink-4 text-sm">
                   Monitor client progress with comprehensive analytics.
                 </p>
               </div>
             </div>
 
             <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-gray-800 rounded-lg flex items-center justify-center flex-shrink-0">
+              <div className="w-10 h-10 bg-ink-2 rounded-lg flex items-center justify-center flex-shrink-0">
                 <Sparkles className="w-5 h-5" />
               </div>
               <div>
                 <h3 className="font-semibold mb-1">Session Transcription</h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-ink-4 text-sm">
                   Automatic transcription with key insights extraction.
                 </p>
               </div>
@@ -233,11 +233,11 @@ function CoachSignupContent() {
                 : "You've been invited to join as a coach"}
             </p>
             {invitationInfo.existing_user && invitationInfo.existing_roles && (
-              <div className="mt-3 p-3 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg">
-                <p className="text-sm text-blue-800 dark:text-blue-200">
+              <div className="mt-3 p-3 bg-ds-accent-bg border border-ds-accent rounded-lg">
+                <p className="text-sm text-ds-accent ">
                   <strong>Existing Account Detected</strong>
                 </p>
-                <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+                <p className="text-xs text-ds-accent mt-1">
                   You already have an account as a{' '}
                   {invitationInfo.existing_roles
                     .map(r => r.replace('_', ' '))
@@ -257,10 +257,10 @@ function CoachSignupContent() {
                   type="email"
                   value={invitationInfo.email}
                   disabled
-                  className="bg-gray-100 dark:bg-gray-800"
+                  className="bg-surface-3 "
                 />
                 {invitationInfo.existing_user && (
-                  <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+                  <p className="text-xs text-ds-accent mt-1">
                     This email is already registered in our system
                   </p>
                 )}
@@ -340,7 +340,7 @@ function CoachSignupContent() {
             <CardFooter className="flex flex-col gap-4 pt-6">
               <Button
                 type="submit"
-                className="w-full bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+                className="w-full bg-ink hover:bg-ink-2 "
                 disabled={isLoading}
               >
                 {isLoading

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -171,7 +171,7 @@ function ResetPasswordContent() {
     text: string
   }) => (
     <div
-      className={`flex items-center gap-2 text-sm ${met ? 'text-green-600' : 'text-gray-400'}`}
+      className={`flex items-center gap-2 text-sm ${met ? 'text-forest' : 'text-ink-4'}`}
     >
       {met ? (
         <CheckCircle className="h-4 w-4" />
@@ -184,12 +184,12 @@ function ResetPasswordContent() {
 
   if (verifying) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
+      <div className="min-h-screen flex items-center justify-center  ">
         <Card className="w-full max-w-md">
           <CardContent className="pt-6">
             <div className="flex flex-col items-center space-y-4">
-              <Loader2 className="h-8 w-8 animate-spin text-gray-600" />
-              <p className="text-gray-600">Verifying reset link...</p>
+              <Loader2 className="h-8 w-8 animate-spin text-ink-3" />
+              <p className="text-ink-3">Verifying reset link...</p>
             </div>
           </CardContent>
         </Card>
@@ -199,18 +199,18 @@ function ResetPasswordContent() {
 
   if (!valid && !verifying) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
-        <Card className="w-full max-w-md border-red-200">
+      <div className="min-h-screen flex items-center justify-center  ">
+        <Card className="w-full max-w-md border-vermillion">
           <CardContent className="pt-6">
             <div className="flex flex-col items-center space-y-4">
-              <div className="p-3 bg-red-100 rounded-full">
-                <XCircle className="h-8 w-8 text-red-600" />
+              <div className="p-3 bg-vermillion-bg rounded-full">
+                <XCircle className="h-8 w-8 text-vermillion" />
               </div>
-              <h2 className="text-xl font-semibold text-gray-900">
+              <h2 className="text-xl font-semibold text-ink">
                 Invalid or Expired Link
               </h2>
-              <p className="text-gray-600 text-center">{error}</p>
-              <p className="text-sm text-gray-500">Redirecting to sign in...</p>
+              <p className="text-ink-3 text-center">{error}</p>
+              <p className="text-sm text-ink-3">Redirecting to sign in...</p>
             </div>
           </CardContent>
         </Card>
@@ -220,20 +220,20 @@ function ResetPasswordContent() {
 
   if (success) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
-        <Card className="w-full max-w-md border-green-200 bg-green-50/50">
+      <div className="min-h-screen flex items-center justify-center  ">
+        <Card className="w-full max-w-md border-forest bg-forest-bg/50">
           <CardContent className="pt-6">
             <div className="flex flex-col items-center space-y-4">
-              <div className="p-3 bg-green-100 rounded-full">
-                <CheckCircle className="h-12 w-12 text-green-600" />
+              <div className="p-3 bg-forest-bg rounded-full">
+                <CheckCircle className="h-12 w-12 text-forest" />
               </div>
-              <h2 className="text-2xl font-bold text-gray-900">
+              <h2 className="text-2xl font-bold text-ink">
                 Password Reset Successful!
               </h2>
-              <p className="text-gray-600 text-center">
+              <p className="text-ink-3 text-center">
                 Your password has been successfully reset.
               </p>
-              <p className="text-sm text-gray-500">Redirecting to sign in...</p>
+              <p className="text-sm text-ink-3">Redirecting to sign in...</p>
             </div>
           </CardContent>
         </Card>
@@ -242,12 +242,12 @@ function ResetPasswordContent() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 p-4">
+    <div className="min-h-screen flex items-center justify-center  p-4">
       <Card className="w-full max-w-md">
         <CardHeader>
           <div className="flex justify-center mb-4">
-            <div className="p-3 bg-gray-100 rounded-full">
-              <Key className="h-8 w-8 text-gray-700" />
+            <div className="p-3 bg-surface-3 rounded-full">
+              <Key className="h-8 w-8 text-ink-2" />
             </div>
           </div>
           <CardTitle className="text-center text-2xl font-bold">
@@ -262,12 +262,12 @@ function ResetPasswordContent() {
             <div className="space-y-2">
               <label
                 htmlFor="new-password"
-                className="text-sm font-medium text-gray-700"
+                className="text-sm font-medium text-ink-2"
               >
                 New Password
               </label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-3" />
                 <Input
                   id="new-password"
                   type={showPassword ? 'text' : 'password'}
@@ -282,7 +282,7 @@ function ResetPasswordContent() {
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-ink-3 hover:text-ink-2"
                 >
                   {showPassword ? (
                     <EyeOff className="h-4 w-4" />
@@ -296,12 +296,12 @@ function ResetPasswordContent() {
             <div className="space-y-2">
               <label
                 htmlFor="confirm-password"
-                className="text-sm font-medium text-gray-700"
+                className="text-sm font-medium text-ink-2"
               >
                 Confirm Password
               </label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-3" />
                 <Input
                   id="confirm-password"
                   type={showPassword ? 'text' : 'password'}
@@ -317,8 +317,8 @@ function ResetPasswordContent() {
             </div>
 
             {/* Password Requirements */}
-            <div className="bg-gray-50 rounded-lg p-4 space-y-2">
-              <div className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <div className="bg-paper rounded-lg p-4 space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium text-ink-2 mb-2">
                 <Shield className="h-4 w-4" />
                 <span>Password Requirements</span>
               </div>
@@ -345,7 +345,7 @@ function ResetPasswordContent() {
             </div>
 
             {error && (
-              <div className="flex items-start gap-2 text-red-600 text-sm bg-red-50 p-3 rounded-lg border border-red-200">
+              <div className="flex items-start gap-2 text-vermillion text-sm bg-vermillion-bg p-3 rounded-lg border border-vermillion">
                 <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                 <span>{error}</span>
               </div>
@@ -354,7 +354,7 @@ function ResetPasswordContent() {
             <Button
               type="submit"
               disabled={loading || !newPassword || !confirmPassword}
-              className="w-full bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+              className="w-full bg-ink hover:bg-ink-2 text-ink-on-dark "
             >
               {loading ? (
                 <>
@@ -369,7 +369,7 @@ function ResetPasswordContent() {
             <div className="text-center">
               <a
                 href="/auth"
-                className="text-sm text-gray-600 hover:text-gray-900 hover:underline"
+                className="text-sm text-ink-3 hover:text-ink hover:underline"
               >
                 Back to sign in
               </a>
@@ -385,12 +385,12 @@ export default function ResetPasswordPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
+        <div className="min-h-screen flex items-center justify-center  ">
           <Card className="w-full max-w-md">
             <CardContent className="pt-6">
               <div className="flex flex-col items-center space-y-4">
-                <Loader2 className="h-8 w-8 animate-spin text-gray-600" />
-                <p className="text-gray-600">Loading...</p>
+                <Loader2 className="h-8 w-8 animate-spin text-ink-3" />
+                <p className="text-ink-3">Loading...</p>
               </div>
             </CardContent>
           </Card>

--- a/src/app/client-meeting/[token]/components/client-meeting-header.tsx
+++ b/src/app/client-meeting/[token]/components/client-meeting-header.tsx
@@ -40,14 +40,14 @@ export function ClientMeetingHeader({
   }
 
   return (
-    <div className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 border-b border-gray-700 shadow-lg">
+    <div className=" border-b border-line shadow-lg">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <div className="flex items-center justify-between">
           {/* Left: Logo and Session Info */}
           <div className="flex items-center gap-6">
             {/* Brand Logo */}
             <div className="flex items-center gap-2">
-              <div className="w-10 h-10 bg-white rounded-xl flex items-center justify-center shadow-lg p-1.5">
+              <div className="w-10 h-10 bg-surface-1 rounded-xl flex items-center justify-center shadow-lg p-1.5">
                 <Image
                   src="/novus-global-logo.webp"
                   alt="Logo"
@@ -57,31 +57,31 @@ export function ClientMeetingHeader({
                 />
               </div>
               <div>
-                <h1 className="text-lg font-bold text-white tracking-tight">
+                <h1 className="text-lg font-bold text-ink-on-dark tracking-tight">
                   Coach Sidekick
                 </h1>
-                <p className="text-xs text-gray-400 hidden sm:block">
+                <p className="text-xs text-ink-4 hidden sm:block">
                   Live Session
                 </p>
               </div>
             </div>
 
-            <div className="hidden md:block h-8 w-px bg-gray-700" />
+            <div className="hidden md:block h-8 w-px bg-ink-2" />
 
             {/* Session Info */}
             <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2 text-white">
-                <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center">
-                  <User className="h-4 w-4 text-gray-300" />
+              <div className="flex items-center gap-2 text-ink-on-dark">
+                <div className="w-8 h-8 bg-ink-2 rounded-full flex items-center justify-center">
+                  <User className="h-4 w-4 text-ink-2" />
                 </div>
                 <div>
-                  <p className="font-medium text-white">
+                  <p className="font-medium text-ink-on-dark">
                     {coachName
                       ? `Session with ${coachName}`
                       : 'Coaching Session'}
                   </p>
                   {clientName && (
-                    <p className="text-xs text-gray-400">
+                    <p className="text-xs text-ink-4">
                       Welcome back, {clientName}
                     </p>
                   )}
@@ -93,9 +93,9 @@ export function ClientMeetingHeader({
           {/* Right: Timer and Status */}
           <div className="flex items-center gap-4">
             {/* Timer */}
-            <div className="flex items-center gap-2 bg-gray-800/50 rounded-lg px-4 py-2 border border-gray-700">
-              <Clock className="h-4 w-4 text-gray-400" />
-              <span className="font-mono text-xl font-semibold text-white tabular-nums">
+            <div className="flex items-center gap-2 bg-ink-2/50 rounded-lg px-4 py-2 border border-line">
+              <Clock className="h-4 w-4 text-ink-4" />
+              <span className="font-mono text-xl font-semibold text-ink-on-dark tabular-nums">
                 {formatDuration(durationSeconds)}
               </span>
             </div>
@@ -106,7 +106,7 @@ export function ClientMeetingHeader({
                 variant="ghost"
                 size="sm"
                 onClick={toggleTheme}
-                className="text-gray-400 hover:text-white hover:bg-gray-700"
+                className="text-ink-4 hover:text-ink-on-dark hover:bg-ink-2"
                 title={
                   theme === 'dark'
                     ? 'Switch to light mode'
@@ -127,7 +127,7 @@ export function ClientMeetingHeader({
                 variant="ghost"
                 size="sm"
                 onClick={onRefresh}
-                className="text-gray-400 hover:text-white hover:bg-gray-700"
+                className="text-ink-4 hover:text-ink-on-dark hover:bg-ink-2"
                 title="Refresh data"
               >
                 <RefreshCw className="h-4 w-4" />
@@ -138,17 +138,17 @@ export function ClientMeetingHeader({
             {isEnded ? (
               <Badge
                 variant="secondary"
-                className="bg-gray-700 text-gray-300 flex items-center gap-1.5 px-3 py-1.5"
+                className="bg-ink-2 text-ink-2 flex items-center gap-1.5 px-3 py-1.5"
               >
-                <Circle className="h-2 w-2 fill-gray-500" />
+                <Circle className="h-2 w-2 fill-ink-3" />
                 Session Ended
               </Badge>
             ) : (
               <Badge
                 variant="secondary"
-                className="bg-white/20 text-white border border-white/30 flex items-center gap-1.5 px-3 py-1.5"
+                className="bg-surface-1/20 text-ink-on-dark border border-paper/30 flex items-center gap-1.5 px-3 py-1.5"
               >
-                <Circle className="h-2 w-2 fill-white animate-pulse" />
+                <Circle className="h-2 w-2 fill-paper animate-pulse" />
                 Live
               </Badge>
             )}

--- a/src/app/client-meeting/[token]/components/client-notes-panel.tsx
+++ b/src/app/client-meeting/[token]/components/client-notes-panel.tsx
@@ -190,19 +190,17 @@ export function ClientNotesPanel({
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 h-full flex flex-col shadow-sm dark:bg-gray-800">
-      <CardHeader className="border-b border-gray-100 dark:border-gray-700 py-4 flex-shrink-0 bg-white dark:bg-gray-800">
+    <Card className="border-line h-full flex flex-col shadow-sm ">
+      <CardHeader className="border-b border-line py-4 flex-shrink-0 bg-surface-1 ">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg font-semibold flex items-center gap-2">
-            <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900/50 rounded-lg flex items-center justify-center">
-              <FileText className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+            <div className="w-8 h-8 bg-ds-accent-bg rounded-lg flex items-center justify-center">
+              <FileText className="h-4 w-4 text-ds-accent " />
             </div>
             <div>
-              <span className="text-gray-900 dark:text-white">
-                Session Notes
-              </span>
+              <span className="text-ink ">Session Notes</span>
               {notes.length > 0 && (
-                <span className="text-xs font-normal text-gray-500 dark:text-gray-400 ml-2">
+                <span className="text-xs font-normal text-ink-3 ml-2">
                   ({notes.length})
                 </span>
               )}
@@ -213,11 +211,11 @@ export function ClientNotesPanel({
 
       <CardContent className="flex-1 flex flex-col p-0 overflow-hidden">
         {/* Editor */}
-        <div className="flex-shrink-0 p-4 border-b border-gray-100 dark:border-gray-700 bg-gradient-to-b from-blue-50/50 to-white dark:from-blue-900/20 dark:to-gray-800">
+        <div className="flex-shrink-0 p-4 border-b border-line  ">
           {/* Tips section */}
-          <div className="mb-3 flex items-start gap-2 p-2.5 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-100 dark:border-blue-800">
-            <Lightbulb className="h-4 w-4 text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-            <p className="text-xs text-blue-700 dark:text-blue-300">
+          <div className="mb-3 flex items-start gap-2 p-2.5 bg-ds-accent-bg rounded-lg border border-ds-accent ">
+            <Lightbulb className="h-4 w-4 text-ds-accent flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-ds-accent ">
               Capture key insights, questions, or action items from this
               session. Use formatting for better organization.
             </p>
@@ -238,14 +236,14 @@ export function ClientNotesPanel({
           />
 
           <div className="flex items-center justify-between mt-3">
-            <span className="text-xs text-gray-400 dark:text-gray-500">
+            <span className="text-xs text-ink-4 ">
               {hasContent(newNote) ? 'Press Cmd+Enter to save' : ''}
             </span>
             <Button
               onClick={handleSaveNote}
               disabled={!hasContent(newNote) || isSaving || !guestToken}
               size="sm"
-              className="bg-blue-600 hover:bg-blue-700 text-white"
+              className="bg-ds-accent hover:bg-ds-accent text-ink-on-dark"
             >
               {isSaving ? (
                 <>
@@ -266,22 +264,17 @@ export function ClientNotesPanel({
         {isLoading ? (
           <div className="flex-1 flex items-center justify-center">
             <div className="text-center">
-              <Loader2 className="h-6 w-6 mx-auto animate-spin text-gray-400 dark:text-gray-500 mb-2" />
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Loading your notes...
-              </p>
+              <Loader2 className="h-6 w-6 mx-auto animate-spin text-ink-4 mb-2" />
+              <p className="text-sm text-ink-3 ">Loading your notes...</p>
             </div>
           </div>
         ) : notes.length > 0 ? (
           <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-            <div className="px-4 py-2 bg-gray-50 dark:bg-gray-900/50 flex items-center justify-between flex-shrink-0">
-              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+            <div className="px-4 py-2 bg-paper flex items-center justify-between flex-shrink-0">
+              <span className="text-xs font-medium text-ink-3 ">
                 Your Notes
               </span>
-              <Badge
-                variant="secondary"
-                className="text-xs dark:bg-gray-700 dark:text-gray-300"
-              >
+              <Badge variant="secondary" className="text-xs ">
                 {notes.length}
               </Badge>
             </div>
@@ -289,7 +282,7 @@ export function ClientNotesPanel({
               {notes.map(note => (
                 <div
                   key={note.id}
-                  className="px-4 py-3 border-b border-gray-50 dark:border-gray-700 last:border-b-0 hover:bg-gray-50/50 dark:hover:bg-gray-700/50"
+                  className="px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper/50 "
                 >
                   {editingId === note.id ? (
                     <div className="space-y-2">
@@ -312,7 +305,7 @@ export function ClientNotesPanel({
                           size="sm"
                           onClick={() => handleUpdateNote(note.id)}
                           disabled={!hasContent(editContent)}
-                          className="h-7 text-xs bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900"
+                          className="h-7 text-xs bg-ink hover:bg-ink-2 text-ink-on-dark "
                         >
                           <Check className="h-3 w-3 mr-1" />
                           Save
@@ -323,27 +316,27 @@ export function ClientNotesPanel({
                     <div>
                       <div className="flex items-start justify-between gap-2">
                         <div
-                          className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3 flex-1 prose prose-sm dark:prose-invert max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0.5"
+                          className="text-sm text-ink-2 line-clamp-3 flex-1 prose prose-sm dark:prose-invert max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0.5"
                           dangerouslySetInnerHTML={{ __html: note.content }}
                         />
                         <div className="flex items-center gap-1 flex-shrink-0">
                           <button
                             onClick={() => startEditing(note)}
-                            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                            className="p-1 text-ink-4 hover:text-ink-3 hover:bg-surface-3 rounded"
                             title="Edit note"
                           >
                             <Pencil className="h-3.5 w-3.5" />
                           </button>
                           <button
                             onClick={() => handleDeleteNote(note.id)}
-                            className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded"
+                            className="p-1 text-ink-4 hover:text-vermillion hover:bg-vermillion-bg rounded"
                             title="Delete note"
                           >
                             <Trash2 className="h-3.5 w-3.5" />
                           </button>
                         </div>
                       </div>
-                      <span className="text-xs text-gray-400 dark:text-gray-500 mt-1.5 block">
+                      <span className="text-xs text-ink-4 mt-1.5 block">
                         {formatRelativeTime(note.created_at)}
                       </span>
                     </div>
@@ -355,13 +348,11 @@ export function ClientNotesPanel({
         ) : (
           <div className="flex-1 flex items-center justify-center p-6">
             <div className="text-center">
-              <div className="w-12 h-12 bg-gray-100 dark:bg-gray-700 rounded-xl flex items-center justify-center mx-auto mb-3">
-                <FileText className="h-6 w-6 text-gray-400 dark:text-gray-500" />
+              <div className="w-12 h-12 bg-surface-3 rounded-xl flex items-center justify-center mx-auto mb-3">
+                <FileText className="h-6 w-6 text-ink-4 " />
               </div>
-              <h3 className="font-medium text-gray-700 dark:text-gray-300 mb-1">
-                No notes yet
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 max-w-[200px] mx-auto">
+              <h3 className="font-medium text-ink-2 mb-1">No notes yet</h3>
+              <p className="text-sm text-ink-3 max-w-[200px] mx-auto">
                 Use the editor above to capture your thoughts and insights
               </p>
             </div>
@@ -369,27 +360,24 @@ export function ClientNotesPanel({
         )}
         {/* Collapsible Resources Section */}
         {resources.length > 0 && (
-          <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex-shrink-0 border-t border-line ">
             <button
               onClick={() => setResourcesOpen(!resourcesOpen)}
-              className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+              className="w-full flex items-center justify-between px-4 py-3 hover:bg-paper transition-colors"
             >
               <div className="flex items-center gap-2">
-                <BookOpen className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                <BookOpen className="h-4 w-4 text-ds-accent " />
+                <span className="text-sm font-medium text-ink-2 ">
                   Shared Resources
                 </span>
-                <Badge
-                  variant="secondary"
-                  className="text-xs px-1.5 py-0 h-5 dark:bg-gray-700 dark:text-gray-300"
-                >
+                <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5 ">
                   {resources.length}
                 </Badge>
               </div>
               {resourcesOpen ? (
-                <ChevronUp className="h-4 w-4 text-gray-400" />
+                <ChevronUp className="h-4 w-4 text-ink-4" />
               ) : (
-                <ChevronDown className="h-4 w-4 text-gray-400" />
+                <ChevronDown className="h-4 w-4 text-ink-4" />
               )}
             </button>
 
@@ -404,17 +392,17 @@ export function ClientNotesPanel({
                   return (
                     <div
                       key={resource.id}
-                      className="flex items-center gap-3 p-2.5 rounded-lg border border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600 transition-colors"
+                      className="flex items-center gap-3 p-2.5 rounded-lg border border-line hover:border-line transition-colors"
                     >
                       <div className={`p-1.5 rounded-lg ${colors.bg} shrink-0`}>
                         <Icon className={`h-3.5 w-3.5 ${colors.text}`} />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <p className="text-sm font-medium text-ink truncate">
                           {resource.title}
                         </p>
                         {resource.description && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                          <p className="text-xs text-ink-3 truncate">
                             {resource.description}
                           </p>
                         )}
@@ -424,7 +412,7 @@ export function ClientNotesPanel({
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="h-7 w-7 p-0 text-gray-400 hover:text-blue-600"
+                            className="h-7 w-7 p-0 text-ink-4 hover:text-ds-accent"
                             onClick={() =>
                               window.open(resource.file_url!, '_blank')
                             }
@@ -437,7 +425,7 @@ export function ClientNotesPanel({
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="h-7 w-7 p-0 text-gray-400 hover:text-blue-600"
+                            className="h-7 w-7 p-0 text-ink-4 hover:text-ds-accent"
                             onClick={() =>
                               window.open(
                                 resource.content_url!,

--- a/src/app/client-meeting/[token]/components/client-resources-panel.tsx
+++ b/src/app/client-meeting/[token]/components/client-resources-panel.tsx
@@ -81,16 +81,14 @@ export function ClientResourcesPanel({
   }, [fetchResources, guestToken])
 
   return (
-    <Card className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 flex flex-col h-full">
+    <Card className="bg-surface-1 rounded-2xl shadow-sm border border-line flex flex-col h-full">
       {/* Header */}
-      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between flex-shrink-0">
+      <div className="px-5 py-4 border-b border-line flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-2.5">
-          <div className="p-1.5 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
-            <BookOpen className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+          <div className="p-1.5 bg-ds-accent-bg rounded-lg">
+            <BookOpen className="h-4 w-4 text-ds-accent " />
           </div>
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-            Shared Resources
-          </h3>
+          <h3 className="text-sm font-semibold text-ink ">Shared Resources</h3>
           {resources.length > 0 && (
             <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5">
               {resources.length}
@@ -102,7 +100,7 @@ export function ClientResourcesPanel({
           size="sm"
           onClick={fetchResources}
           disabled={isLoading}
-          className="h-7 w-7 p-0 text-gray-400 hover:text-gray-600"
+          className="h-7 w-7 p-0 text-ink-4 hover:text-ink-3"
         >
           <RefreshCw
             className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`}
@@ -113,13 +111,13 @@ export function ClientResourcesPanel({
       {/* Content */}
       <div className="flex-1 overflow-y-auto min-h-0">
         {isLoading && resources.length === 0 ? (
-          <div className="p-6 flex items-center justify-center gap-2 text-gray-400">
+          <div className="p-6 flex items-center justify-center gap-2 text-ink-4">
             <Loader2 className="h-4 w-4 animate-spin" />
             <span className="text-sm">Loading resources...</span>
           </div>
         ) : error ? (
           <div className="p-6 text-center">
-            <p className="text-sm text-gray-500 dark:text-gray-400">{error}</p>
+            <p className="text-sm text-ink-3 ">{error}</p>
             <Button
               variant="outline"
               size="sm"
@@ -131,11 +129,9 @@ export function ClientResourcesPanel({
           </div>
         ) : resources.length === 0 ? (
           <div className="p-8 text-center">
-            <BookOpen className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              No resources yet
-            </p>
-            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+            <BookOpen className="h-10 w-10 text-ink-2 mx-auto mb-3" />
+            <p className="text-sm font-medium text-ink-3 ">No resources yet</p>
+            <p className="text-xs text-ink-4 mt-1">
               Resources shared by your coach will appear here
             </p>
           </div>
@@ -150,18 +146,18 @@ export function ClientResourcesPanel({
               return (
                 <div
                   key={resource.id}
-                  className="p-3 rounded-lg border border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600 transition-colors"
+                  className="p-3 rounded-lg border border-line hover:border-line transition-colors"
                 >
                   <div className="flex items-start gap-3">
                     <div className={`p-2 rounded-lg ${colors.bg} shrink-0`}>
                       <Icon className={`h-4 w-4 ${colors.text}`} />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
+                      <p className="text-sm font-medium text-ink ">
                         {resource.title}
                       </p>
                       {resource.description && (
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">
+                        <p className="text-xs text-ink-3 mt-0.5 line-clamp-2">
                           {resource.description}
                         </p>
                       )}
@@ -175,7 +171,7 @@ export function ClientResourcesPanel({
                           ] || resource.category}
                         </Badge>
                         {resource.tags?.length > 0 && (
-                          <span className="text-xs text-gray-400">
+                          <span className="text-xs text-ink-4">
                             {resource.tags.slice(0, 2).join(', ')}
                           </span>
                         )}

--- a/src/app/client-meeting/[token]/components/meeting-ended-overlay.tsx
+++ b/src/app/client-meeting/[token]/components/meeting-ended-overlay.tsx
@@ -41,21 +41,19 @@ export function MeetingEndedOverlay({
   }, [])
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="max-w-md w-full border-gray-200 dark:border-gray-700 shadow-2xl dark:bg-gray-800">
+    <div className="fixed inset-0 bg-overlay backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <Card className="max-w-md w-full border-line shadow-2xl ">
         <CardContent className="p-8 text-center">
           {/* Success Icon */}
-          <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
-            <CheckCircle className="h-8 w-8 text-green-600 dark:text-green-400" />
+          <div className="w-16 h-16 bg-forest-bg rounded-full flex items-center justify-center mx-auto mb-6">
+            <CheckCircle className="h-8 w-8 text-forest " />
           </div>
 
           {/* Title */}
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-            Session Complete
-          </h2>
+          <h2 className="text-2xl font-bold text-ink mb-2">Session Complete</h2>
 
           {/* Subtitle */}
-          <p className="text-gray-600 dark:text-gray-400 mb-6">
+          <p className="text-ink-3 mb-6">
             {coachName
               ? `Your session with ${coachName} has ended.`
               : 'This coaching session has ended.'}
@@ -63,30 +61,30 @@ export function MeetingEndedOverlay({
 
           {/* Summary Stats */}
           {(notesCount > 0 || commitmentsCount > 0) && (
-            <div className="flex justify-center gap-6 mb-6 py-4 border-y border-gray-100 dark:border-gray-700">
+            <div className="flex justify-center gap-6 mb-6 py-4 border-y border-line ">
               {notesCount > 0 && (
                 <div className="text-center">
-                  <div className="flex items-center justify-center gap-1.5 text-gray-700 dark:text-gray-300">
+                  <div className="flex items-center justify-center gap-1.5 text-ink-2 ">
                     <FileText className="h-4 w-4" />
                     <span className="text-2xl font-bold">{notesCount}</span>
                   </div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-xs text-ink-3 mt-1">
                     {notesCount === 1 ? 'Note' : 'Notes'} saved
                   </p>
                 </div>
               )}
               {notesCount > 0 && commitmentsCount > 0 && (
-                <div className="w-px bg-gray-200 dark:bg-gray-700" />
+                <div className="w-px bg-surface-3 " />
               )}
               {commitmentsCount > 0 && (
                 <div className="text-center">
-                  <div className="flex items-center justify-center gap-1.5 text-gray-700 dark:text-gray-300">
+                  <div className="flex items-center justify-center gap-1.5 text-ink-2 ">
                     <Target className="h-4 w-4" />
                     <span className="text-2xl font-bold">
                       {commitmentsCount}
                     </span>
                   </div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-xs text-ink-3 mt-1">
                     {commitmentsCount === 1 ? 'Commitment' : 'Commitments'}
                   </p>
                 </div>
@@ -110,7 +108,7 @@ export function MeetingEndedOverlay({
                   Open Thrill Form
                 </Button>
               </a>
-              <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+              <p className="text-xs text-ink-4 mt-2">
                 We&apos;ve also emailed you the link.
               </p>
             </div>
@@ -119,7 +117,7 @@ export function MeetingEndedOverlay({
           {/* Message & Actions - different for logged in vs guest */}
           {isLoggedIn ? (
             <>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+              <p className="text-sm text-ink-3 mb-6">
                 Your notes and commitments have been saved. You can review them
                 in your dashboard.
               </p>
@@ -132,7 +130,7 @@ export function MeetingEndedOverlay({
                 </Link>
                 <Button
                   variant="ghost"
-                  className="text-gray-500 dark:text-gray-400"
+                  className="text-ink-3 "
                   onClick={() => window.close()}
                 >
                   Close this page
@@ -141,7 +139,7 @@ export function MeetingEndedOverlay({
             </>
           ) : (
             <>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+              <p className="text-sm text-ink-3 mb-6">
                 Your notes and commitments have been saved. You can access them
                 anytime by signing up for the client portal.
               </p>
@@ -154,17 +152,17 @@ export function MeetingEndedOverlay({
                 </Link>
                 <Button
                   variant="ghost"
-                  className="text-gray-500 dark:text-gray-400"
+                  className="text-ink-3 "
                   onClick={() => window.close()}
                 >
                   Close this page
                 </Button>
               </div>
-              <p className="text-xs text-gray-400 dark:text-gray-500 mt-4">
+              <p className="text-xs text-ink-4 mt-4">
                 Already have an account?{' '}
                 <Link
                   href="/client-portal/auth/signup"
-                  className="text-gray-600 dark:text-gray-300 hover:underline"
+                  className="text-ink-3 hover:underline"
                 >
                   Sign in
                 </Link>

--- a/src/app/client-meeting/[token]/components/past-commitments-panel.tsx
+++ b/src/app/client-meeting/[token]/components/past-commitments-panel.tsx
@@ -72,48 +72,48 @@ export function PastCommitmentsPanel({
 
   const getStatusIcon = (status: string) => {
     return status === 'completed' ? (
-      <CheckCircle2 className="h-4 w-4 text-green-500" />
+      <CheckCircle2 className="h-4 w-4 text-forest" />
     ) : (
-      <Circle className="h-4 w-4 text-gray-300 dark:text-gray-500" />
+      <Circle className="h-4 w-4 text-ink-2 " />
     )
   }
 
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-400'
+        return 'bg-forest-bg text-forest '
       case 'active':
-        return 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400'
+        return 'bg-ds-accent-bg text-ds-accent '
       case 'abandoned':
-        return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400'
+        return 'bg-surface-3 text-ink-2 '
       default:
-        return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400'
+        return 'bg-surface-3 text-ink-2 '
     }
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 dark:bg-gray-800">
+    <Card className="border-line ">
       <CardHeader
-        className="border-b border-gray-100 dark:border-gray-700 py-3 cursor-pointer hover:bg-gray-50/50 dark:hover:bg-gray-700/50 transition-colors"
+        className="border-b border-line py-3 cursor-pointer hover:bg-paper/50 transition-colors"
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium flex items-center gap-2 text-gray-600 dark:text-gray-400">
+          <CardTitle className="text-sm font-medium flex items-center gap-2 text-ink-3 ">
             <History className="h-4 w-4" />
             Past Commitments
             {totalCount > 0 && (
               <Badge
                 variant="secondary"
-                className="bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs"
+                className="bg-surface-3 text-ink-3 text-xs"
               >
                 {totalCount}
               </Badge>
             )}
           </CardTitle>
           {isExpanded ? (
-            <ChevronUp className="h-4 w-4 text-gray-400" />
+            <ChevronUp className="h-4 w-4 text-ink-4" />
           ) : (
-            <ChevronDown className="h-4 w-4 text-gray-400" />
+            <ChevronDown className="h-4 w-4 text-ink-4" />
           )}
         </div>
       </CardHeader>
@@ -121,12 +121,12 @@ export function PastCommitmentsPanel({
       {isExpanded && (
         <CardContent className="p-0">
           {isLoading ? (
-            <div className="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">
+            <div className="text-center py-4 text-ink-3 text-sm">
               Loading...
             </div>
           ) : !pastCommitments || pastCommitments.length === 0 ? (
-            <div className="text-center py-6 text-gray-500 dark:text-gray-400">
-              <History className="h-6 w-6 mx-auto mb-2 text-gray-300 dark:text-gray-600" />
+            <div className="text-center py-6 text-ink-3 ">
+              <History className="h-6 w-6 mx-auto mb-2 text-ink-2 " />
               <p className="text-xs">No past commitments</p>
             </div>
           ) : (
@@ -135,7 +135,7 @@ export function PastCommitmentsPanel({
                 {pastCommitments.map((group, groupIndex) => (
                   <div key={groupIndex}>
                     {/* Session Date Header */}
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 flex items-center gap-1">
+                    <div className="text-xs font-medium text-ink-3 mb-2 flex items-center gap-1">
                       <Calendar className="h-3 w-3" />
                       {group.session_date
                         ? formatDate(group.session_date, 'MMM d, yyyy')
@@ -143,7 +143,7 @@ export function PastCommitmentsPanel({
                     </div>
 
                     {/* Commitments in this group */}
-                    <div className="space-y-2 pl-3 border-l-2 border-gray-100 dark:border-gray-700">
+                    <div className="space-y-2 pl-3 border-l-2 border-line ">
                       {(group?.commitments || []).map(commitment => (
                         <div
                           key={commitment.id}
@@ -154,8 +154,8 @@ export function PastCommitmentsPanel({
                             <p
                               className={`text-xs ${
                                 commitment.status === 'completed'
-                                  ? 'text-gray-500 dark:text-gray-400 line-through'
-                                  : 'text-gray-700 dark:text-gray-300'
+                                  ? 'text-ink-3 line-through'
+                                  : 'text-ink-2 '
                               }`}
                             >
                               {commitment.title}
@@ -169,7 +169,7 @@ export function PastCommitmentsPanel({
                               </Badge>
                               {commitment.progress_percentage > 0 &&
                                 commitment.progress_percentage < 100 && (
-                                  <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                                  <span className="text-[10px] text-ink-4 ">
                                     {commitment.progress_percentage}%
                                   </span>
                                 )}

--- a/src/app/client-meeting/[token]/page.tsx
+++ b/src/app/client-meeting/[token]/page.tsx
@@ -86,9 +86,9 @@ export default function ClientMeetingPage() {
   // Loading state
   if (isSessionLoading || isGuestLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
+      <div className="min-h-screen flex items-center justify-center  ">
         <div className="text-center">
-          <div className="w-16 h-16 bg-gray-900 rounded-2xl flex items-center justify-center shadow-lg mx-auto mb-4 p-2">
+          <div className="w-16 h-16 bg-ink rounded-2xl flex items-center justify-center shadow-lg mx-auto mb-4 p-2">
             <Image
               src="/novus-global-logo.webp"
               alt="Logo"
@@ -97,11 +97,9 @@ export default function ClientMeetingPage() {
               className="object-contain filter brightness-0 invert"
             />
           </div>
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-            Coach Sidekick
-          </h2>
+          <h2 className="text-xl font-bold text-ink mb-2">Coach Sidekick</h2>
           <LoadingSpinner className="mx-auto mb-4" />
-          <p className="text-gray-600 dark:text-gray-400">Joining session...</p>
+          <p className="text-ink-3 ">Joining session...</p>
         </div>
       </div>
     )
@@ -110,10 +108,10 @@ export default function ClientMeetingPage() {
   // Error state
   if (sessionError) {
     return (
-      <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
+      <div className="min-h-screen flex flex-col  ">
         <div className="flex-1 flex items-center justify-center p-4">
           <div className="text-center max-w-md">
-            <div className="w-12 h-12 bg-gray-900 rounded-xl flex items-center justify-center shadow-lg mx-auto mb-4 p-1.5">
+            <div className="w-12 h-12 bg-ink rounded-xl flex items-center justify-center shadow-lg mx-auto mb-4 p-1.5">
               <Image
                 src="/novus-global-logo.webp"
                 alt="Logo"
@@ -122,12 +120,10 @@ export default function ClientMeetingPage() {
                 className="object-contain filter brightness-0 invert"
               />
             </div>
-            <h1 className="text-lg font-bold text-gray-900 dark:text-white mb-6">
-              Coach Sidekick
-            </h1>
-            <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+            <h1 className="text-lg font-bold text-ink mb-6">Coach Sidekick</h1>
+            <div className="w-16 h-16 bg-vermillion-bg rounded-full flex items-center justify-center mx-auto mb-4">
               <svg
-                className="h-8 w-8 text-red-600 dark:text-red-400"
+                className="h-8 w-8 text-vermillion "
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -140,20 +136,16 @@ export default function ClientMeetingPage() {
                 />
               </svg>
             </div>
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-              Unable to Join
-            </h2>
-            <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {sessionError}
-            </p>
-            <p className="text-sm text-gray-500 dark:text-gray-500">
+            <h2 className="text-xl font-bold text-ink mb-2">Unable to Join</h2>
+            <p className="text-ink-3 mb-6">{sessionError}</p>
+            <p className="text-sm text-ink-3 ">
               The meeting link may have expired or been revoked.
             </p>
           </div>
         </div>
-        <footer className="flex-shrink-0 py-3 border-t border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60">
-          <div className="flex items-center justify-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-            <div className="w-5 h-5 bg-gray-900 rounded-md flex items-center justify-center p-0.5">
+        <footer className="flex-shrink-0 py-3 border-t border-line bg-surface-1/60 ">
+          <div className="flex items-center justify-center gap-2 text-sm text-ink-3 ">
+            <div className="w-5 h-5 bg-ink rounded-md flex items-center justify-center p-0.5">
               <Image
                 src="/novus-global-logo.webp"
                 alt="Logo"
@@ -164,9 +156,7 @@ export default function ClientMeetingPage() {
             </div>
             <span>
               Powered by{' '}
-              <span className="font-medium text-gray-700 dark:text-gray-300">
-                Coach Sidekick
-              </span>
+              <span className="font-medium text-ink-2 ">Coach Sidekick</span>
             </span>
           </div>
         </footer>
@@ -179,7 +169,7 @@ export default function ClientMeetingPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
+    <div className="min-h-screen flex flex-col  ">
       {/* Header */}
       <ClientMeetingHeader
         coachName={sessionInfo.coach_name}
@@ -216,10 +206,10 @@ export default function ClientMeetingPage() {
       </div>
 
       {/* Footer with branding */}
-      <footer className="flex-shrink-0 py-3 border-t border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 backdrop-blur-sm">
+      <footer className="flex-shrink-0 py-3 border-t border-line bg-surface-1/60 backdrop-blur-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-            <div className="w-5 h-5 bg-gray-900 rounded-md flex items-center justify-center p-0.5">
+          <div className="flex items-center justify-center gap-2 text-sm text-ink-3 ">
+            <div className="w-5 h-5 bg-ink rounded-md flex items-center justify-center p-0.5">
               <Image
                 src="/novus-global-logo.webp"
                 alt="Logo"
@@ -230,9 +220,7 @@ export default function ClientMeetingPage() {
             </div>
             <span>
               Powered by{' '}
-              <span className="font-medium text-gray-700 dark:text-gray-300">
-                Coach Sidekick
-              </span>
+              <span className="font-medium text-ink-2 ">Coach Sidekick</span>
             </span>
           </div>
         </div>

--- a/src/app/client-portal/auth/signup/page.tsx
+++ b/src/app/client-portal/auth/signup/page.tsx
@@ -127,7 +127,7 @@ function ClientSignupContent() {
 
   if (isValidating) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 to-blue-50">
+      <div className="min-h-screen flex items-center justify-center  ">
         <LoadingSpinner />
       </div>
     )
@@ -135,7 +135,7 @@ function ClientSignupContent() {
 
   if (!invitationInfo?.valid) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 to-blue-50 p-4">
+      <div className="min-h-screen flex items-center justify-center  p-4">
         <Alert className="max-w-md">
           <AlertDescription>
             {error || 'This invitation link is invalid or has expired.'}
@@ -148,7 +148,7 @@ function ClientSignupContent() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 to-blue-50 p-4">
+    <div className="min-h-screen flex items-center justify-center  p-4">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>
@@ -161,11 +161,11 @@ function ClientSignupContent() {
           </p>
           {/* NEW: Show message if user already exists */}
           {invitationInfo.existing_user && invitationInfo.existing_roles && (
-            <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-              <p className="text-sm text-blue-800">
+            <div className="mt-3 p-3 bg-ds-accent-bg border border-ds-accent rounded-lg">
+              <p className="text-sm text-ds-accent">
                 <strong>Existing Account Detected</strong>
               </p>
-              <p className="text-xs text-blue-600 mt-1">
+              <p className="text-xs text-ds-accent mt-1">
                 You already have an account as a{' '}
                 {invitationInfo.existing_roles
                   .map(r => r.replace('_', ' '))
@@ -188,7 +188,7 @@ function ClientSignupContent() {
                 className="bg-muted"
               />
               {invitationInfo.existing_user && (
-                <p className="text-xs text-blue-600 mt-1">
+                <p className="text-xs text-ds-accent mt-1">
                   This email is already registered in our system
                 </p>
               )}

--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -3,9 +3,7 @@
 import { useState, useEffect } from 'react'
 import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 import Link from 'next/link'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { ActiveSessionsCard } from '@/components/client-portal/active-sessions-card'
 import { ClientPortalChat } from '@/components/client-portal/client-portal-chat'
@@ -43,8 +41,9 @@ import {
   AlertTriangle,
   Loader2,
   Trash2,
+  Video,
 } from 'lucide-react'
-import { formatDate } from '@/lib/date-utils'
+import { formatDate, formatRelativeTime } from '@/lib/date-utils'
 import type { Task } from '@/services/client-dashboard-api'
 
 interface DashboardData {
@@ -289,36 +288,98 @@ export default function ClientDashboard() {
   }
 
   const lastSession = dashboardData.recent_sessions?.[0]
+  const firstName = dashboardData.client_info?.name?.split(' ')[0] || 'there'
+  const pendingTasks = dashboardData.stats?.pending_tasks ?? 0
+  const nextSession = dashboardData.stats?.next_session
+  const todayLabel = formatDate(new Date().toISOString(), 'EEEE, MMMM d')
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      {/* Header */}
-      <div className="mb-6">
-        <p className="text-ink-3 text-sm font-medium mb-1">{getGreeting()}</p>
-        <h1 className="text-3xl font-bold text-ink ">
-          {dashboardData.client_info?.name || 'Welcome back'}
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
+      {/* Header — calm greeting */}
+      <div className="mb-7">
+        <p className="text-[12px] font-medium text-ink-3 mb-1">{todayLabel}</p>
+        <h1 className="text-[30px] font-bold tracking-tight leading-[1.2] text-ink m-0">
+          {getGreeting()}, {firstName}.
         </h1>
-        <p className="text-ink-3 mt-1">
-          Your coaching journey at a glance
+        <p className="text-[13px] text-ink-3 mt-1.5">
+          {pendingTasks > 0 ? (
+            <>
+              You&apos;re on track this week.{' '}
+              <b className="font-medium text-ink-2">
+                {pendingTasks} commitment{pendingTasks === 1 ? '' : 's'} pending
+              </b>
+              .
+            </>
+          ) : (
+            <>Your coaching journey at a glance.</>
+          )}
           {dashboardData.coach_name && (
             <>
               <span className="mx-2">·</span>
-              <span className="text-ink-3 font-medium">
-                Coach: {dashboardData.coach_name}
-              </span>
-            </>
-          )}
-          {dashboardData.client_info?.member_since && (
-            <>
-              <span className="mx-2">·</span>
-              <span>
-                Member since{' '}
-                {formatDate(dashboardData.client_info.member_since, 'MMM yyyy')}
-              </span>
+              <span>Coach: {dashboardData.coach_name}</span>
             </>
           )}
         </p>
       </div>
+
+      {/* Hero — Next session */}
+      {nextSession && (
+        <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm p-7 mb-6">
+          <div className="flex flex-col lg:flex-row lg:items-start gap-6">
+            <div className="flex-1 min-w-0">
+              <span className="text-[11px] font-medium uppercase tracking-[0.04em] text-ink-3">
+                Next session
+              </span>
+              <h2 className="text-[24px] font-semibold tracking-tight m-0 mt-2 text-ink">
+                {formatDate(nextSession, 'EEEE, MMMM d · h:mm a')}
+              </h2>
+              <p className="m-0 mt-1 text-[14px] text-ink-3">
+                {dashboardData.coach_name
+                  ? `Weekly check-in with ${dashboardData.coach_name}`
+                  : 'Weekly check-in'}
+                <span className="mx-2">·</span>
+                {formatRelativeTime(nextSession)}
+              </p>
+              <div className="flex flex-wrap gap-3 mt-4">
+                <Button className="bg-ink text-ink-on-dark hover:bg-ink-2 h-9 px-3.5 text-[13px] font-medium">
+                  <Video className="h-3.5 w-3.5" />
+                  Join when ready
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-line bg-surface-1 text-ink hover:bg-surface-3 h-9 px-3.5 text-[13px] font-medium"
+                >
+                  Reschedule
+                </Button>
+              </div>
+            </div>
+            <div className="w-full lg:w-[260px] bg-surface-2 rounded-xl p-4 flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.04em] text-ink-3">
+                Your prep
+              </span>
+              <p className="m-0 text-[13px] leading-[1.5] text-ink-2">
+                Bring one moment from this week worth talking through with your
+                coach.
+              </p>
+              {dashboardData.coach_name && (
+                <div className="flex items-center gap-2 mt-2">
+                  <div className="w-6 h-6 rounded-full bg-surface-3 text-ink-2 inline-flex items-center justify-center text-[10px] font-semibold">
+                    {dashboardData.coach_name
+                      .split(' ')
+                      .map(n => n[0])
+                      .join('')
+                      .toUpperCase()
+                      .slice(0, 2)}
+                  </div>
+                  <span className="text-[12px] font-medium text-ink-2">
+                    {dashboardData.coach_name}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Active Sessions Banner */}
       <div className="mb-6">
@@ -371,7 +432,7 @@ export default function ClientDashboard() {
       )}
 
       {/* Two-Panel Layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)] gap-6 mb-8">
         {/* Left Panel - Coaching Data */}
         <div className="space-y-4">
           {/* Last Session Insights */}
@@ -392,59 +453,57 @@ export default function ClientDashboard() {
         </div>
       </div>
 
-      {/* Recent Sessions - Full Width */}
+      {/* Recent Sessions - Editorial rows */}
       {dashboardData.recent_sessions &&
         dashboardData.recent_sessions.length > 1 && (
-          <Card className="border-line ">
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg font-semibold">
-                  Recent Sessions
-                </CardTitle>
-                <Link href="/client-portal/sessions">
-                  <Button variant="ghost" size="sm">
-                    View All
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </Button>
-                </Link>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {dashboardData.recent_sessions.slice(1, 4).map(session => (
-                  <Link
-                    key={session.id}
-                    href={`/client-portal/sessions/${session.id}`}
-                  >
-                    <div className="group p-4 border border-line rounded-xl bg-surface-1 hover:border-line-strong hover:shadow-sm transition-all cursor-pointer">
-                      <div className="flex items-center justify-between mb-2">
-                        <p className="text-sm font-medium text-ink ">
-                          {formatDate(session.date, 'MMM d, yyyy')}
-                        </p>
-                        <Badge
-                          variant="secondary"
-                          className="text-xs bg-surface-3 text-ink-3 "
-                        >
-                          {session.duration_minutes} min
-                        </Badge>
-                      </div>
-                      {session.summary && (
-                        <p className="text-sm text-ink-3 line-clamp-2">
-                          {session.summary}
-                        </p>
-                      )}
-                      <div className="flex items-center justify-end mt-3">
-                        <span className="text-xs text-ink-3 group-hover:text-ink-2 font-medium">
-                          View details
-                          <ChevronRight className="h-3 w-3 inline ml-0.5" />
-                        </span>
-                      </div>
+          <div className="mb-2">
+            <div className="flex items-baseline justify-between mb-3">
+              <h3 className="text-[14px] font-semibold tracking-tight text-ink m-0">
+                Recent sessions
+              </h3>
+              <Link
+                href="/client-portal/sessions"
+                className="inline-flex items-center gap-1 text-[12px] font-medium text-ink-3 hover:text-ink"
+              >
+                View all
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+            <div className="border-t border-line">
+              {dashboardData.recent_sessions.slice(1, 5).map(session => (
+                <Link
+                  key={session.id}
+                  href={`/client-portal/sessions/${session.id}`}
+                  className="group flex items-center gap-4 py-5 px-2 border-b border-line transition-colors hover:bg-surface-2"
+                >
+                  <div className="w-14 flex flex-col items-center">
+                    <span className="text-[24px] font-semibold leading-none text-ink">
+                      {formatDate(session.date, 'd')}
+                    </span>
+                    <span className="font-mono text-[10px] uppercase text-ink-3 mt-1">
+                      {formatDate(session.date, 'MMM')}
+                    </span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="text-[14px] font-medium text-ink">
+                        {formatDate(session.date, 'EEEE')}
+                      </span>
+                      <span className="font-mono text-[11px] text-ink-3">
+                        {session.duration_minutes} min
+                      </span>
                     </div>
-                  </Link>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+                    {session.summary && (
+                      <p className="m-0 text-[13px] leading-[1.5] text-ink-2 line-clamp-2">
+                        {session.summary}
+                      </p>
+                    )}
+                  </div>
+                  <ChevronRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 flex-shrink-0" />
+                </Link>
+              ))}
+            </div>
+          </div>
         )}
 
       {/* ===== Modals ===== */}

--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -271,7 +271,7 @@ export default function ClientDashboard() {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center py-12">
-          <p className="text-red-600 mb-4">Error: {error}</p>
+          <p className="text-vermillion mb-4">Error: {error}</p>
           <Button onClick={fetchDashboardData}>Retry</Button>
         </div>
       </div>
@@ -282,7 +282,7 @@ export default function ClientDashboard() {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center py-12">
-          <p className="text-gray-600 dark:text-gray-400">No data available</p>
+          <p className="text-ink-3 ">No data available</p>
         </div>
       </div>
     )
@@ -294,18 +294,16 @@ export default function ClientDashboard() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
       {/* Header */}
       <div className="mb-6">
-        <p className="text-gray-500 dark:text-gray-400 text-sm font-medium mb-1">
-          {getGreeting()}
-        </p>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+        <p className="text-ink-3 text-sm font-medium mb-1">{getGreeting()}</p>
+        <h1 className="text-3xl font-bold text-ink ">
           {dashboardData.client_info?.name || 'Welcome back'}
         </h1>
-        <p className="text-gray-500 dark:text-gray-400 mt-1">
+        <p className="text-ink-3 mt-1">
           Your coaching journey at a glance
           {dashboardData.coach_name && (
             <>
               <span className="mx-2">·</span>
-              <span className="text-gray-600 dark:text-gray-400 font-medium">
+              <span className="text-ink-3 font-medium">
                 Coach: {dashboardData.coach_name}
               </span>
             </>
@@ -397,7 +395,7 @@ export default function ClientDashboard() {
       {/* Recent Sessions - Full Width */}
       {dashboardData.recent_sessions &&
         dashboardData.recent_sessions.length > 1 && (
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardHeader>
               <div className="flex items-center justify-between">
                 <CardTitle className="text-lg font-semibold">
@@ -418,25 +416,25 @@ export default function ClientDashboard() {
                     key={session.id}
                     href={`/client-portal/sessions/${session.id}`}
                   >
-                    <div className="group p-4 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all cursor-pointer">
+                    <div className="group p-4 border border-line rounded-xl bg-surface-1 hover:border-line-strong hover:shadow-sm transition-all cursor-pointer">
                       <div className="flex items-center justify-between mb-2">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white">
+                        <p className="text-sm font-medium text-ink ">
                           {formatDate(session.date, 'MMM d, yyyy')}
                         </p>
                         <Badge
                           variant="secondary"
-                          className="text-xs bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                          className="text-xs bg-surface-3 text-ink-3 "
                         >
                           {session.duration_minutes} min
                         </Badge>
                       </div>
                       {session.summary && (
-                        <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+                        <p className="text-sm text-ink-3 line-clamp-2">
                           {session.summary}
                         </p>
                       )}
                       <div className="flex items-center justify-end mt-3">
-                        <span className="text-xs text-gray-500 dark:text-gray-400 group-hover:text-gray-700 dark:group-hover:text-gray-300 font-medium">
+                        <span className="text-xs text-ink-3 group-hover:text-ink-2 font-medium">
                           View details
                           <ChevronRight className="h-3 w-3 inline ml-0.5" />
                         </span>
@@ -542,8 +540,8 @@ export default function ClientDashboard() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <div className="flex items-center gap-3 mb-2">
-              <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                <AlertTriangle className="h-5 w-5 text-red-600" />
+              <div className="p-2 bg-vermillion-bg rounded-full">
+                <AlertTriangle className="h-5 w-5 text-vermillion" />
               </div>
               <AlertDialogTitle>Delete Vision</AlertDialogTitle>
             </div>
@@ -559,7 +557,7 @@ export default function ClientDashboard() {
             <AlertDialogAction
               onClick={handleDeleteGoal}
               disabled={isDeletingGoal}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               {isDeletingGoal ? (
                 <>
@@ -586,8 +584,8 @@ export default function ClientDashboard() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <div className="flex items-center gap-3 mb-2">
-              <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                <AlertTriangle className="h-5 w-5 text-red-600" />
+              <div className="p-2 bg-vermillion-bg rounded-full">
+                <AlertTriangle className="h-5 w-5 text-vermillion" />
               </div>
               <AlertDialogTitle>Delete Outcome</AlertDialogTitle>
             </div>
@@ -603,7 +601,7 @@ export default function ClientDashboard() {
             <AlertDialogAction
               onClick={handleDeleteOutcome}
               disabled={isDeletingOutcome}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               {isDeletingOutcome ? (
                 <>
@@ -630,8 +628,8 @@ export default function ClientDashboard() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <div className="flex items-center gap-3 mb-2">
-              <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                <AlertTriangle className="h-5 w-5 text-red-600" />
+              <div className="p-2 bg-vermillion-bg rounded-full">
+                <AlertTriangle className="h-5 w-5 text-vermillion" />
               </div>
               <AlertDialogTitle>Delete Sprint</AlertDialogTitle>
             </div>
@@ -647,7 +645,7 @@ export default function ClientDashboard() {
             <AlertDialogAction
               onClick={handleDeleteSprint}
               disabled={isDeletingSprint}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               {isDeletingSprint ? (
                 <>

--- a/src/app/client-portal/persona/page.tsx
+++ b/src/app/client-portal/persona/page.tsx
@@ -132,15 +132,15 @@ export default function ClientPersonaPage() {
   if (noPersona || !persona) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-12">
-        <Card className="border-gray-200 dark:border-gray-700">
+        <Card className="border-line ">
           <CardContent className="flex flex-col items-center justify-center py-16 px-8">
-            <div className="h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-6">
-              <Brain className="h-8 w-8 text-gray-400 dark:text-gray-500" />
+            <div className="h-16 w-16 rounded-full bg-surface-3 flex items-center justify-center mb-6">
+              <Brain className="h-8 w-8 text-ink-4 " />
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3 text-center">
+            <h2 className="text-xl font-semibold text-ink mb-3 text-center">
               Your Coaching Persona is Being Developed
             </h2>
-            <p className="text-center text-gray-600 dark:text-gray-400 max-w-md mb-8">
+            <p className="text-center text-ink-3 max-w-md mb-8">
               {error ||
                 'Your personalized coaching profile will be available after a few sessions with your coach. This helps us provide better, more tailored coaching suggestions.'}
             </p>
@@ -190,68 +190,60 @@ export default function ClientPersonaPage() {
       {/* Header */}
       <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-2">
         <div>
-          <p className="text-gray-500 dark:text-gray-400 text-sm font-medium mb-1">
+          <p className="text-ink-3 text-sm font-medium mb-1">
             AI-Generated Profile
           </p>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-ink ">
             Your Coaching Persona
           </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-1">
+          <p className="text-ink-3 mt-1">
             Based on your coaching journey and sessions
           </p>
         </div>
 
         <div className="flex items-center gap-6 md:gap-8">
           <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+            <p className="text-2xl font-bold text-ink ">
               {persona.metadata.sessions_analyzed}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Sessions</p>
+            <p className="text-xs text-ink-3 ">Sessions</p>
           </div>
-          <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+          <div className="h-8 w-px bg-surface-3 " />
           <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">
-              {confidence}
-            </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Confidence
-            </p>
+            <p className="text-2xl font-bold text-ink ">{confidence}</p>
+            <p className="text-xs text-ink-3 ">Confidence</p>
           </div>
-          <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+          <div className="h-8 w-px bg-surface-3 " />
           <div className="text-center">
-            <p className="text-sm text-gray-900 dark:text-white">
+            <p className="text-sm text-ink ">
               {persona.metadata.last_updated
                 ? formatDate(persona.metadata.last_updated, 'MMM d')
                 : '-'}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Updated</p>
+            <p className="text-xs text-ink-3 ">Updated</p>
           </div>
           {dashboard?.stats?.current_streak_days > 0 && (
             <>
-              <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+              <div className="h-8 w-px bg-surface-3 " />
               <div className="text-center">
-                <p className="text-2xl font-bold text-gray-900 dark:text-white flex items-center justify-center gap-1">
-                  <Flame className="h-5 w-5 text-orange-500" />
+                <p className="text-2xl font-bold text-ink flex items-center justify-center gap-1">
+                  <Flame className="h-5 w-5 text-amber-token" />
                   {Math.floor(dashboard.stats.current_streak_days / 7) > 0
                     ? `${Math.floor(dashboard.stats.current_streak_days / 7)}w`
                     : `${dashboard.stats.current_streak_days}d`}
                 </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Streak
-                </p>
+                <p className="text-xs text-ink-3 ">Streak</p>
               </div>
             </>
           )}
           {dashboard?.stats?.total_sessions > 0 && (
             <>
-              <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+              <div className="h-8 w-px bg-surface-3 " />
               <div className="text-center">
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                <p className="text-2xl font-bold text-ink ">
                   {dashboard.stats.total_sessions}
                 </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Total
-                </p>
+                <p className="text-xs text-ink-3 ">Total</p>
               </div>
             </>
           )}
@@ -262,26 +254,24 @@ export default function ClientPersonaPage() {
       {hasProgress && (
         <section>
           <div className="flex items-center gap-2 mb-4">
-            <TrendingUp className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              Your Journey
-            </h2>
+            <TrendingUp className="h-5 w-5 text-ink-3 " />
+            <h2 className="text-lg font-semibold text-ink ">Your Journey</h2>
           </div>
-          <Card className="border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+          <Card className="border-line bg-paper ">
             <CardContent className="p-5 space-y-5">
               {/* Overall Trend */}
               {progress.overall_trend && (
                 <div className="flex items-center gap-3">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  <span className="text-sm font-medium text-ink-2 ">
                     Overall Trend:
                   </span>
                   <Badge
                     className={`${
                       progress.overall_trend === 'improving'
-                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                        ? 'bg-forest-bg text-forest '
                         : progress.overall_trend === 'declining'
-                          ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'
-                          : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                          ? 'bg-amber-token-bg text-amber-token '
+                          : 'bg-surface-3 text-ink-2 '
                     }`}
                   >
                     {progress.overall_trend === 'improving' && (
@@ -302,7 +292,7 @@ export default function ClientPersonaPage() {
               {/* Milestones */}
               {progress.milestones && progress.milestones.length > 0 && (
                 <div>
-                  <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wide">
+                  <p className="text-xs font-medium text-ink-3 mb-3 uppercase tracking-wide">
                     Milestones
                   </p>
                   <div className="flex items-center gap-3 overflow-x-auto pb-2">
@@ -311,12 +301,10 @@ export default function ClientPersonaPage() {
                         key={idx}
                         className="flex items-center gap-2 flex-shrink-0"
                       >
-                        {idx > 0 && (
-                          <div className="w-8 h-px bg-gray-300 dark:bg-gray-600" />
-                        )}
-                        <div className="flex items-center gap-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full px-3 py-1.5">
-                          <div className="h-2 w-2 rounded-full bg-gray-900 dark:bg-white" />
-                          <span className="text-xs text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {idx > 0 && <div className="w-8 h-px bg-line " />}
+                        <div className="flex items-center gap-2 bg-surface-1 border border-line rounded-full px-3 py-1.5">
+                          <div className="h-2 w-2 rounded-full bg-ink " />
+                          <span className="text-xs text-ink-2 whitespace-nowrap">
                             {milestone.type === 'first_session'
                               ? 'First Session'
                               : `${milestone.count} Sessions`}
@@ -333,7 +321,7 @@ export default function ClientPersonaPage() {
               {/* Engagement Dots */}
               {progress.timeline && progress.timeline.length > 0 && (
                 <div>
-                  <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">
+                  <p className="text-xs font-medium text-ink-3 mb-2 uppercase tracking-wide">
                     Session Engagement
                   </p>
                   <div className="flex items-center gap-1 flex-wrap">
@@ -343,19 +331,17 @@ export default function ClientPersonaPage() {
                         className={`h-3 w-3 rounded-full ${
                           entry.sentiment === 'positive' ||
                           entry.engagement_score > 7
-                            ? 'bg-green-500 dark:bg-green-400'
+                            ? 'bg-forest '
                             : entry.sentiment === 'negative' ||
                                 entry.engagement_score < 4
-                              ? 'bg-amber-500 dark:bg-amber-400'
-                              : 'bg-gray-300 dark:bg-gray-600'
+                              ? 'bg-amber-token '
+                              : 'bg-line '
                         }`}
                         title={`${formatDate(entry.date, 'MMM d')} - ${entry.sentiment || 'neutral'}`}
                       />
                     ))}
                   </div>
-                  <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                    Last 90 days
-                  </p>
+                  <p className="text-xs text-ink-4 mt-1">Last 90 days</p>
                 </div>
               )}
             </CardContent>
@@ -367,33 +353,33 @@ export default function ClientPersonaPage() {
       {hasBasicInfo && (
         <div className="flex flex-wrap gap-3">
           {persona.basic_info.occupation && (
-            <div className="flex items-center gap-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2">
-              <Briefcase className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+            <div className="flex items-center gap-2 bg-paper border border-line rounded-full px-4 py-2">
+              <Briefcase className="h-4 w-4 text-ink-3 " />
+              <span className="text-sm text-ink-2 ">
                 {persona.basic_info.occupation}
               </span>
             </div>
           )}
           {persona.basic_info.location && (
-            <div className="flex items-center gap-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2">
-              <MapPin className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+            <div className="flex items-center gap-2 bg-paper border border-line rounded-full px-4 py-2">
+              <MapPin className="h-4 w-4 text-ink-3 " />
+              <span className="text-sm text-ink-2 ">
                 {persona.basic_info.location}
               </span>
             </div>
           )}
           {persona.basic_info.age_range && (
-            <div className="flex items-center gap-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2">
-              <User className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+            <div className="flex items-center gap-2 bg-paper border border-line rounded-full px-4 py-2">
+              <User className="h-4 w-4 text-ink-3 " />
+              <span className="text-sm text-ink-2 ">
                 {persona.basic_info.age_range}
               </span>
             </div>
           )}
           {persona.basic_info.family_situation && (
-            <div className="flex items-center gap-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2">
-              <Users className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+            <div className="flex items-center gap-2 bg-paper border border-line rounded-full px-4 py-2">
+              <Users className="h-4 w-4 text-ink-3 " />
+              <span className="text-sm text-ink-2 ">
                 {persona.basic_info.family_situation}
               </span>
             </div>
@@ -405,30 +391,24 @@ export default function ClientPersonaPage() {
       {(hasPrimaryGoals || hasShortTermGoals || hasLongTermGoals) && (
         <section>
           <div className="flex items-center gap-2 mb-4">
-            <Target className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              Vision
-            </h2>
+            <Target className="h-5 w-5 text-ink-3 " />
+            <h2 className="text-lg font-semibold text-ink ">Vision</h2>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {hasPrimaryGoals && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3">
-                    Primary Vision
-                  </h3>
+                  <h3 className="font-medium text-ink mb-3">Primary Vision</h3>
                   <div className="space-y-3">
                     {persona.goals.primary.map((goal, idx) => (
                       <div key={idx} className="flex items-start gap-3">
-                        <div className="h-5 w-5 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center flex-shrink-0 mt-0.5">
-                          <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                        <div className="h-5 w-5 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 mt-0.5">
+                          <span className="text-xs font-medium text-ink-3 ">
                             {idx + 1}
                           </span>
                         </div>
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                          {goal}
-                        </p>
+                        <p className="text-sm text-ink-3 ">{goal}</p>
                       </div>
                     ))}
                   </div>
@@ -437,18 +417,14 @@ export default function ClientPersonaPage() {
             )}
 
             {hasShortTermGoals && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3">
-                    Short-term
-                  </h3>
+                  <h3 className="font-medium text-ink mb-3">Short-term</h3>
                   <div className="space-y-2">
                     {persona.goals.short_term.map((goal, idx) => (
                       <div key={idx} className="flex items-start gap-2">
-                        <ChevronRight className="h-4 w-4 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" />
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                          {goal}
-                        </p>
+                        <ChevronRight className="h-4 w-4 text-ink-4 mt-0.5 flex-shrink-0" />
+                        <p className="text-sm text-ink-3 ">{goal}</p>
                       </div>
                     ))}
                   </div>
@@ -457,18 +433,16 @@ export default function ClientPersonaPage() {
             )}
 
             {hasLongTermGoals && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3">
+                  <h3 className="font-medium text-ink mb-3">
                     Long-term Vision
                   </h3>
                   <div className="space-y-2">
                     {persona.goals.long_term.map((goal, idx) => (
                       <div key={idx} className="flex items-start gap-2">
-                        <ChevronRight className="h-4 w-4 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" />
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                          {goal}
-                        </p>
+                        <ChevronRight className="h-4 w-4 text-ink-4 mt-0.5 flex-shrink-0" />
+                        <p className="text-sm text-ink-3 ">{goal}</p>
                       </div>
                     ))}
                   </div>
@@ -484,8 +458,8 @@ export default function ClientPersonaPage() {
         <section>
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
-              <Target className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              <Target className="h-5 w-5 text-ink-3 " />
+              <h2 className="text-lg font-semibold text-ink ">
                 Goals & Commitments
               </h2>
             </div>
@@ -493,7 +467,7 @@ export default function ClientPersonaPage() {
               <Button
                 variant="ghost"
                 size="sm"
-                className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 text-xs"
+                className="text-ink-3 hover:text-ink-2 text-xs"
               >
                 View full board
                 <ArrowRight className="h-3 w-3 ml-1" />
@@ -502,14 +476,14 @@ export default function ClientPersonaPage() {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {activeGoals.length > 0 && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3 flex items-center gap-2">
-                    <Target className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <h3 className="font-medium text-ink mb-3 flex items-center gap-2">
+                    <Target className="h-4 w-4 text-ink-3 " />
                     Active Goals
                     <Badge
                       variant="secondary"
-                      className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs ml-auto"
+                      className="bg-surface-3 text-ink-3 text-xs ml-auto"
                     >
                       {activeGoals.length}
                     </Badge>
@@ -518,10 +492,10 @@ export default function ClientPersonaPage() {
                     {activeGoals.slice(0, 4).map((goal: any) => (
                       <div key={goal.id}>
                         <div className="flex items-center justify-between mb-1">
-                          <p className="text-sm text-gray-700 dark:text-gray-300 truncate flex-1 mr-2">
+                          <p className="text-sm text-ink-2 truncate flex-1 mr-2">
                             {goal.title}
                           </p>
-                          <span className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0">
+                          <span className="text-xs text-ink-3 flex-shrink-0">
                             {goal.progress}%
                           </span>
                         </div>
@@ -533,22 +507,22 @@ export default function ClientPersonaPage() {
               </Card>
             )}
             {commitmentStats.total > 0 && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3 flex items-center gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <h3 className="font-medium text-ink mb-3 flex items-center gap-2">
+                    <CheckCircle2 className="h-4 w-4 text-ink-3 " />
                     Commitments
                   </h3>
                   <div className="flex items-center gap-3 mt-2">
-                    <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                    <Badge className="bg-ds-accent-bg text-ds-accent ">
                       {commitmentStats.active} active
                     </Badge>
-                    <Badge className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                    <Badge className="bg-forest-bg text-forest ">
                       {commitmentStats.completed} completed
                     </Badge>
                     <Badge
                       variant="secondary"
-                      className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                      className="bg-surface-3 text-ink-3 "
                     >
                       {commitmentStats.total} total
                     </Badge>
@@ -565,20 +539,18 @@ export default function ClientPersonaPage() {
         <section>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {hasStrengths && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <Sparkles className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
-                      Your Strengths
-                    </h3>
+                    <Sparkles className="h-5 w-5 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">Your Strengths</h3>
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {persona.development.strengths.map((strength, idx) => (
                       <Badge
                         key={idx}
                         variant="secondary"
-                        className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                        className="bg-surface-3 text-ink-2 "
                       >
                         {strength}
                       </Badge>
@@ -589,21 +561,19 @@ export default function ClientPersonaPage() {
             )}
 
             {hasGrowthAreas && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <Lightbulb className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
+                    <Lightbulb className="h-5 w-5 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">
                       Growth Opportunities
                     </h3>
                   </div>
                   <div className="space-y-2">
                     {persona.development.growth_areas.map((area, idx) => (
                       <div key={idx} className="flex items-start gap-2">
-                        <ChevronRight className="h-4 w-4 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" />
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                          {area}
-                        </p>
+                        <ChevronRight className="h-4 w-4 text-ink-4 mt-0.5 flex-shrink-0" />
+                        <p className="text-sm text-ink-3 ">{area}</p>
                       </div>
                     ))}
                   </div>
@@ -618,26 +588,24 @@ export default function ClientPersonaPage() {
       {hasTriggers && (
         <section>
           <div className="flex items-center gap-2 mb-4">
-            <Eye className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            <Eye className="h-5 w-5 text-ink-3 " />
+            <h2 className="text-lg font-semibold text-ink ">
               Patterns to Watch
             </h2>
           </div>
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardContent className="p-5">
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+              <p className="text-xs text-ink-3 mb-3">
                 Self-awareness insights from your coaching sessions
               </p>
               <div className="space-y-2">
                 {persona.development.triggers.map((trigger, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-2 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                    className="flex items-start gap-3 p-2 bg-paper rounded-lg"
                   >
-                    <Eye className="h-4 w-4 text-gray-500 dark:text-gray-400 mt-0.5 flex-shrink-0" />
-                    <p className="text-sm text-gray-600 dark:text-gray-400">
-                      {trigger}
-                    </p>
+                    <Eye className="h-4 w-4 text-ink-3 mt-0.5 flex-shrink-0" />
+                    <p className="text-sm text-ink-3 ">{trigger}</p>
                   </div>
                 ))}
               </div>
@@ -650,27 +618,25 @@ export default function ClientPersonaPage() {
       {(hasChallenges || hasObstacles) && (
         <section>
           <div className="flex items-center gap-2 mb-4">
-            <AlertTriangle className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            <AlertTriangle className="h-5 w-5 text-ink-3 " />
+            <h2 className="text-lg font-semibold text-ink ">
               Challenges to Overcome
             </h2>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {hasChallenges && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3">
+                  <h3 className="font-medium text-ink mb-3">
                     Current Challenges
                   </h3>
                   <div className="space-y-2">
                     {persona.challenges.main_challenges.map(
                       (challenge, idx) => (
                         <div key={idx} className="flex items-start gap-2">
-                          <div className="h-1.5 w-1.5 rounded-full bg-gray-400 dark:bg-gray-500 mt-2 flex-shrink-0" />
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            {challenge}
-                          </p>
+                          <div className="h-1.5 w-1.5 rounded-full bg-line mt-2 flex-shrink-0" />
+                          <p className="text-sm text-ink-3 ">{challenge}</p>
                         </div>
                       ),
                     )}
@@ -680,7 +646,7 @@ export default function ClientPersonaPage() {
             )}
 
             {hasObstacles && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   {persona.challenges.obstacles.length > 0 && (
                     <div
@@ -688,16 +654,13 @@ export default function ClientPersonaPage() {
                         persona.challenges.fears.length > 0 ? 'mb-4' : ''
                       }
                     >
-                      <h3 className="font-medium text-gray-900 dark:text-white mb-3 flex items-center gap-2">
-                        <Shield className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                      <h3 className="font-medium text-ink mb-3 flex items-center gap-2">
+                        <Shield className="h-4 w-4 text-ink-3 " />
                         Obstacles
                       </h3>
                       <div className="space-y-2">
                         {persona.challenges.obstacles.map((obstacle, idx) => (
-                          <p
-                            key={idx}
-                            className="text-sm text-gray-600 dark:text-gray-400 pl-6"
-                          >
+                          <p key={idx} className="text-sm text-ink-3 pl-6">
                             {obstacle}
                           </p>
                         ))}
@@ -706,15 +669,10 @@ export default function ClientPersonaPage() {
                   )}
                   {persona.challenges.fears.length > 0 && (
                     <div>
-                      <h3 className="font-medium text-gray-900 dark:text-white mb-3">
-                        Concerns
-                      </h3>
+                      <h3 className="font-medium text-ink mb-3">Concerns</h3>
                       <div className="space-y-2">
                         {persona.challenges.fears.map((fear, idx) => (
-                          <p
-                            key={idx}
-                            className="text-sm text-gray-600 dark:text-gray-400 pl-6"
-                          >
+                          <p key={idx} className="text-sm text-ink-3 pl-6">
                             {fear}
                           </p>
                         ))}
@@ -732,31 +690,29 @@ export default function ClientPersonaPage() {
       {(hasTraits || hasValues || hasStyles) && (
         <section>
           <div className="flex items-center gap-2 mb-4">
-            <Brain className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            <Brain className="h-5 w-5 text-ink-3 " />
+            <h2 className="text-lg font-semibold text-ink ">
               Personality & Style
             </h2>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {hasStyles && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <MessageCircle className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
-                      Style
-                    </h3>
+                    <MessageCircle className="h-4 w-4 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">Style</h3>
                   </div>
                   <div className="space-y-3">
                     {persona.personality.communication_style && (
                       <div>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+                        <p className="text-xs text-ink-3 uppercase tracking-wide mb-1">
                           Communication
                         </p>
                         <Badge
                           variant="secondary"
-                          className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                          className="bg-surface-3 text-ink-2 "
                         >
                           {persona.personality.communication_style}
                         </Badge>
@@ -764,12 +720,12 @@ export default function ClientPersonaPage() {
                     )}
                     {persona.personality.learning_style && (
                       <div>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+                        <p className="text-xs text-ink-3 uppercase tracking-wide mb-1">
                           Learning
                         </p>
                         <Badge
                           variant="secondary"
-                          className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                          className="bg-surface-3 text-ink-2 "
                         >
                           {persona.personality.learning_style}
                         </Badge>
@@ -781,17 +737,15 @@ export default function ClientPersonaPage() {
             )}
 
             {hasTraits && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
-                  <h3 className="font-medium text-gray-900 dark:text-white mb-3">
-                    Traits
-                  </h3>
+                  <h3 className="font-medium text-ink mb-3">Traits</h3>
                   <div className="flex flex-wrap gap-2">
                     {persona.personality.traits.map((trait, idx) => (
                       <Badge
                         key={idx}
                         variant="secondary"
-                        className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                        className="bg-surface-3 text-ink-2 "
                       >
                         {trait}
                       </Badge>
@@ -802,21 +756,17 @@ export default function ClientPersonaPage() {
             )}
 
             {hasValues && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-3">
-                    <Heart className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
-                      Core Values
-                    </h3>
+                    <Heart className="h-4 w-4 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">Core Values</h3>
                   </div>
                   <div className="space-y-2">
                     {persona.personality.values.map((value, idx) => (
                       <div key={idx} className="flex items-center gap-2">
-                        <div className="h-1.5 w-1.5 rounded-full bg-gray-400 dark:bg-gray-500" />
-                        <span className="text-sm text-gray-600 dark:text-gray-400">
-                          {value}
-                        </span>
+                        <div className="h-1.5 w-1.5 rounded-full bg-line " />
+                        <span className="text-sm text-ink-3 ">{value}</span>
                       </div>
                     ))}
                   </div>
@@ -832,11 +782,11 @@ export default function ClientPersonaPage() {
         <section>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {hasAchievements && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <Trophy className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
+                    <Trophy className="h-5 w-5 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">
                       Achievements & Breakthroughs
                     </h3>
                   </div>
@@ -844,10 +794,8 @@ export default function ClientPersonaPage() {
                     {persona.development.achievements.map(
                       (achievement, idx) => (
                         <div key={idx} className="flex items-start gap-3">
-                          <Trophy className="h-4 w-4 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" />
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            {achievement}
-                          </p>
+                          <Trophy className="h-4 w-4 text-ink-4 mt-0.5 flex-shrink-0" />
+                          <p className="text-sm text-ink-3 ">{achievement}</p>
                         </div>
                       ),
                     )}
@@ -857,11 +805,11 @@ export default function ClientPersonaPage() {
             )}
 
             {hasBreakthroughMoments && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <Star className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
+                    <Star className="h-5 w-5 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">
                       Breakthrough Moments
                     </h3>
                   </div>
@@ -869,10 +817,8 @@ export default function ClientPersonaPage() {
                     {persona.development.breakthrough_moments.map(
                       (moment, idx) => (
                         <div key={idx} className="flex items-start gap-3">
-                          <Sparkles className="h-4 w-4 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" />
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            {moment}
-                          </p>
+                          <Sparkles className="h-4 w-4 text-ink-4 mt-0.5 flex-shrink-0" />
+                          <p className="text-sm text-ink-3 ">{moment}</p>
                         </div>
                       ),
                     )}
@@ -882,20 +828,18 @@ export default function ClientPersonaPage() {
             )}
 
             {hasThemes && (
-              <Card className="border-gray-200 dark:border-gray-700">
+              <Card className="border-line ">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <BookOpen className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-                    <h3 className="font-medium text-gray-900 dark:text-white">
-                      Recurring Themes
-                    </h3>
+                    <BookOpen className="h-5 w-5 text-ink-3 " />
+                    <h3 className="font-medium text-ink ">Recurring Themes</h3>
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {persona.development.recurring_themes.map((theme, idx) => (
                       <Badge
                         key={idx}
                         variant="secondary"
-                        className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                        className="bg-surface-3 text-ink-2 "
                       >
                         {theme}
                       </Badge>

--- a/src/app/client-portal/persona/page.tsx
+++ b/src/app/client-portal/persona/page.tsx
@@ -131,24 +131,25 @@ export default function ClientPersonaPage() {
 
   if (noPersona || !persona) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-12">
-        <Card className="border-line ">
-          <CardContent className="flex flex-col items-center justify-center py-16 px-8">
-            <div className="h-16 w-16 rounded-full bg-surface-3 flex items-center justify-center mb-6">
-              <Brain className="h-8 w-8 text-ink-4 " />
-            </div>
-            <h2 className="text-xl font-semibold text-ink mb-3 text-center">
-              Your Coaching Persona is Being Developed
-            </h2>
-            <p className="text-center text-ink-3 max-w-md mb-8">
-              {error ||
-                'Your personalized coaching profile will be available after a few sessions with your coach. This helps us provide better, more tailored coaching suggestions.'}
-            </p>
-            <Button onClick={() => router.push('/client-portal/dashboard')}>
-              Back to Dashboard
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="max-w-[720px] mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
+        <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm flex flex-col items-center justify-center py-16 px-8 text-center">
+          <div className="h-14 w-14 rounded-full bg-surface-2 flex items-center justify-center mb-5">
+            <Brain className="h-7 w-7 text-ink-3" strokeWidth={1.75} />
+          </div>
+          <h2 className="text-[18px] font-semibold text-ink mb-2 m-0">
+            Your coaching profile is taking shape
+          </h2>
+          <p className="text-[13px] leading-[1.55] text-ink-3 max-w-md mb-7 m-0">
+            {error ||
+              'Your personalized profile builds as you complete sessions. Check back after a few coaching conversations.'}
+          </p>
+          <Button
+            onClick={() => router.push('/client-portal/dashboard')}
+            className="bg-ink text-ink-on-dark hover:bg-ink-2 h-9 px-3.5 text-[13px] font-medium"
+          >
+            Back to dashboard
+          </Button>
+        </div>
       </div>
     )
   }
@@ -185,67 +186,94 @@ export default function ClientPersonaPage() {
     (progress.timeline?.length > 0 || progress.milestones?.length > 0)
   const activeGoals = goals.filter((g: any) => g.status === 'active')
 
-  return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
-      {/* Header */}
-      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-2">
-        <div>
-          <p className="text-ink-3 text-sm font-medium mb-1">
-            AI-Generated Profile
-          </p>
-          <h1 className="text-3xl font-bold text-ink ">
-            Your Coaching Persona
-          </h1>
-          <p className="text-ink-3 mt-1">
-            Based on your coaching journey and sessions
-          </p>
-        </div>
+  const clientName = dashboard?.client_info?.name as string | undefined
+  const clientInitials = clientName
+    ? clientName
+        .split(' ')
+        .map(w => w[0])
+        .join('')
+        .toUpperCase()
+        .slice(0, 2)
+    : 'CP'
 
-        <div className="flex items-center gap-6 md:gap-8">
-          <div className="text-center">
-            <p className="text-2xl font-bold text-ink ">
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14 space-y-4">
+      {/* Editorial header */}
+      <div className="mb-3">
+        <h1 className="text-[30px] font-bold tracking-tight leading-[1.2] text-ink m-0">
+          Coaching profile
+        </h1>
+        <p className="text-[13px] text-ink-3 mt-1.5">
+          What your coach and Sidekick know about you. Built from your sessions.
+        </p>
+      </div>
+
+      {/* Identity card + stats */}
+      <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm p-6">
+        <div className="flex items-center gap-4">
+          <div className="w-[72px] h-[72px] rounded-full bg-ink text-ink-on-dark inline-flex items-center justify-center text-[20px] font-semibold flex-shrink-0">
+            {clientInitials}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-[20px] font-semibold tracking-tight text-ink m-0 truncate">
+              {clientName || 'Your coaching profile'}
+            </h2>
+            <p className="m-0 text-[13px] text-ink-3 truncate">
+              {dashboard?.coach_name
+                ? `Coached by ${dashboard.coach_name}`
+                : 'Profile built from your coaching sessions'}
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-7 gap-y-3 mt-5 pt-5 border-t border-line-2">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold m-0">
+              Sessions analyzed
+            </p>
+            <p className="text-[16px] font-semibold text-ink m-0 mt-0.5">
               {persona.metadata.sessions_analyzed}
             </p>
-            <p className="text-xs text-ink-3 ">Sessions</p>
           </div>
-          <div className="h-8 w-px bg-surface-3 " />
-          <div className="text-center">
-            <p className="text-2xl font-bold text-ink ">{confidence}</p>
-            <p className="text-xs text-ink-3 ">Confidence</p>
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold m-0">
+              Confidence
+            </p>
+            <p className="text-[16px] font-semibold text-ink m-0 mt-0.5">
+              {confidence}
+            </p>
           </div>
-          <div className="h-8 w-px bg-surface-3 " />
-          <div className="text-center">
-            <p className="text-sm text-ink ">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold m-0">
+              Last updated
+            </p>
+            <p className="text-[16px] font-semibold text-ink m-0 mt-0.5">
               {persona.metadata.last_updated
                 ? formatDate(persona.metadata.last_updated, 'MMM d')
-                : '-'}
+                : '–'}
             </p>
-            <p className="text-xs text-ink-3 ">Updated</p>
           </div>
           {dashboard?.stats?.current_streak_days > 0 && (
-            <>
-              <div className="h-8 w-px bg-surface-3 " />
-              <div className="text-center">
-                <p className="text-2xl font-bold text-ink flex items-center justify-center gap-1">
-                  <Flame className="h-5 w-5 text-amber-token" />
-                  {Math.floor(dashboard.stats.current_streak_days / 7) > 0
-                    ? `${Math.floor(dashboard.stats.current_streak_days / 7)}w`
-                    : `${dashboard.stats.current_streak_days}d`}
-                </p>
-                <p className="text-xs text-ink-3 ">Streak</p>
-              </div>
-            </>
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold m-0">
+                Streak
+              </p>
+              <p className="text-[16px] font-semibold text-ink m-0 mt-0.5 inline-flex items-center gap-1">
+                <Flame className="h-3.5 w-3.5 text-amber-token" />
+                {Math.floor(dashboard.stats.current_streak_days / 7) > 0
+                  ? `${Math.floor(dashboard.stats.current_streak_days / 7)}w`
+                  : `${dashboard.stats.current_streak_days}d`}
+              </p>
+            </div>
           )}
           {dashboard?.stats?.total_sessions > 0 && (
-            <>
-              <div className="h-8 w-px bg-surface-3 " />
-              <div className="text-center">
-                <p className="text-2xl font-bold text-ink ">
-                  {dashboard.stats.total_sessions}
-                </p>
-                <p className="text-xs text-ink-3 ">Total</p>
-              </div>
-            </>
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold m-0">
+                Total sessions
+              </p>
+              <p className="text-[16px] font-semibold text-ink m-0 mt-0.5">
+                {dashboard.stats.total_sessions}
+              </p>
+            </div>
           )}
         </div>
       </div>

--- a/src/app/client-portal/profile/page.tsx
+++ b/src/app/client-portal/profile/page.tsx
@@ -235,10 +235,8 @@ export default function ClientProfilePage() {
       <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 py-10">
         <div className="flex items-center justify-center min-h-[60vh]">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-white mx-auto mb-4"></div>
-            <p className="text-gray-600 dark:text-gray-400">
-              Loading profile...
-            </p>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-line mx-auto mb-4"></div>
+            <p className="text-ink-3 ">Loading profile...</p>
           </div>
         </div>
       </div>
@@ -249,10 +247,8 @@ export default function ClientProfilePage() {
     <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 py-10">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-          Profile Settings
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400 mt-2">
+        <h1 className="text-3xl font-bold text-ink ">Profile Settings</h1>
+        <p className="text-ink-3 mt-2">
           Manage your account information and preferences
         </p>
       </div>
@@ -260,30 +256,28 @@ export default function ClientProfilePage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Left Column - Profile Card */}
         <div className="lg:col-span-1">
-          <Card className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+          <Card className="bg-surface-1 border-line ">
             <CardContent className="pt-6">
               <div className="flex flex-col items-center text-center">
-                <Avatar className="h-24 w-24 bg-white dark:bg-gray-900 border-4 border-gray-200 dark:border-gray-700 mb-4">
-                  <AvatarFallback className="bg-white dark:bg-gray-900 text-black dark:text-white text-2xl font-bold">
+                <Avatar className="h-24 w-24 bg-surface-1 border-4 border-line mb-4">
+                  <AvatarFallback className="bg-surface-1 text-ink text-2xl font-bold">
                     {profileData?.full_name
                       ? getInitials(profileData.full_name)
                       : user?.email?.slice(0, 2).toUpperCase()}
                   </AvatarFallback>
                 </Avatar>
 
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-1">
+                <h2 className="text-xl font-bold text-ink mb-1">
                   {profileData?.full_name || 'User'}
                 </h2>
-                <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
-                  {user?.email}
-                </p>
+                <p className="text-ink-3 text-sm mb-4">{user?.email}</p>
 
                 <div className="flex flex-wrap gap-2 justify-center mb-4">
                   {roles.map(role => (
                     <Badge
                       key={role}
                       variant="outline"
-                      className="bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300"
+                      className="bg-paper border-line-strong text-ink-2 "
                     >
                       {role === 'client' && <User className="h-3 w-3 mr-1" />}
                       {role === 'coach' && <Users className="h-3 w-3 mr-1" />}
@@ -294,7 +288,7 @@ export default function ClientProfilePage() {
                 </div>
 
                 {profileData?.created_at && (
-                  <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+                  <div className="flex items-center text-sm text-ink-3 ">
                     <Calendar className="h-4 w-4 mr-2" />
                     Member since{' '}
                     {formatDate(profileData.created_at, 'MMMM yyyy')}
@@ -302,26 +296,26 @@ export default function ClientProfilePage() {
                 )}
               </div>
 
-              <Separator className="my-6 bg-gray-50 dark:bg-gray-800" />
+              <Separator className="my-6 bg-paper " />
 
               {/* Coaches List */}
               {clientInfo.length > 0 && (
                 <div>
-                  <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                  <h3 className="text-sm font-semibold text-ink-2 mb-3">
                     Your Coaches
                   </h3>
                   <div className="space-y-3">
                     {clientInfo.map((client, index) => (
                       <div
                         key={index}
-                        className="flex items-start space-x-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600"
+                        className="flex items-start space-x-3 p-3 bg-paper rounded-lg border border-line-strong "
                       >
-                        <Users className="h-5 w-5 text-gray-600 dark:text-gray-400 mt-0.5" />
+                        <Users className="h-5 w-5 text-ink-3 mt-0.5" />
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                          <p className="text-sm font-medium text-ink truncate">
                             {client.coach_name || 'Coach'}
                           </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                          <p className="text-xs text-ink-3 truncate">
                             {client.coach_email || 'Email not available'}
                           </p>
                         </div>
@@ -337,47 +331,39 @@ export default function ClientProfilePage() {
         {/* Right Column - Edit Form */}
         <div className="lg:col-span-2 space-y-6">
           {/* Personal Information */}
-          <Card className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+          <Card className="bg-surface-1 border-line ">
             <CardHeader>
-              <CardTitle className="text-gray-900 dark:text-white">
-                Personal Information
-              </CardTitle>
-              <CardDescription className="text-gray-600 dark:text-gray-400">
+              <CardTitle className="text-ink ">Personal Information</CardTitle>
+              <CardDescription className="text-ink-3 ">
                 Update your personal details
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label
-                  htmlFor="email"
-                  className="text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="email" className="text-ink-2 ">
                   Email Address
                 </Label>
                 <div className="relative">
-                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
                   <Input
                     id="email"
                     type="email"
                     value={user?.email || ''}
                     disabled
-                    className="pl-10 bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 cursor-not-allowed"
+                    className="pl-10 bg-paper border-line-strong text-ink-3 cursor-not-allowed"
                   />
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-3 ">
                   Email cannot be changed. Contact support if needed.
                 </p>
               </div>
 
               <div className="space-y-2">
-                <Label
-                  htmlFor="full_name"
-                  className="text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="full_name" className="text-ink-2 ">
                   Full Name
                 </Label>
                 <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
                   <Input
                     id="full_name"
                     type="text"
@@ -388,7 +374,7 @@ export default function ClientProfilePage() {
                         full_name: e.target.value,
                       }))
                     }
-                    className="pl-10 bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder:text-gray-500 dark:placeholder:text-gray-400"
+                    className="pl-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
                     placeholder="Enter your full name"
                   />
                 </div>
@@ -397,25 +383,20 @@ export default function ClientProfilePage() {
           </Card>
 
           {/* Change Password */}
-          <Card className="bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+          <Card className="bg-surface-1 border-line ">
             <CardHeader>
-              <CardTitle className="text-gray-900 dark:text-white">
-                Change Password
-              </CardTitle>
-              <CardDescription className="text-gray-600 dark:text-gray-400">
+              <CardTitle className="text-ink ">Change Password</CardTitle>
+              <CardDescription className="text-ink-3 ">
                 Update your password to keep your account secure
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label
-                  htmlFor="current_password"
-                  className="text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="current_password" className="text-ink-2 ">
                   Current Password
                 </Label>
                 <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
                   <Input
                     id="current_password"
                     type={showPassword ? 'text' : 'password'}
@@ -426,13 +407,13 @@ export default function ClientProfilePage() {
                         current_password: e.target.value,
                       }))
                     }
-                    className="pl-10 pr-10 bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder:text-gray-500 dark:placeholder:text-gray-400"
+                    className="pl-10 pr-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
                     placeholder="Enter current password"
                   />
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-3 hover:text-ink-2 "
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -444,14 +425,11 @@ export default function ClientProfilePage() {
               </div>
 
               <div className="space-y-2">
-                <Label
-                  htmlFor="new_password"
-                  className="text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="new_password" className="text-ink-2 ">
                   New Password
                 </Label>
                 <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
                   <Input
                     id="new_password"
                     type={showPassword ? 'text' : 'password'}
@@ -462,7 +440,7 @@ export default function ClientProfilePage() {
                         new_password: e.target.value,
                       }))
                     }
-                    className="pl-10 bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder:text-gray-500 dark:placeholder:text-gray-400"
+                    className="pl-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
                     placeholder="Create a strong password"
                   />
                 </div>
@@ -478,14 +456,11 @@ export default function ClientProfilePage() {
               </div>
 
               <div className="space-y-2">
-                <Label
-                  htmlFor="confirm_password"
-                  className="text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="confirm_password" className="text-ink-2 ">
                   Confirm New Password
                 </Label>
                 <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
                   <Input
                     id="confirm_password"
                     type={showConfirmPassword ? 'text' : 'password'}
@@ -496,13 +471,13 @@ export default function ClientProfilePage() {
                         confirm_password: e.target.value,
                       }))
                     }
-                    className="pl-10 pr-10 bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder:text-gray-500 dark:placeholder:text-gray-400"
+                    className="pl-10 pr-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
                     placeholder="Confirm new password"
                   />
                   <button
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-3 hover:text-ink-2 "
                   >
                     {showConfirmPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -520,11 +495,11 @@ export default function ClientProfilePage() {
             <Button
               onClick={handleSaveProfile}
               disabled={saving}
-              className="bg-white text-black hover:bg-zinc-200 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+              className="bg-surface-1 text-ink hover:bg-surface-3 "
             >
               {saving ? (
                 <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-black border-t-transparent mr-2" />
+                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-ink border-t-transparent mr-2" />
                   Saving...
                 </>
               ) : (

--- a/src/app/client-portal/profile/page.tsx
+++ b/src/app/client-portal/profile/page.tsx
@@ -3,19 +3,9 @@
 import { useState, useEffect, useMemo } from 'react'
 import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 import { useAuth } from '@/contexts/auth-context'
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
-import { Badge } from '@/components/ui/badge'
-import { Separator } from '@/components/ui/separator'
 import { toast } from 'sonner'
 import {
   User,
@@ -23,7 +13,6 @@ import {
   Lock,
   Save,
   Users,
-  Calendar,
   Shield,
   Eye,
   EyeOff,
@@ -232,285 +221,289 @@ export default function ClientProfilePage() {
 
   if (loading) {
     return (
-      <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 py-10">
+      <div className="max-w-[720px] mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
         <div className="flex items-center justify-center min-h-[60vh]">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-line mx-auto mb-4"></div>
-            <p className="text-ink-3 ">Loading profile...</p>
+            <div className="animate-spin rounded-full h-7 w-7 border-2 border-line border-t-ink mx-auto mb-3" />
+            <p className="text-[13px] text-ink-3">Loading account…</p>
           </div>
         </div>
       </div>
     )
   }
 
+  const initials = profileData?.full_name
+    ? getInitials(profileData.full_name)
+    : user?.email?.slice(0, 2).toUpperCase() || 'U'
+
   return (
-    <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 py-10">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-ink ">Profile Settings</h1>
-        <p className="text-ink-3 mt-2">
-          Manage your account information and preferences
+    <div className="max-w-[720px] mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
+      {/* Header — editorial */}
+      <div className="mb-7">
+        <h1 className="text-[30px] font-bold tracking-tight leading-[1.2] text-ink m-0">
+          Account
+        </h1>
+        <p className="text-[13px] text-ink-3 mt-1.5">
+          Sign-in, profile details, and how you appear to your coach.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Left Column - Profile Card */}
-        <div className="lg:col-span-1">
-          <Card className="bg-surface-1 border-line ">
-            <CardContent className="pt-6">
-              <div className="flex flex-col items-center text-center">
-                <Avatar className="h-24 w-24 bg-surface-1 border-4 border-line mb-4">
-                  <AvatarFallback className="bg-surface-1 text-ink text-2xl font-bold">
-                    {profileData?.full_name
-                      ? getInitials(profileData.full_name)
-                      : user?.email?.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-
-                <h2 className="text-xl font-bold text-ink mb-1">
-                  {profileData?.full_name || 'User'}
-                </h2>
-                <p className="text-ink-3 text-sm mb-4">{user?.email}</p>
-
-                <div className="flex flex-wrap gap-2 justify-center mb-4">
-                  {roles.map(role => (
-                    <Badge
-                      key={role}
-                      variant="outline"
-                      className="bg-paper border-line-strong text-ink-2 "
-                    >
-                      {role === 'client' && <User className="h-3 w-3 mr-1" />}
-                      {role === 'coach' && <Users className="h-3 w-3 mr-1" />}
-                      {role === 'admin' && <Shield className="h-3 w-3 mr-1" />}
-                      {role.replace('_', ' ')}
-                    </Badge>
-                  ))}
-                </div>
-
-                {profileData?.created_at && (
-                  <div className="flex items-center text-sm text-ink-3 ">
-                    <Calendar className="h-4 w-4 mr-2" />
-                    Member since{' '}
-                    {formatDate(profileData.created_at, 'MMMM yyyy')}
-                  </div>
-                )}
-              </div>
-
-              <Separator className="my-6 bg-paper " />
-
-              {/* Coaches List */}
-              {clientInfo.length > 0 && (
-                <div>
-                  <h3 className="text-sm font-semibold text-ink-2 mb-3">
-                    Your Coaches
-                  </h3>
-                  <div className="space-y-3">
-                    {clientInfo.map((client, index) => (
-                      <div
-                        key={index}
-                        className="flex items-start space-x-3 p-3 bg-paper rounded-lg border border-line-strong "
-                      >
-                        <Users className="h-5 w-5 text-ink-3 mt-0.5" />
-                        <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-ink truncate">
-                            {client.coach_name || 'Coach'}
-                          </p>
-                          <p className="text-xs text-ink-3 truncate">
-                            {client.coach_email || 'Email not available'}
-                          </p>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+      {/* Identity card */}
+      <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm p-6 mb-4">
+        <div className="flex items-center gap-4">
+          <div className="w-[64px] h-[64px] rounded-full bg-ink text-ink-on-dark inline-flex items-center justify-center text-[18px] font-semibold flex-shrink-0">
+            {initials}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-[20px] font-semibold tracking-tight text-ink m-0 truncate">
+              {profileData?.full_name || 'User'}
+            </h2>
+            <p className="m-0 text-[13px] text-ink-3 truncate">{user?.email}</p>
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {roles.map(role => (
+                <span
+                  key={role}
+                  className="inline-flex items-center gap-1 h-[20px] px-1.5 rounded-md bg-surface-2 border border-line-2 text-ink-2 text-[10px] font-medium capitalize"
+                >
+                  {role === 'client' && <User className="h-3 w-3" />}
+                  {role === 'coach' && <Users className="h-3 w-3" />}
+                  {role === 'admin' && <Shield className="h-3 w-3" />}
+                  {role.replace('_', ' ')}
+                </span>
+              ))}
+            </div>
+          </div>
+          {profileData?.created_at && (
+            <div className="text-right flex-shrink-0 hidden sm:block">
+              <p className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.05em] font-semibold m-0">
+                Member since
+              </p>
+              <p className="text-[13px] font-medium text-ink-2 m-0 mt-0.5">
+                {formatDate(profileData.created_at, 'MMM yyyy')}
+              </p>
+            </div>
+          )}
         </div>
 
-        {/* Right Column - Edit Form */}
-        <div className="lg:col-span-2 space-y-6">
-          {/* Personal Information */}
-          <Card className="bg-surface-1 border-line ">
-            <CardHeader>
-              <CardTitle className="text-ink ">Personal Information</CardTitle>
-              <CardDescription className="text-ink-3 ">
-                Update your personal details
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="email" className="text-ink-2 ">
-                  Email Address
-                </Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
-                  <Input
-                    id="email"
-                    type="email"
-                    value={user?.email || ''}
-                    disabled
-                    className="pl-10 bg-paper border-line-strong text-ink-3 cursor-not-allowed"
-                  />
-                </div>
-                <p className="text-xs text-ink-3 ">
-                  Email cannot be changed. Contact support if needed.
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="full_name" className="text-ink-2 ">
-                  Full Name
-                </Label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
-                  <Input
-                    id="full_name"
-                    type="text"
-                    value={formData.full_name}
-                    onChange={e =>
-                      setFormData(prev => ({
-                        ...prev,
-                        full_name: e.target.value,
-                      }))
-                    }
-                    className="pl-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
-                    placeholder="Enter your full name"
-                  />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Change Password */}
-          <Card className="bg-surface-1 border-line ">
-            <CardHeader>
-              <CardTitle className="text-ink ">Change Password</CardTitle>
-              <CardDescription className="text-ink-3 ">
-                Update your password to keep your account secure
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="current_password" className="text-ink-2 ">
-                  Current Password
-                </Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
-                  <Input
-                    id="current_password"
-                    type={showPassword ? 'text' : 'password'}
-                    value={formData.current_password}
-                    onChange={e =>
-                      setFormData(prev => ({
-                        ...prev,
-                        current_password: e.target.value,
-                      }))
-                    }
-                    className="pl-10 pr-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
-                    placeholder="Enter current password"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-3 hover:text-ink-2 "
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="new_password" className="text-ink-2 ">
-                  New Password
-                </Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
-                  <Input
-                    id="new_password"
-                    type={showPassword ? 'text' : 'password'}
-                    value={formData.new_password}
-                    onChange={e =>
-                      setFormData(prev => ({
-                        ...prev,
-                        new_password: e.target.value,
-                      }))
-                    }
-                    className="pl-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
-                    placeholder="Create a strong password"
-                  />
-                </div>
-                {formData.new_password && (
-                  <div className="mt-2">
-                    <PasswordStrengthIndicator
-                      strength={passwordValidation.strength}
-                      score={passwordValidation.score}
-                      showRequirements={true}
-                    />
+        {clientInfo.length > 0 && (
+          <div className="border-t border-line-2 mt-5 pt-4">
+            <p className="font-mono text-[10px] text-ink-4 uppercase tracking-[0.05em] font-semibold m-0 mb-2">
+              Your coach
+            </p>
+            <div className="space-y-2">
+              {clientInfo.map((client, idx) => (
+                <div key={idx} className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-surface-2 text-ink-2 inline-flex items-center justify-center text-[11px] font-semibold flex-shrink-0">
+                    {(client.coach_name || 'Coach')
+                      .split(' ')
+                      .map(w => w[0])
+                      .join('')
+                      .toUpperCase()
+                      .slice(0, 2)}
                   </div>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="confirm_password" className="text-ink-2 ">
-                  Confirm New Password
-                </Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-3 " />
-                  <Input
-                    id="confirm_password"
-                    type={showConfirmPassword ? 'text' : 'password'}
-                    value={formData.confirm_password}
-                    onChange={e =>
-                      setFormData(prev => ({
-                        ...prev,
-                        confirm_password: e.target.value,
-                      }))
-                    }
-                    className="pl-10 pr-10 bg-paper border-line-strong text-ink placeholder:text-ink-3 "
-                    placeholder="Confirm new password"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-3 hover:text-ink-2 "
-                  >
-                    {showConfirmPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[13px] font-medium text-ink m-0 truncate">
+                      {client.coach_name || 'Coach'}
+                    </p>
+                    <p className="text-[12px] text-ink-3 m-0 truncate">
+                      {client.coach_email || 'Email not available'}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
 
-          {/* Save Button */}
-          <div className="flex justify-end">
-            <Button
-              onClick={handleSaveProfile}
-              disabled={saving}
-              className="bg-surface-1 text-ink hover:bg-surface-3 "
+      {/* Profile section */}
+      <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm p-2 mb-4">
+        <h3 className="m-0 px-4 pt-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.04em] text-ink-3">
+          Profile
+        </h3>
+        <div className="px-4 py-3 border-t border-line-2 space-y-3">
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="email"
+              className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold"
             >
-              {saving ? (
-                <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-ink border-t-transparent mr-2" />
-                  Saving...
-                </>
-              ) : (
-                <>
-                  <Save className="h-4 w-4 mr-2" />
-                  Save Changes
-                </>
-              )}
-            </Button>
+              Email
+            </Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
+              <Input
+                id="email"
+                type="email"
+                value={user?.email || ''}
+                disabled
+                className="pl-9 h-9 text-[13px] bg-surface-2 border-line text-ink-3 cursor-not-allowed"
+              />
+            </div>
+            <p className="text-[11px] text-ink-4 m-0">
+              Email cannot be changed. Contact support if needed.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="full_name"
+              className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold"
+            >
+              Full name
+            </Label>
+            <div className="relative">
+              <User className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
+              <Input
+                id="full_name"
+                type="text"
+                value={formData.full_name}
+                onChange={e =>
+                  setFormData(prev => ({
+                    ...prev,
+                    full_name: e.target.value,
+                  }))
+                }
+                className="pl-9 h-9 text-[13px] bg-surface-1 border-line text-ink placeholder:text-ink-4"
+                placeholder="Your full name"
+              />
+            </div>
           </div>
         </div>
+      </div>
+
+      {/* Password section */}
+      <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm p-2 mb-4">
+        <h3 className="m-0 px-4 pt-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.04em] text-ink-3">
+          Change password
+        </h3>
+        <div className="px-4 py-3 border-t border-line-2 space-y-3">
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="current_password"
+              className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold"
+            >
+              Current password
+            </Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
+              <Input
+                id="current_password"
+                type={showPassword ? 'text' : 'password'}
+                value={formData.current_password}
+                onChange={e =>
+                  setFormData(prev => ({
+                    ...prev,
+                    current_password: e.target.value,
+                  }))
+                }
+                className="pl-9 pr-9 h-9 text-[13px] bg-surface-1 border-line text-ink placeholder:text-ink-4"
+                placeholder="Enter current password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-3 hover:text-ink"
+              >
+                {showPassword ? (
+                  <EyeOff className="h-3.5 w-3.5" />
+                ) : (
+                  <Eye className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="new_password"
+              className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold"
+            >
+              New password
+            </Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
+              <Input
+                id="new_password"
+                type={showPassword ? 'text' : 'password'}
+                value={formData.new_password}
+                onChange={e =>
+                  setFormData(prev => ({
+                    ...prev,
+                    new_password: e.target.value,
+                  }))
+                }
+                className="pl-9 h-9 text-[13px] bg-surface-1 border-line text-ink placeholder:text-ink-4"
+                placeholder="Create a strong password"
+              />
+            </div>
+            {formData.new_password && (
+              <div className="mt-2">
+                <PasswordStrengthIndicator
+                  strength={passwordValidation.strength}
+                  score={passwordValidation.score}
+                  showRequirements={true}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="confirm_password"
+              className="font-mono text-[10px] uppercase tracking-[0.05em] text-ink-4 font-semibold"
+            >
+              Confirm new password
+            </Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
+              <Input
+                id="confirm_password"
+                type={showConfirmPassword ? 'text' : 'password'}
+                value={formData.confirm_password}
+                onChange={e =>
+                  setFormData(prev => ({
+                    ...prev,
+                    confirm_password: e.target.value,
+                  }))
+                }
+                className="pl-9 pr-9 h-9 text-[13px] bg-surface-1 border-line text-ink placeholder:text-ink-4"
+                placeholder="Confirm new password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-3 hover:text-ink"
+              >
+                {showConfirmPassword ? (
+                  <EyeOff className="h-3.5 w-3.5" />
+                ) : (
+                  <Eye className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Save Button */}
+      <div className="flex justify-end">
+        <Button
+          onClick={handleSaveProfile}
+          disabled={saving}
+          className="bg-ink text-ink-on-dark hover:bg-ink-2 h-9 px-3.5 text-[13px] font-medium"
+        >
+          {saving ? (
+            <>
+              <div className="animate-spin rounded-full h-3.5 w-3.5 border-2 border-ink-on-dark border-t-transparent mr-2" />
+              Saving…
+            </>
+          ) : (
+            <>
+              <Save className="h-3.5 w-3.5 mr-2" />
+              Save changes
+            </>
+          )}
+        </Button>
       </div>
     </div>
   )

--- a/src/app/client-portal/sessions/[id]/components/client-session-analysis.tsx
+++ b/src/app/client-portal/sessions/[id]/components/client-session-analysis.tsx
@@ -24,12 +24,12 @@ export function ClientSessionAnalysis({
   const insights = sessionData.insights
   if (!insights) {
     return (
-      <div className="text-center py-16 bg-gray-50 dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
-        <Brain className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+      <div className="text-center py-16 bg-paper rounded-xl border border-line ">
+        <Brain className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+        <h3 className="text-lg font-medium text-ink mb-2">
           No Analysis Available
         </h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400">
+        <p className="text-sm text-ink-3 ">
           Analysis will appear here once your session has been processed.
         </p>
       </div>
@@ -52,12 +52,10 @@ export function ClientSessionAnalysis({
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Sentiment Gauge */}
           {hasSentiment && (
-            <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-              <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                <h3 className="font-semibold text-gray-900 dark:text-white">
-                  Session Pulse
-                </h3>
+            <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+              <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+                <TrendingUp className="h-4 w-4 text-ink-3 " />
+                <h3 className="font-semibold text-ink ">Session Pulse</h3>
               </div>
               <div className="p-5">
                 <SentimentGauge sentiment={insights.sentiment} />
@@ -67,12 +65,10 @@ export function ClientSessionAnalysis({
 
           {/* Word Cloud */}
           {hasTopics && (
-            <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-              <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-                <Brain className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                <h3 className="font-semibold text-gray-900 dark:text-white">
-                  Topics & Keywords
-                </h3>
+            <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+              <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+                <Brain className="h-4 w-4 text-ink-3 " />
+                <h3 className="font-semibold text-ink ">Topics & Keywords</h3>
               </div>
               <div className="p-5">
                 <WordCloud
@@ -90,38 +86,32 @@ export function ClientSessionAnalysis({
 
       {/* Engagement & Emotions Badges */}
       {hasSentiment && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h3 className="font-semibold text-gray-900 dark:text-white">
-              Session Metrics
-            </h3>
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-ink-3 " />
+            <h3 className="font-semibold text-ink ">Session Metrics</h3>
           </div>
           <div className="p-5">
             <div className="flex flex-wrap gap-3">
               {insights.sentiment.engagement && (
-                <div className="flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                  <TrendingUp className="h-4 w-4 text-gray-500" />
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
-                    Engagement
-                  </span>
+                <div className="flex items-center gap-2 px-4 py-2.5 bg-paper rounded-lg">
+                  <TrendingUp className="h-4 w-4 text-ink-3" />
+                  <span className="text-sm text-ink-3 ">Engagement</span>
                   <Badge
                     variant="secondary"
-                    className="bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 capitalize"
+                    className="bg-surface-1 text-ink-2 capitalize"
                   >
                     {insights.sentiment.engagement}
                   </Badge>
                 </div>
               )}
               {insights.sentiment.overall && (
-                <div className="flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                  <Target className="h-4 w-4 text-gray-500" />
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
-                    Overall Sentiment
-                  </span>
+                <div className="flex items-center gap-2 px-4 py-2.5 bg-paper rounded-lg">
+                  <Target className="h-4 w-4 text-ink-3" />
+                  <span className="text-sm text-ink-3 ">Overall Sentiment</span>
                   <Badge
                     variant="secondary"
-                    className="bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 capitalize"
+                    className="bg-surface-1 text-ink-2 capitalize"
                   >
                     {insights.sentiment.overall}
                   </Badge>
@@ -129,10 +119,8 @@ export function ClientSessionAnalysis({
               )}
               {insights.sentiment.emotions &&
                 insights.sentiment.emotions.length > 0 && (
-                  <div className="flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                    <span className="text-sm text-gray-600 dark:text-gray-400">
-                      Emotions
-                    </span>
+                  <div className="flex items-center gap-2 px-4 py-2.5 bg-paper rounded-lg">
+                    <span className="text-sm text-ink-3 ">Emotions</span>
                     <div className="flex gap-1.5">
                       {insights.sentiment.emotions
                         .slice(0, 4)
@@ -155,15 +143,13 @@ export function ClientSessionAnalysis({
 
       {/* Full Insights List */}
       {hasInsights && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <Lightbulb className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h3 className="font-semibold text-gray-900 dark:text-white">
-              All Insights
-            </h3>
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <Lightbulb className="h-4 w-4 text-ink-3 " />
+            <h3 className="font-semibold text-ink ">All Insights</h3>
             <Badge
               variant="secondary"
-              className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs ml-auto"
+              className="bg-surface-3 text-ink-3 text-xs ml-auto"
             >
               {insights.insights!.length}
             </Badge>
@@ -171,19 +157,14 @@ export function ClientSessionAnalysis({
           <div className="p-5">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {insights.insights!.map((insight, index) => (
-                <div
-                  key={index}
-                  className="relative p-4 bg-gray-50 dark:bg-gray-800 rounded-lg"
-                >
+                <div key={index} className="relative p-4 bg-paper rounded-lg">
                   <div className="absolute top-3 right-3">
-                    <span className="text-2xl font-bold text-gray-200 dark:text-gray-700">
+                    <span className="text-2xl font-bold text-ink-2 ">
                       {String(index + 1).padStart(2, '0')}
                     </span>
                   </div>
-                  <Zap className="h-4 w-4 text-gray-500 dark:text-gray-400 mb-2" />
-                  <p className="text-sm text-gray-700 dark:text-gray-300 pr-8">
-                    {insight}
-                  </p>
+                  <Zap className="h-4 w-4 text-ink-3 mb-2" />
+                  <p className="text-sm text-ink-2 pr-8">{insight}</p>
                 </div>
               ))}
             </div>
@@ -193,10 +174,10 @@ export function ClientSessionAnalysis({
 
       {/* Suggestions & Next Steps */}
       {(suggestions.length > 0 || nextSessionFocus.length > 0) && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <ArrowUpRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h3 className="font-semibold text-gray-900 dark:text-white">
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <ArrowUpRight className="h-4 w-4 text-ink-3 " />
+            <h3 className="font-semibold text-ink ">
               Next Steps & Recommendations
             </h3>
           </div>
@@ -204,7 +185,7 @@ export function ClientSessionAnalysis({
             {/* Next session focus tags */}
             {nextSessionFocus.length > 0 && (
               <div>
-                <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">
+                <span className="text-xs font-medium text-ink-3 uppercase tracking-wide mb-2 block">
                   Focus Areas for Next Session
                 </span>
                 <div className="flex flex-wrap gap-2">
@@ -212,7 +193,7 @@ export function ClientSessionAnalysis({
                     <Badge
                       key={idx}
                       variant="secondary"
-                      className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                      className="bg-surface-3 text-ink-2 "
                     >
                       {focus}
                     </Badge>
@@ -226,12 +207,12 @@ export function ClientSessionAnalysis({
                 {suggestions.map((suggestion: any, index: number) => (
                   <div
                     key={index}
-                    className="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                    className="flex items-start gap-3 p-3 bg-paper rounded-lg"
                   >
-                    <div className="h-5 w-5 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">
+                    <div className="h-5 w-5 rounded-full bg-ink text-ink-on-dark flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">
                       {index + 1}
                     </div>
-                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                    <span className="text-sm text-ink-2 ">
                       {typeof suggestion === 'string'
                         ? suggestion
                         : suggestion.text ||

--- a/src/app/client-portal/sessions/[id]/components/client-session-overview.tsx
+++ b/src/app/client-portal/sessions/[id]/components/client-session-overview.tsx
@@ -69,29 +69,23 @@ const CATEGORY_ICONS: Record<string, any> = {
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
-  document: 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
-  worksheet:
-    'bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400',
-  exercise:
-    'bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400',
-  article:
-    'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400',
-  template: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
-  video: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
-  link: 'bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400',
+  document: 'bg-ds-accent-bg text-ds-accent ',
+  worksheet: 'bg-indigo-bg text-indigo ',
+  exercise: 'bg-amber-token-bg text-amber-token ',
+  article: 'bg-forest-bg text-forest ',
+  template: 'bg-surface-3 text-ink-3 ',
+  video: 'bg-vermillion-bg text-vermillion ',
+  link: 'bg-ds-accent-bg text-ds-accent ',
 }
 
 const CATEGORY_BADGE_COLORS: Record<string, string> = {
-  document: 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300',
-  worksheet:
-    'bg-purple-50 text-purple-700 dark:bg-purple-900/20 dark:text-purple-300',
-  exercise:
-    'bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-300',
-  article:
-    'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300',
-  template: 'bg-gray-50 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
-  video: 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300',
-  link: 'bg-cyan-50 text-cyan-700 dark:bg-cyan-900/20 dark:text-cyan-300',
+  document: 'bg-ds-accent-bg text-ds-accent ',
+  worksheet: 'bg-indigo-bg text-indigo ',
+  exercise: 'bg-amber-token-bg text-amber-token ',
+  article: 'bg-forest-bg text-forest ',
+  template: 'bg-paper text-ink-2 ',
+  video: 'bg-vermillion-bg text-vermillion ',
+  link: 'bg-ds-accent-bg text-ds-accent ',
 }
 
 // ---- Commitment Item with inline editing ----
@@ -158,46 +152,46 @@ function CommitmentItem({
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return <CheckCircle2 className="h-4 w-4 text-green-600" />
+        return <CheckCircle2 className="h-4 w-4 text-forest" />
       case 'in_progress':
-        return <PlayCircle className="h-4 w-4 text-blue-600" />
+        return <PlayCircle className="h-4 w-4 text-ds-accent" />
       default:
-        return <Circle className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+        return <Circle className="h-4 w-4 text-ink-3 " />
     }
   }
 
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'text-green-700 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-900/30 dark:border-green-800'
+        return 'text-forest bg-forest-bg border-forest '
       case 'in_progress':
-        return 'text-blue-700 bg-blue-50 border-blue-200 dark:text-blue-400 dark:bg-blue-900/30 dark:border-blue-800'
+        return 'text-ds-accent bg-ds-accent-bg border-ds-accent '
       default:
-        return 'text-gray-700 bg-gray-50 border-gray-200 dark:text-gray-300 dark:bg-gray-800 dark:border-gray-600'
+        return 'text-ink-2 bg-paper border-line '
     }
   }
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between gap-2 p-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+    <div className="border border-line rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between gap-2 p-3 hover:bg-paper transition-colors">
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <div className="flex-shrink-0">
             {getStatusIcon(commitment.status)}
           </div>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="flex-shrink-0 p-0.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+            className="flex-shrink-0 p-0.5 hover:bg-surface-3 rounded transition-colors"
           >
             {isExpanded ? (
-              <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronDown className="h-4 w-4 text-ink-3 " />
             ) : (
-              <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronRight className="h-4 w-4 text-ink-3 " />
             )}
           </button>
           <p
-            className={`text-sm font-medium flex-1 dark:text-gray-200 ${
+            className={`text-sm font-medium flex-1 ${
               commitment.status === 'completed'
-                ? 'line-through text-gray-500 dark:text-gray-500'
+                ? 'line-through text-ink-3 '
                 : ''
             }`}
           >
@@ -233,14 +227,12 @@ function CommitmentItem({
         </Select>
       </div>
       {isExpanded && (
-        <div className="px-3 pb-3 pt-1 space-y-3 border-t border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+        <div className="px-3 pb-3 pt-1 space-y-3 border-t border-line bg-paper ">
           {isEditing ? (
             /* Inline edit form */
             <div className="space-y-3">
               <div>
-                <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">
-                  Title
-                </label>
+                <label className="text-xs text-ink-3 mb-1 block">Title</label>
                 <Input
                   value={editTitle}
                   onChange={e => setEditTitle(e.target.value)}
@@ -248,7 +240,7 @@ function CommitmentItem({
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">
+                <label className="text-xs text-ink-3 mb-1 block">
                   Description
                 </label>
                 <Textarea
@@ -259,7 +251,7 @@ function CommitmentItem({
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">
+                <label className="text-xs text-ink-3 mb-1 block">
                   Priority
                 </label>
                 <Select value={editPriority} onValueChange={setEditPriority}>
@@ -299,12 +291,10 @@ function CommitmentItem({
             /* Read view */
             <>
               {commitment.description && (
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  {commitment.description}
-                </p>
+                <p className="text-sm text-ink-3 ">{commitment.description}</p>
               )}
               <div className="flex items-center justify-between">
-                <div className="flex flex-wrap gap-3 text-xs text-gray-600 dark:text-gray-400">
+                <div className="flex flex-wrap gap-3 text-xs text-ink-3 ">
                   {commitment.priority && (
                     <span>
                       Priority: <strong>{commitment.priority}</strong>
@@ -332,7 +322,7 @@ function CommitmentItem({
                   size="sm"
                   variant="ghost"
                   onClick={() => setIsEditing(true)}
-                  className="h-7 text-xs gap-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                  className="h-7 text-xs gap-1 text-ink-3 hover:text-ink-2 "
                 >
                   <Pencil className="h-3 w-3" />
                   Edit
@@ -388,15 +378,13 @@ export function ClientSessionOverview({
     <div className="space-y-6">
       {/* Summary Section with Topics & Keywords inline */}
       {(session.summary || (insights?.topics?.length ?? 0) > 0) && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <Quote className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h2 className="font-semibold text-gray-900 dark:text-white">
-              Session Summary
-            </h2>
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <Quote className="h-4 w-4 text-ink-3 " />
+            <h2 className="font-semibold text-ink ">Session Summary</h2>
             <Badge
               variant="secondary"
-              className="bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs ml-auto"
+              className="bg-surface-3 text-ink-3 text-xs ml-auto"
             >
               <Sparkles className="h-3 w-3 mr-1" />
               AI Generated
@@ -404,17 +392,15 @@ export function ClientSessionOverview({
           </div>
           <div className="p-5 space-y-4">
             {session.summary && (
-              <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-                {session.summary}
-              </p>
+              <p className="text-ink-3 leading-relaxed">{session.summary}</p>
             )}
             {/* Topics inline */}
             {((insights?.topics?.length ?? 0) > 0 ||
               (session.key_topics?.length ?? 0) > 0) && (
               <div>
                 <div className="flex items-center gap-2 mb-2">
-                  <Hash className="h-3.5 w-3.5 text-gray-400" />
-                  <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  <Hash className="h-3.5 w-3.5 text-ink-4" />
+                  <span className="text-xs font-medium text-ink-3 uppercase tracking-wide">
                     Topics Discussed
                   </span>
                 </div>
@@ -425,7 +411,7 @@ export function ClientSessionOverview({
                   ).map((topic: string, idx: number) => (
                     <span
                       key={idx}
-                      className="px-3 py-1.5 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm rounded-lg"
+                      className="px-3 py-1.5 bg-surface-3 text-ink-2 text-sm rounded-lg"
                     >
                       {topic}
                     </span>
@@ -441,7 +427,7 @@ export function ClientSessionOverview({
                   .map((keyword: string, idx: number) => (
                     <span
                       key={idx}
-                      className="px-2 py-1 border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 text-xs rounded"
+                      className="px-2 py-1 border border-line text-ink-3 text-xs rounded"
                     >
                       {keyword}
                     </span>
@@ -457,19 +443,14 @@ export function ClientSessionOverview({
         {/* Commitments */}
         {(commitments.length > 0 ||
           (session.action_items && session.action_items.length > 0)) && (
-          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-            <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800">
+          <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+            <div className="px-5 py-4 border-b border-line ">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                  <h2 className="font-semibold text-gray-900 dark:text-white">
-                    Commitments
-                  </h2>
+                  <CheckCircle2 className="h-4 w-4 text-ink-3 " />
+                  <h2 className="font-semibold text-ink ">Commitments</h2>
                 </div>
-                <Badge
-                  variant="secondary"
-                  className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
-                >
+                <Badge variant="secondary" className="bg-surface-3 text-ink-3 ">
                   {commitments.length > 0
                     ? `${completedCommitments}/${totalCommitments} done`
                     : `${session.action_items?.length || 0} items`}
@@ -478,7 +459,7 @@ export function ClientSessionOverview({
               {commitments.length > 0 && (
                 <div className="mt-3 flex items-center gap-3">
                   <Progress value={completionPct} className="flex-1 h-2" />
-                  <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+                  <span className="text-xs text-ink-3 font-medium">
                     {completionPct}%
                   </span>
                 </div>
@@ -495,16 +476,16 @@ export function ClientSessionOverview({
                 ))}
               </div>
             ) : (
-              <div className="divide-y divide-gray-100 dark:divide-gray-800">
+              <div className="divide-y divide-line ">
                 {session.action_items?.map((item: any, index: number) => (
                   <div
                     key={index}
-                    className="px-5 py-3 flex items-start gap-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    className="px-5 py-3 flex items-start gap-3 hover:bg-paper transition-colors"
                   >
-                    <div className="h-6 w-6 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">
+                    <div className="h-6 w-6 rounded-full bg-ink text-ink-on-dark flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">
                       {index + 1}
                     </div>
-                    <span className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+                    <span className="text-sm text-ink-2 leading-relaxed">
                       {typeof item === 'string'
                         ? item
                         : item.item || item.text || item.title || String(item)}
@@ -518,15 +499,13 @@ export function ClientSessionOverview({
 
         {/* Wins */}
         {wins.length > 0 && (
-          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-            <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-              <Trophy className="h-4 w-4 text-amber-500" />
-              <h2 className="font-semibold text-gray-900 dark:text-white">
-                Wins & Achievements
-              </h2>
+          <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+            <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+              <Trophy className="h-4 w-4 text-amber-token" />
+              <h2 className="font-semibold text-ink ">Wins & Achievements</h2>
               <Badge
                 variant="secondary"
-                className="bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-xs ml-auto"
+                className="bg-amber-token-bg text-amber-token text-xs ml-auto"
               >
                 {wins.length}
               </Badge>
@@ -535,17 +514,15 @@ export function ClientSessionOverview({
               {wins.map((win: any, index: number) => (
                 <div
                   key={win.id || index}
-                  className="flex items-start gap-3 p-3 bg-amber-50/50 dark:bg-amber-900/10 border border-amber-100 dark:border-amber-900/30 rounded-lg"
+                  className="flex items-start gap-3 p-3 bg-amber-token-bg/50 border border-amber-token rounded-lg"
                 >
-                  <div className="h-6 w-6 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <div className="h-6 w-6 rounded-full bg-amber-token-bg text-amber-token flex items-center justify-center flex-shrink-0 mt-0.5">
                     <Trophy className="h-3 w-3" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 dark:text-white">
-                      {win.title}
-                    </p>
+                    <p className="text-sm font-medium text-ink ">{win.title}</p>
                     {win.description && (
-                      <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5 line-clamp-2">
+                      <p className="text-xs text-ink-3 mt-0.5 line-clamp-2">
                         {win.description}
                       </p>
                     )}
@@ -559,12 +536,10 @@ export function ClientSessionOverview({
 
       {/* Key Insights — Bento Grid */}
       {insights?.insights && insights.insights.length > 0 && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <Lightbulb className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h2 className="font-semibold text-gray-900 dark:text-white">
-              Key Insights
-            </h2>
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <Lightbulb className="h-4 w-4 text-ink-3 " />
+            <h2 className="font-semibold text-ink ">Key Insights</h2>
           </div>
           <div className="p-5">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
@@ -573,17 +548,15 @@ export function ClientSessionOverview({
                 .map((insight: string, index: number) => (
                   <div
                     key={index}
-                    className="relative p-4 bg-gray-50 dark:bg-gray-800 rounded-lg hover:shadow-sm transition-shadow"
+                    className="relative p-4 bg-paper rounded-lg hover:shadow-sm transition-shadow"
                   >
                     <div className="absolute top-3 right-3">
-                      <span className="text-2xl font-bold text-gray-200 dark:text-gray-700">
+                      <span className="text-2xl font-bold text-ink-2 ">
                         {String(index + 1).padStart(2, '0')}
                       </span>
                     </div>
-                    <Zap className="h-4 w-4 text-gray-500 dark:text-gray-400 mb-2" />
-                    <p className="text-sm text-gray-700 dark:text-gray-300 pr-8">
-                      {insight}
-                    </p>
+                    <Zap className="h-4 w-4 text-ink-3 mb-2" />
+                    <p className="text-sm text-ink-2 pr-8">{insight}</p>
                   </div>
                 ))}
             </div>
@@ -593,23 +566,21 @@ export function ClientSessionOverview({
 
       {/* Recommendations */}
       {suggestions.length > 0 && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <ArrowUpRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h2 className="font-semibold text-gray-900 dark:text-white">
-              Recommendations
-            </h2>
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <ArrowUpRight className="h-4 w-4 text-ink-3 " />
+            <h2 className="font-semibold text-ink ">Recommendations</h2>
           </div>
           <div className="p-5 space-y-3">
             {suggestions.map((suggestion: any, index: number) => (
               <div
                 key={index}
-                className="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                className="flex items-start gap-3 p-3 bg-paper rounded-lg"
               >
-                <div className="h-5 w-5 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">
+                <div className="h-5 w-5 rounded-full bg-ink text-ink-on-dark flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">
                   {index + 1}
                 </div>
-                <span className="text-sm text-gray-700 dark:text-gray-300">
+                <span className="text-sm text-ink-2 ">
                   {typeof suggestion === 'string'
                     ? suggestion
                     : suggestion.text || suggestion.suggestion || ''}
@@ -623,12 +594,10 @@ export function ClientSessionOverview({
       {/* Notes & Resources — 2 column on lg */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Session Notes — always visible with type badges */}
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-            <StickyNote className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            <h2 className="font-semibold text-gray-900 dark:text-white">
-              Session Notes
-            </h2>
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+            <StickyNote className="h-4 w-4 text-ink-3 " />
+            <h2 className="font-semibold text-ink ">Session Notes</h2>
           </div>
           <div className="p-4">
             <NotesList sessionId={sessionId} isClientPortal={true} />
@@ -637,20 +606,18 @@ export function ClientSessionOverview({
 
         {/* Materials & Resources — with category icons/colors */}
         {hasMaterials && (
-          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-            <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2">
-              <BookOpen className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              <h2 className="font-semibold text-gray-900 dark:text-white">
-                Resources
-              </h2>
+          <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
+            <div className="px-5 py-4 border-b border-line flex items-center gap-2">
+              <BookOpen className="h-4 w-4 text-ink-3 " />
+              <h2 className="font-semibold text-ink ">Resources</h2>
               <Badge
                 variant="secondary"
-                className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs ml-auto"
+                className="bg-surface-3 text-ink-3 text-xs ml-auto"
               >
                 {sessionData.materials.length}
               </Badge>
             </div>
-            <div className="divide-y divide-gray-100 dark:divide-gray-800">
+            <div className="divide-y divide-line ">
               {sessionData.materials.map(material => {
                 const IconComponent =
                   CATEGORY_ICONS[material.material_type] || FileText
@@ -663,7 +630,7 @@ export function ClientSessionOverview({
                 return (
                   <div
                     key={material.id}
-                    className="px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    className="px-5 py-3 hover:bg-paper transition-colors"
                   >
                     <div className="flex items-start gap-3">
                       <div
@@ -672,11 +639,11 @@ export function ClientSessionOverview({
                         <IconComponent className="h-4 w-4" />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white">
+                        <p className="text-sm font-medium text-ink ">
                           {material.title}
                         </p>
                         {material.description && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">
+                          <p className="text-xs text-ink-3 mt-0.5 line-clamp-1">
                             {material.description}
                           </p>
                         )}
@@ -692,7 +659,7 @@ export function ClientSessionOverview({
                           href={material.file_url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1"
+                          className="text-ink-4 hover:text-ink-3 p-1"
                         >
                           <ExternalLink className="h-4 w-4" />
                         </a>
@@ -708,27 +675,27 @@ export function ClientSessionOverview({
 
       {/* Transcript */}
       {hasTranscript && (
-        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+        <div className="bg-surface-1 border border-line rounded-xl overflow-hidden">
           <button
             onClick={() => toggleSection('transcript')}
-            className="w-full px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            className="w-full px-5 py-4 border-b border-line flex items-center justify-between hover:bg-paper transition-colors"
           >
             <div className="flex items-center gap-2">
-              <MessageSquare className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              <h2 className="font-semibold text-gray-900 dark:text-white">
+              <MessageSquare className="h-4 w-4 text-ink-3 " />
+              <h2 className="font-semibold text-ink ">
                 Conversation Transcript
               </h2>
               <Badge
                 variant="secondary"
-                className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs ml-2"
+                className="bg-surface-3 text-ink-3 text-xs ml-2"
               >
                 {sessionData.transcript.length} messages
               </Badge>
             </div>
             {expandedSections.transcript ? (
-              <ChevronUp className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+              <ChevronUp className="h-4 w-4 text-ink-4 " />
             ) : (
-              <ChevronDown className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+              <ChevronDown className="h-4 w-4 text-ink-4 " />
             )}
           </button>
 
@@ -745,8 +712,8 @@ export function ClientSessionOverview({
                       <div
                         className={`h-8 w-8 rounded-full flex items-center justify-center flex-shrink-0 ${
                           isCoach
-                            ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                            : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+                            ? 'bg-ink text-ink-on-dark '
+                            : 'bg-surface-3 text-ink-3 '
                         }`}
                       >
                         <User className="h-4 w-4" />
@@ -757,11 +724,11 @@ export function ClientSessionOverview({
                         <div
                           className={`flex items-center gap-2 mb-1 ${isCoach ? '' : 'justify-end'}`}
                         >
-                          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                          <span className="text-xs font-medium text-ink-2 ">
                             {entry.speaker}
                           </span>
                           {entry.timestamp && (
-                            <span className="text-xs text-gray-400 dark:text-gray-500">
+                            <span className="text-xs text-ink-4 ">
                               {formatDate(entry.timestamp, 'h:mm a')}
                             </span>
                           )}
@@ -769,8 +736,8 @@ export function ClientSessionOverview({
                         <div
                           className={`inline-block px-4 py-2 rounded-2xl text-sm ${
                             isCoach
-                              ? 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-tl-sm'
-                              : 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-tr-sm'
+                              ? 'bg-surface-3 text-ink-2 rounded-tl-sm'
+                              : 'bg-ink text-ink-on-dark rounded-tr-sm'
                           }`}
                         >
                           {entry.text}
@@ -789,13 +756,13 @@ export function ClientSessionOverview({
                     <div
                       className={`h-6 w-6 rounded-full flex items-center justify-center flex-shrink-0 text-xs ${
                         entry.speaker?.toLowerCase().includes('coach')
-                          ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                          : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+                          ? 'bg-ink text-ink-on-dark '
+                          : 'bg-surface-3 text-ink-3 '
                       }`}
                     >
                       {entry.speaker?.charAt(0).toUpperCase()}
                     </div>
-                    <p className="text-sm text-gray-600 dark:text-gray-400 truncate flex-1">
+                    <p className="text-sm text-ink-3 truncate flex-1">
                       {entry.text}
                     </p>
                   </div>
@@ -803,7 +770,7 @@ export function ClientSessionOverview({
               </div>
               <button
                 onClick={() => toggleSection('transcript')}
-                className="mt-3 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 font-medium flex items-center gap-1"
+                className="mt-3 text-sm text-ink-3 hover:text-ink-2 font-medium flex items-center gap-1"
               >
                 View full transcript
                 <ChevronRight className="h-4 w-4" />

--- a/src/app/client-portal/sessions/[id]/page.tsx
+++ b/src/app/client-portal/sessions/[id]/page.tsx
@@ -3,11 +3,10 @@
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
-  ArrowLeft,
+  ChevronLeft,
   Clock,
   Users,
   BarChart3,
@@ -40,32 +39,13 @@ export default function ClientSessionDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {/* Header skeleton */}
-        <div className="flex items-center justify-between mb-6">
-          <Skeleton className="h-9 w-32" />
-          <Skeleton className="h-6 w-20" />
-        </div>
-        {/* Hero skeleton */}
-        <div className="bg-paper border border-line rounded-2xl p-6 mb-6">
-          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-            <div className="flex items-center gap-4">
-              <Skeleton className="h-16 w-16 rounded-xl" />
-              <div>
-                <Skeleton className="h-6 w-56 mb-2" />
-                <Skeleton className="h-4 w-24" />
-              </div>
-            </div>
-            <div className="flex items-center gap-6">
-              <Skeleton className="h-14 w-16" />
-              <Skeleton className="h-14 w-16" />
-              <Skeleton className="h-14 w-16" />
-            </div>
-          </div>
-        </div>
-        {/* Tab skeleton */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
+        <Skeleton className="h-5 w-24 mb-4" />
+        <Skeleton className="h-4 w-56 mb-2" />
+        <Skeleton className="h-9 w-2/3 mb-3" />
+        <Skeleton className="h-4 w-1/3 mb-7" />
+        <Skeleton className="h-28 w-full rounded-xl mb-4" />
         <Skeleton className="h-10 w-64 mb-6" />
-        {/* Content skeleton */}
         <div className="space-y-4">
           <Skeleton className="h-40 w-full rounded-xl" />
           <Skeleton className="h-32 w-full rounded-xl" />
@@ -77,14 +57,14 @@ export default function ClientSessionDetailPage() {
 
   if (error || !sessionData) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
         <div className="text-center py-12">
           <p className="text-ink-3 mb-4">
             {error instanceof Error ? error.message : 'Session not found'}
           </p>
           <Link href="/client-portal/sessions">
             <Button variant="outline">
-              <ArrowLeft className="mr-2 h-4 w-4" />
+              <ChevronLeft className="mr-2 h-4 w-4" />
               Back to Sessions
             </Button>
           </Link>
@@ -100,151 +80,107 @@ export default function ClientSessionDetailPage() {
 
   const getSentimentIcon = () => {
     if (sentimentScore == null) return null
-    if (sentimentScore >= 7) return <Smile className="h-4 w-4 text-forest" />
-    if (sentimentScore >= 4) return <Meh className="h-4 w-4 text-amber-token" />
-    return <Frown className="h-4 w-4 text-ink-4" />
+    if (sentimentScore >= 7)
+      return <Smile className="h-3.5 w-3.5 text-forest" />
+    if (sentimentScore >= 4)
+      return <Meh className="h-3.5 w-3.5 text-amber-token" />
+    return <Frown className="h-3.5 w-3.5 text-ink-4" />
   }
 
-  const getSentimentBgColor = () => {
+  const getSentimentPillClass = () => {
     if (sentimentScore == null) return ''
-    if (sentimentScore >= 7) return 'bg-forest-bg text-forest '
-    if (sentimentScore >= 4) return 'bg-amber-token-bg text-amber-token '
-    return 'bg-surface-3 text-ink-3 '
+    if (sentimentScore >= 7) return 'bg-forest-bg text-forest'
+    if (sentimentScore >= 4) return 'bg-amber-token-bg text-amber-token'
+    return 'bg-surface-3 text-ink-3'
   }
+
+  const startedAt = session.started_at
+  const headerLine = startedAt
+    ? `${formatDate(startedAt, 'EEEE')} · ${formatDate(startedAt, 'MMMM d')} · ${
+        session.duration_minutes || 0
+      } minutes`
+    : 'Session Details'
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <Link href="/client-portal/sessions">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-2 text-ink-3 hover:text-ink "
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            All Sessions
-          </Button>
-        </Link>
-        <Badge
-          variant="secondary"
-          className="bg-surface-3 text-ink-3 capitalize"
-        >
-          {session.status}
-        </Badge>
-      </div>
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
+      {/* Editorial back link */}
+      <Link
+        href="/client-portal/sessions"
+        className="inline-flex items-center gap-1 text-[12px] font-medium text-ink-3 hover:text-ink mb-4"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" />
+        All sessions
+      </Link>
 
-      {/* Hero Section */}
-      <div className="bg-paper border border-line rounded-2xl p-6 mb-6">
-        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-          {/* Date & Title */}
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 bg-ink rounded-xl flex flex-col items-center justify-center text-ink-on-dark ">
-              <span className="text-2xl font-bold">
-                {session.started_at ? formatDate(session.started_at, 'd') : '-'}
-              </span>
-              <span className="text-xs uppercase tracking-wide opacity-80">
-                {session.started_at
-                  ? formatDate(session.started_at, 'MMM')
-                  : ''}
-              </span>
-            </div>
-            <div>
-              <h1 className="text-xl font-bold text-ink ">
-                {session.started_at
-                  ? formatDate(session.started_at, 'EEEE, MMMM d, yyyy')
-                  : 'Session Details'}
-              </h1>
-              <p className="text-sm text-ink-3 ">
-                {session.started_at && formatRelativeTime(session.started_at)}
-              </p>
-              {session.is_group_session && (
-                <Badge className="mt-1 bg-surface-3 text-ink-2 text-xs">
-                  <Users className="h-3 w-3 mr-1" />
-                  Group Session
-                </Badge>
-              )}
-            </div>
-          </div>
+      {/* Editorial hero */}
+      <div className="mb-7">
+        <p className="text-[12px] font-medium text-ink-3 mb-1">{headerLine}</p>
+        <h1 className="text-[30px] font-bold tracking-tight leading-[1.2] text-ink m-0">
+          {session.summary
+            ? session.summary.split(/[.!?]/)[0]?.trim() || 'Session recap'
+            : 'Session recap'}
+        </h1>
+        <p className="text-[13px] text-ink-3 mt-1.5">
+          {session.coach ? (
+            <>
+              A check-in with{' '}
+              <b className="font-medium text-ink-2">{session.coach.name}</b>
+            </>
+          ) : (
+            <>{startedAt && formatRelativeTime(startedAt)}</>
+          )}
+        </p>
 
-          {/* Quick Stats */}
-          <div className="flex items-center gap-5 flex-wrap">
-            <div className="text-center">
-              <p className="text-2xl font-bold text-ink ">
-                {session.duration_minutes || 0}
-              </p>
-              <p className="text-xs text-ink-3 ">Minutes</p>
-            </div>
-            <div className="h-10 w-px bg-surface-3 " />
-            <div className="text-center">
-              <p className="text-2xl font-bold text-ink ">
-                {session.key_topics?.length || 0}
-              </p>
-              <p className="text-xs text-ink-3 ">Topics</p>
-            </div>
-            <div className="h-10 w-px bg-surface-3 " />
-            <div className="text-center">
-              <p className="text-2xl font-bold text-ink ">
-                {structuredCommitments.length ||
-                  session.action_items?.length ||
-                  0}
-              </p>
-              <p className="text-xs text-ink-3 ">Commitments</p>
-            </div>
-            {/* Sentiment score chip */}
-            {sentimentScore != null && (
-              <>
-                <div className="h-10 w-px bg-surface-3 " />
-                <div
-                  className={`flex items-center gap-2 px-3 py-2 rounded-lg ${getSentimentBgColor()}`}
-                >
-                  {getSentimentIcon()}
-                  <div>
-                    <p className="text-lg font-bold leading-none">
-                      {sentimentScore.toFixed(1)}
-                    </p>
-                    <p className="text-xs capitalize opacity-80">
-                      {sentimentLabel}
-                    </p>
-                  </div>
-                </div>
-              </>
-            )}
-            {/* Coach */}
-            {session.coach && (
-              <>
-                <div className="h-10 w-px bg-surface-3 " />
-                <div className="flex items-center gap-2">
-                  <div className="h-10 w-10 rounded-full bg-ink flex items-center justify-center text-ink-on-dark font-medium">
-                    {session.coach.name?.charAt(0).toUpperCase() || 'C'}
-                  </div>
-                  <div>
-                    <p className="text-xs text-ink-3 ">Coach</p>
-                    <p className="text-sm font-medium text-ink ">
-                      {session.coach.name}
-                    </p>
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
+        {/* Quiet meta row */}
+        <div className="flex flex-wrap items-center gap-2 mt-3">
+          <span className="inline-flex items-center gap-1.5 h-[22px] px-2 rounded-md bg-surface-3 text-ink-2 text-[11px] font-medium capitalize">
+            {session.status}
+          </span>
+          {sentimentScore != null && (
+            <span
+              className={`inline-flex items-center gap-1.5 h-[22px] px-2 rounded-md text-[11px] font-medium ${getSentimentPillClass()}`}
+            >
+              {getSentimentIcon()}
+              {sentimentLabel} · {sentimentScore.toFixed(1)}
+            </span>
+          )}
+          {session.is_group_session && (
+            <span className="inline-flex items-center gap-1.5 h-[22px] px-2 rounded-md bg-indigo-bg text-indigo text-[11px] font-medium">
+              <Users className="h-3 w-3" />
+              Group session
+            </span>
+          )}
+          {(session.key_topics?.length ?? 0) > 0 && (
+            <span className="font-mono text-[11px] text-ink-3">
+              {session.key_topics?.length} topics
+            </span>
+          )}
+          {(structuredCommitments.length || session.action_items?.length || 0) >
+            0 && (
+            <span className="font-mono text-[11px] text-ink-3">
+              {structuredCommitments.length ||
+                session.action_items?.length ||
+                0}{' '}
+              commitments
+            </span>
+          )}
         </div>
       </div>
 
-      {/* Processing Notice — only show if there's no content yet */}
+      {/* Processing Notice */}
       {session.status === 'processing' &&
         !session.summary &&
         !sessionData.transcript?.length &&
         !hasInsights && (
-          <div className="mb-6 p-4 bg-surface-3 border border-line rounded-xl flex items-center gap-3">
+          <div className="mb-6 p-4 bg-surface-2 border border-line rounded-[10px] flex items-center gap-3">
             <div className="h-8 w-8 rounded-full bg-surface-3 flex items-center justify-center animate-pulse">
-              <Clock className="h-4 w-4 text-ink-3 " />
+              <Clock className="h-4 w-4 text-ink-3" />
             </div>
             <div>
-              <p className="text-sm font-medium text-ink ">
-                Session Processing
+              <p className="text-[13px] font-medium text-ink m-0">
+                Session processing
               </p>
-              <p className="text-xs text-ink-3 ">
+              <p className="text-[12px] text-ink-3 m-0">
                 Details will appear once processing is complete.
               </p>
             </div>
@@ -253,17 +189,17 @@ export default function ClientSessionDetailPage() {
 
       {/* Tabs */}
       <Tabs defaultValue="overview" className="w-full">
-        <TabsList className="mb-6 bg-surface-3 ">
-          <TabsTrigger value="overview" className="gap-2">
-            <LayoutList className="h-4 w-4" />
+        <TabsList className="mb-6 bg-surface-2 border border-line">
+          <TabsTrigger value="overview" className="gap-2 text-[13px]">
+            <LayoutList className="h-3.5 w-3.5" />
             Overview
           </TabsTrigger>
           <TabsTrigger
             value="analysis"
-            className="gap-2"
+            className="gap-2 text-[13px]"
             disabled={!hasInsights}
           >
-            <BarChart3 className="h-4 w-4" />
+            <BarChart3 className="h-3.5 w-3.5" />
             Insights & Analysis
           </TabsTrigger>
         </TabsList>
@@ -282,20 +218,20 @@ export default function ClientSessionDetailPage() {
         </TabsContent>
       </Tabs>
 
-      {/* Empty State — only when session has absolutely no content */}
+      {/* Empty State */}
       {!session.summary &&
         (!session.action_items || session.action_items.length === 0) &&
         !sessionData.transcript?.length &&
         !sessionData.tasks?.length &&
         !hasInsights && (
-          <div className="mt-6 text-center py-16 bg-paper rounded-xl border border-line ">
-            <div className="h-16 w-16 bg-surface-3 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Clock className="h-8 w-8 text-ink-4 " />
+          <div className="mt-6 text-center py-16 bg-surface-1 rounded-[10px] border border-line">
+            <div className="h-14 w-14 bg-surface-3 rounded-full flex items-center justify-center mx-auto mb-3">
+              <Clock className="h-6 w-6 text-ink-4" />
             </div>
-            <h3 className="text-lg font-medium text-ink mb-2">
+            <h3 className="text-[15px] font-medium text-ink mb-1">
               Session details coming soon
             </h3>
-            <p className="text-sm text-ink-3 max-w-md mx-auto">
+            <p className="text-[13px] text-ink-3 max-w-md mx-auto">
               This session is still being processed. Check back soon for the
               full summary, transcript, and insights.
             </p>

--- a/src/app/client-portal/sessions/[id]/page.tsx
+++ b/src/app/client-portal/sessions/[id]/page.tsx
@@ -47,7 +47,7 @@ export default function ClientSessionDetailPage() {
           <Skeleton className="h-6 w-20" />
         </div>
         {/* Hero skeleton */}
-        <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 mb-6">
+        <div className="bg-paper border border-line rounded-2xl p-6 mb-6">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
             <div className="flex items-center gap-4">
               <Skeleton className="h-16 w-16 rounded-xl" />
@@ -79,7 +79,7 @@ export default function ClientSessionDetailPage() {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center py-12">
-          <p className="text-gray-600 dark:text-gray-400 mb-4">
+          <p className="text-ink-3 mb-4">
             {error instanceof Error ? error.message : 'Session not found'}
           </p>
           <Link href="/client-portal/sessions">
@@ -100,19 +100,16 @@ export default function ClientSessionDetailPage() {
 
   const getSentimentIcon = () => {
     if (sentimentScore == null) return null
-    if (sentimentScore >= 7)
-      return <Smile className="h-4 w-4 text-emerald-500" />
-    if (sentimentScore >= 4) return <Meh className="h-4 w-4 text-amber-500" />
-    return <Frown className="h-4 w-4 text-gray-400" />
+    if (sentimentScore >= 7) return <Smile className="h-4 w-4 text-forest" />
+    if (sentimentScore >= 4) return <Meh className="h-4 w-4 text-amber-token" />
+    return <Frown className="h-4 w-4 text-ink-4" />
   }
 
   const getSentimentBgColor = () => {
     if (sentimentScore == null) return ''
-    if (sentimentScore >= 7)
-      return 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-    if (sentimentScore >= 4)
-      return 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-    return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    if (sentimentScore >= 7) return 'bg-forest-bg text-forest '
+    if (sentimentScore >= 4) return 'bg-amber-token-bg text-amber-token '
+    return 'bg-surface-3 text-ink-3 '
   }
 
   return (
@@ -123,7 +120,7 @@ export default function ClientSessionDetailPage() {
           <Button
             variant="ghost"
             size="sm"
-            className="-ml-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            className="-ml-2 text-ink-3 hover:text-ink "
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
             All Sessions
@@ -131,18 +128,18 @@ export default function ClientSessionDetailPage() {
         </Link>
         <Badge
           variant="secondary"
-          className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 capitalize"
+          className="bg-surface-3 text-ink-3 capitalize"
         >
           {session.status}
         </Badge>
       </div>
 
       {/* Hero Section */}
-      <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 mb-6">
+      <div className="bg-paper border border-line rounded-2xl p-6 mb-6">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
           {/* Date & Title */}
           <div className="flex items-center gap-4">
-            <div className="h-16 w-16 bg-gray-900 dark:bg-white rounded-xl flex flex-col items-center justify-center text-white dark:text-gray-900">
+            <div className="h-16 w-16 bg-ink rounded-xl flex flex-col items-center justify-center text-ink-on-dark ">
               <span className="text-2xl font-bold">
                 {session.started_at ? formatDate(session.started_at, 'd') : '-'}
               </span>
@@ -153,16 +150,16 @@ export default function ClientSessionDetailPage() {
               </span>
             </div>
             <div>
-              <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+              <h1 className="text-xl font-bold text-ink ">
                 {session.started_at
                   ? formatDate(session.started_at, 'EEEE, MMMM d, yyyy')
                   : 'Session Details'}
               </h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-3 ">
                 {session.started_at && formatRelativeTime(session.started_at)}
               </p>
               {session.is_group_session && (
-                <Badge className="mt-1 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs">
+                <Badge className="mt-1 bg-surface-3 text-ink-2 text-xs">
                   <Users className="h-3 w-3 mr-1" />
                   Group Session
                 </Badge>
@@ -173,35 +170,31 @@ export default function ClientSessionDetailPage() {
           {/* Quick Stats */}
           <div className="flex items-center gap-5 flex-wrap">
             <div className="text-center">
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-2xl font-bold text-ink ">
                 {session.duration_minutes || 0}
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Minutes
-              </p>
+              <p className="text-xs text-ink-3 ">Minutes</p>
             </div>
-            <div className="h-10 w-px bg-gray-200 dark:bg-gray-700" />
+            <div className="h-10 w-px bg-surface-3 " />
             <div className="text-center">
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-2xl font-bold text-ink ">
                 {session.key_topics?.length || 0}
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">Topics</p>
+              <p className="text-xs text-ink-3 ">Topics</p>
             </div>
-            <div className="h-10 w-px bg-gray-200 dark:bg-gray-700" />
+            <div className="h-10 w-px bg-surface-3 " />
             <div className="text-center">
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-2xl font-bold text-ink ">
                 {structuredCommitments.length ||
                   session.action_items?.length ||
                   0}
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Commitments
-              </p>
+              <p className="text-xs text-ink-3 ">Commitments</p>
             </div>
             {/* Sentiment score chip */}
             {sentimentScore != null && (
               <>
-                <div className="h-10 w-px bg-gray-200 dark:bg-gray-700" />
+                <div className="h-10 w-px bg-surface-3 " />
                 <div
                   className={`flex items-center gap-2 px-3 py-2 rounded-lg ${getSentimentBgColor()}`}
                 >
@@ -220,16 +213,14 @@ export default function ClientSessionDetailPage() {
             {/* Coach */}
             {session.coach && (
               <>
-                <div className="h-10 w-px bg-gray-200 dark:bg-gray-700" />
+                <div className="h-10 w-px bg-surface-3 " />
                 <div className="flex items-center gap-2">
-                  <div className="h-10 w-10 rounded-full bg-gray-900 dark:bg-white flex items-center justify-center text-white dark:text-gray-900 font-medium">
+                  <div className="h-10 w-10 rounded-full bg-ink flex items-center justify-center text-ink-on-dark font-medium">
                     {session.coach.name?.charAt(0).toUpperCase() || 'C'}
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      Coach
-                    </p>
-                    <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    <p className="text-xs text-ink-3 ">Coach</p>
+                    <p className="text-sm font-medium text-ink ">
                       {session.coach.name}
                     </p>
                   </div>
@@ -245,15 +236,15 @@ export default function ClientSessionDetailPage() {
         !session.summary &&
         !sessionData.transcript?.length &&
         !hasInsights && (
-          <div className="mb-6 p-4 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center gap-3">
-            <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center animate-pulse">
-              <Clock className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+          <div className="mb-6 p-4 bg-surface-3 border border-line rounded-xl flex items-center gap-3">
+            <div className="h-8 w-8 rounded-full bg-surface-3 flex items-center justify-center animate-pulse">
+              <Clock className="h-4 w-4 text-ink-3 " />
             </div>
             <div>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
+              <p className="text-sm font-medium text-ink ">
                 Session Processing
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-ink-3 ">
                 Details will appear once processing is complete.
               </p>
             </div>
@@ -262,7 +253,7 @@ export default function ClientSessionDetailPage() {
 
       {/* Tabs */}
       <Tabs defaultValue="overview" className="w-full">
-        <TabsList className="mb-6 bg-gray-100 dark:bg-gray-800">
+        <TabsList className="mb-6 bg-surface-3 ">
           <TabsTrigger value="overview" className="gap-2">
             <LayoutList className="h-4 w-4" />
             Overview
@@ -297,14 +288,14 @@ export default function ClientSessionDetailPage() {
         !sessionData.transcript?.length &&
         !sessionData.tasks?.length &&
         !hasInsights && (
-          <div className="mt-6 text-center py-16 bg-gray-50 dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
-            <div className="h-16 w-16 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Clock className="h-8 w-8 text-gray-400 dark:text-gray-500" />
+          <div className="mt-6 text-center py-16 bg-paper rounded-xl border border-line ">
+            <div className="h-16 w-16 bg-surface-3 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Clock className="h-8 w-8 text-ink-4 " />
             </div>
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            <h3 className="text-lg font-medium text-ink mb-2">
               Session details coming soon
             </h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+            <p className="text-sm text-ink-3 max-w-md mx-auto">
               This session is still being processed. Check back soon for the
               full summary, transcript, and insights.
             </p>

--- a/src/app/client-portal/sessions/page.tsx
+++ b/src/app/client-portal/sessions/page.tsx
@@ -2,10 +2,8 @@
 
 import { useState, useMemo } from 'react'
 import Link from 'next/link'
-import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Select,
@@ -21,20 +19,14 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import {
-  Clock,
-  FileText,
   Search,
   ChevronLeft,
   ChevronRight,
-  TrendingUp,
-  ArrowRight,
   MessageSquare,
-  Users,
-  Flame,
-  Timer,
+  Sparkles,
   ArrowUpDown,
 } from 'lucide-react'
-import { formatDate, formatRelativeTime } from '@/lib/date-utils'
+import { formatDate } from '@/lib/date-utils'
 import {
   useClientSessions,
   useClientDashboardStats,
@@ -95,72 +87,34 @@ export default function ClientSessionsPage() {
     }
   }, [filteredSessions, sortBy])
 
-  const getSentimentColor = (score?: number) => {
-    if (score == null) return null
-    if (score >= 7) return 'bg-forest'
-    if (score >= 4) return 'bg-amber-token'
-    return 'bg-line'
-  }
-
-  const getSentimentLabel = (score?: number) => {
-    if (score == null) return null
-    if (score >= 7) return 'Positive'
-    if (score >= 4) return 'Neutral'
-    return 'Needs attention'
-  }
-
-  const getStatusBorder = (session: (typeof sessions)[0]) => {
-    if (session.status === 'processing') return 'border-l-2 border-l-amber-400'
-    return 'border-l-2 border-l-emerald-500'
-  }
+  const isStrongScore = (score?: number) => score != null && score >= 7
 
   // Stats from dashboard (accurate totals)
   const totalSessions = dashboardStats?.total_sessions ?? sessions.length
-  const avgDuration = dashboardStats?.average_duration ?? 0
-  const streakDays = dashboardStats?.streak_days ?? 0
 
   if (isLoading) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
         {/* Header skeleton */}
-        <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-8">
-          <div>
-            <Skeleton className="h-9 w-48 mb-2" />
-            <Skeleton className="h-5 w-72" />
-          </div>
-          <div className="flex items-center gap-6">
-            <Skeleton className="h-14 w-20" />
-            <Skeleton className="h-14 w-20" />
-            <Skeleton className="h-14 w-20" />
-          </div>
+        <div className="mb-7">
+          <Skeleton className="h-9 w-48 mb-2" />
+          <Skeleton className="h-4 w-72" />
         </div>
         {/* Search skeleton */}
-        <Skeleton className="h-11 w-full mb-6" />
-        {/* Card skeletons */}
-        <div className="space-y-3">
+        <Skeleton className="h-11 w-full mb-4" />
+        {/* Row skeletons */}
+        <div className="border-t border-line">
           {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}
-              className="flex items-stretch border border-line rounded-xl bg-surface-1 overflow-hidden"
+              className="flex items-center gap-4 py-5 px-2 border-b border-line"
             >
-              <div className="w-24 md:w-32 bg-paper p-4 flex flex-col items-center justify-center border-r border-line ">
-                <Skeleton className="h-8 w-10 mb-1" />
-                <Skeleton className="h-3 w-14" />
+              <Skeleton className="h-10 w-12" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-full max-w-md" />
               </div>
-              <div className="flex-1 p-4 md:p-5 space-y-3">
-                <div className="flex items-center gap-3">
-                  <Skeleton className="h-4 w-24" />
-                  <Skeleton className="h-4 w-16" />
-                  <Skeleton className="h-5 w-16 rounded-full" />
-                </div>
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-4 w-3/4" />
-                <div className="flex gap-2">
-                  <Skeleton className="h-5 w-16 rounded" />
-                  <Skeleton className="h-5 w-20 rounded" />
-                  <Skeleton className="h-5 w-14 rounded" />
-                </div>
-              </div>
+              <Skeleton className="h-5 w-20" />
             </div>
           ))}
         </div>
@@ -170,7 +124,7 @@ export default function ClientSessionsPage() {
 
   if (error) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
         <div className="text-center py-12">
           <p className="text-vermillion mb-4">
             Error:{' '}
@@ -185,241 +139,144 @@ export default function ClientSessionsPage() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      {/* Header with Stats */}
-      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-8">
-        <div>
-          <h1 className="text-3xl font-bold text-ink ">Your Sessions</h1>
-          <p className="text-ink-3 mt-1">
-            Review your coaching sessions and track your progress
-          </p>
-        </div>
-
-        {/* Stats — from dashboard for accuracy */}
-        <div className="flex items-center gap-6 md:gap-8">
-          <div className="text-center">
-            <p className="text-2xl font-bold text-ink ">{totalSessions}</p>
-            <p className="text-xs text-ink-3 ">Sessions</p>
-          </div>
-          <div className="h-8 w-px bg-surface-3 " />
-          <div className="text-center">
-            <div className="flex items-center justify-center gap-1">
-              <Timer className="h-3.5 w-3.5 text-ink-4" />
-              <p className="text-2xl font-bold text-ink ">{avgDuration}</p>
-            </div>
-            <p className="text-xs text-ink-3 ">Avg Min</p>
-          </div>
-          {streakDays > 0 && (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-14">
+      {/* Header — editorial */}
+      <div className="mb-7">
+        <h1 className="text-[30px] font-bold tracking-tight leading-[1.2] text-ink m-0">
+          Sessions
+        </h1>
+        <p className="text-[13px] text-ink-3 mt-1.5">
+          {totalSessions > 0 ? (
             <>
-              <div className="h-8 w-px bg-surface-3 " />
-              <div className="text-center">
-                <div className="flex items-center justify-center gap-1">
-                  <Flame className="h-3.5 w-3.5 text-amber-token" />
-                  <p className="text-2xl font-bold text-ink ">{streakDays}</p>
-                </div>
-                <p className="text-xs text-ink-3 ">Week Streak</p>
-              </div>
+              {totalSessions} conversation
+              {totalSessions === 1 ? '' : 's'}
+              {dashboardStats?.streak_days
+                ? ` · ${dashboardStats.streak_days}-week streak`
+                : ''}
             </>
+          ) : (
+            <>Your coaching sessions will appear here.</>
           )}
-        </div>
+        </p>
       </div>
 
-      {/* Search & Sort Bar */}
-      <div className="flex items-center gap-3 mb-6">
+      {/* Search & Sort */}
+      <div className="bg-surface-1 border border-line rounded-[10px] shadow-sm flex items-center gap-2 p-1.5 mb-4">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
           <Input
             type="text"
-            placeholder="Search by date, topic, or summary..."
+            placeholder="Search by topic, date, or what was said…"
             value={searchTerm}
             onChange={e => setSearchTerm(e.target.value)}
-            className="pl-10 h-11 bg-surface-1 border-line text-ink placeholder:text-ink-4 "
+            className="pl-9 h-9 border-0 bg-transparent shadow-none text-[13px] text-ink placeholder:text-ink-4 focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         </div>
         <Select value={sortBy} onValueChange={v => setSortBy(v as SortOption)}>
-          <SelectTrigger className="w-[160px] h-11 bg-surface-1 border-line ">
-            <ArrowUpDown className="h-3.5 w-3.5 mr-2 text-ink-4" />
-            <SelectValue />
+          <SelectTrigger className="w-auto h-8 border-0 bg-transparent shadow-none text-[12px] text-ink-2 px-2.5 gap-1.5 hover:bg-surface-3 focus:ring-0">
+            <ArrowUpDown className="h-3.5 w-3.5 text-ink-4" />
+            <span>
+              Sort: <SelectValue />
+            </span>
           </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="recent">Most Recent</SelectItem>
-            <SelectItem value="longest">Longest</SelectItem>
-            <SelectItem value="most_topics">Most Topics</SelectItem>
+          <SelectContent align="end">
+            <SelectItem value="recent">recent</SelectItem>
+            <SelectItem value="longest">longest</SelectItem>
+            <SelectItem value="most_topics">most topics</SelectItem>
           </SelectContent>
         </Select>
       </div>
 
-      {/* Sessions List */}
+      {/* Sessions List — editorial rows */}
       {sortedSessions.length === 0 ? (
-        <Card className="border-line ">
-          <CardContent className="py-16 text-center">
-            <MessageSquare className="h-12 w-12 text-ink-2 mx-auto mb-4" />
-            {searchTerm ? (
-              <>
-                <h3 className="font-medium text-ink mb-2">No sessions found</h3>
-                <p className="text-sm text-ink-3 ">
-                  No sessions matching &quot;{searchTerm}&quot;
-                </p>
-              </>
-            ) : (
-              <>
-                <h3 className="font-medium text-ink mb-2">No sessions yet</h3>
-                <p className="text-sm text-ink-3 ">
-                  Your coaching sessions will appear here after your first call.
-                </p>
-              </>
-            )}
-          </CardContent>
-        </Card>
+        <div className="bg-surface-1 border border-line rounded-[10px] py-16 text-center">
+          <MessageSquare className="h-10 w-10 text-ink-3 mx-auto mb-3" />
+          {searchTerm ? (
+            <>
+              <h3 className="text-[14px] font-medium text-ink mb-1">
+                No sessions found
+              </h3>
+              <p className="text-[13px] text-ink-3">
+                No sessions matching &quot;{searchTerm}&quot;
+              </p>
+            </>
+          ) : (
+            <>
+              <h3 className="text-[14px] font-medium text-ink mb-1">
+                No sessions yet
+              </h3>
+              <p className="text-[13px] text-ink-3">
+                Your coaching sessions will appear here after your first call.
+              </p>
+            </>
+          )}
+        </div>
       ) : (
         <TooltipProvider>
-          <div className="space-y-3">
+          <div className="border-t border-line">
             {sortedSessions.map(session => {
-              const sentimentColor = getSentimentColor(session.sentiment_score)
-              const sentimentLabel = getSentimentLabel(session.sentiment_score)
-
+              const strong = isStrongScore(session.sentiment_score)
+              const commitmentsCount =
+                session.tasks_assigned || session.action_items?.length || 0
               return (
                 <Link
                   key={session.id}
                   href={`/client-portal/sessions/${session.id}`}
-                  className="block group"
+                  className="group flex items-center gap-4 py-5 px-2 border-b border-line transition-colors hover:bg-surface-2"
                 >
-                  <div
-                    className={`flex items-stretch rounded-xl bg-surface-1 border border-line hover:border-line-strong hover:shadow-sm transition-all overflow-hidden ${getStatusBorder(session)}`}
-                  >
-                    {/* Date Column */}
-                    <div className="w-24 md:w-32 flex-shrink-0 bg-paper p-4 flex flex-col items-center justify-center border-r border-line ">
-                      <span className="text-2xl font-bold text-ink ">
-                        {session.session_date
-                          ? formatDate(session.session_date, 'd')
-                          : '-'}
-                      </span>
-                      <span className="text-xs text-ink-3 uppercase tracking-wide">
-                        {session.session_date
-                          ? formatDate(session.session_date, 'MMM yyyy')
-                          : ''}
-                      </span>
-                    </div>
-
-                    {/* Content */}
-                    <div className="flex-1 p-4 md:p-5 min-w-0">
-                      {/* Top Row */}
-                      <div className="flex items-start justify-between gap-4 mb-2">
-                        <div className="flex items-center gap-3 flex-wrap">
-                          <span className="text-sm font-medium text-ink ">
-                            {session.session_date
-                              ? formatDate(session.session_date, 'EEEE')
-                              : 'Session'}
-                          </span>
-                          <span className="text-xs text-ink-4 ">
-                            {formatRelativeTime(session.session_date)}
-                          </span>
-                          {/* Sentiment dot */}
-                          {sentimentColor && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span
-                                  className={`inline-block h-2.5 w-2.5 rounded-full ${sentimentColor}`}
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                <p>
-                                  {sentimentLabel} (
-                                  {session.sentiment_score?.toFixed(1)}/10)
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2 flex-shrink-0">
-                          <Badge
-                            variant="secondary"
-                            className="bg-surface-3 text-ink-3 text-xs"
-                          >
-                            <Clock className="h-3 w-3 mr-1" />
-                            {session.duration_minutes || 0} min
-                          </Badge>
-                          {session.engagement_level && (
-                            <Badge
-                              variant="secondary"
-                              className="bg-surface-3 text-ink-3 text-xs capitalize"
-                            >
-                              {session.engagement_level}
-                            </Badge>
-                          )}
-                          {session.is_group_session && (
-                            <Badge
-                              variant="secondary"
-                              className="bg-indigo-bg text-indigo text-xs"
-                            >
-                              <Users className="h-3 w-3 mr-1" />
-                              Group
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-
-                      {/* Summary */}
-                      {session.summary ? (
-                        <p className="text-sm text-ink-3 line-clamp-2 mb-3">
-                          {session.summary}
-                        </p>
-                      ) : (
-                        <p className="text-sm text-ink-4 italic mb-3">
-                          No summary available
-                        </p>
-                      )}
-
-                      {/* Bottom Row — Topics and Stats */}
-                      <div className="flex items-center justify-between gap-4">
-                        {/* Key Topics */}
-                        <div className="flex items-center gap-2 flex-wrap min-w-0">
-                          {session.key_topics &&
-                          session.key_topics.length > 0 ? (
-                            <>
-                              {session.key_topics
-                                .slice(0, 3)
-                                .map((topic, idx) => (
-                                  <span
-                                    key={idx}
-                                    className="inline-flex px-2.5 py-1 bg-surface-3 text-ink-3 text-xs rounded-md"
-                                  >
-                                    {topic}
-                                  </span>
-                                ))}
-                              {session.key_topics.length > 3 && (
-                                <span className="text-xs text-ink-4 ">
-                                  +{session.key_topics.length - 3} more
-                                </span>
-                              )}
-                            </>
-                          ) : null}
-                        </div>
-
-                        {/* Stats */}
-                        <div className="flex items-center gap-4 text-xs text-ink-3 flex-shrink-0">
-                          {session.tasks_assigned > 0 && (
-                            <span className="flex items-center gap-1">
-                              <FileText className="h-3.5 w-3.5" />
-                              {session.tasks_assigned} commitments
-                            </span>
-                          )}
-                          {session.action_items &&
-                            session.action_items.length > 0 && (
-                              <span className="flex items-center gap-1">
-                                <TrendingUp className="h-3.5 w-3.5" />
-                                {session.action_items.length} actions
-                              </span>
-                            )}
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Arrow */}
-                    <div className="flex items-center px-4 bg-paper border-l border-line group-hover:bg-surface-3 transition-colors">
-                      <ArrowRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 transition-colors" />
-                    </div>
+                  <div className="w-14 flex-shrink-0 flex flex-col items-center">
+                    <span className="text-[24px] font-semibold leading-none text-ink">
+                      {session.session_date
+                        ? formatDate(session.session_date, 'd')
+                        : '–'}
+                    </span>
+                    <span className="font-mono text-[10px] uppercase text-ink-3 mt-1">
+                      {session.session_date
+                        ? formatDate(session.session_date, 'MMM')
+                        : ''}
+                    </span>
                   </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="text-[14px] font-medium text-ink">
+                        {session.session_date
+                          ? formatDate(session.session_date, 'EEEE')
+                          : 'Session'}
+                      </span>
+                      <span className="font-mono text-[11px] text-ink-3">
+                        {session.duration_minutes || 0} min
+                      </span>
+                    </div>
+                    <p className="m-0 text-[13px] leading-[1.5] text-ink-2 line-clamp-2">
+                      {session.summary ?? (
+                        <span className="italic text-ink-4">
+                          No summary available
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 min-w-[100px]">
+                    {strong && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex items-center gap-1 px-2 h-[22px] rounded-md bg-forest-bg text-forest text-[11px] font-medium">
+                            <Sparkles className="h-3 w-3" />
+                            Strong session
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {session.sentiment_score?.toFixed(1)}/10 sentiment
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {commitmentsCount > 0 && (
+                      <span className="font-mono text-[11px] text-ink-3">
+                        {commitmentsCount} commitment
+                        {commitmentsCount === 1 ? '' : 's'}
+                      </span>
+                    )}
+                  </div>
+                  <ChevronRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 flex-shrink-0" />
                 </Link>
               )
             })}
@@ -429,27 +286,29 @@ export default function ClientSessionsPage() {
 
       {/* Pagination */}
       {sessions.length > 0 && (
-        <div className="flex items-center justify-between mt-8 pt-6 border-t border-line ">
+        <div className="flex items-center justify-between mt-6 pt-5">
           <Button
             variant="ghost"
             onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
             disabled={currentPage === 1}
-            className="text-ink-3 hover:text-ink "
+            className="text-ink-3 hover:text-ink h-8 text-[12px]"
           >
-            <ChevronLeft className="mr-1 h-4 w-4" />
+            <ChevronLeft className="mr-1 h-3.5 w-3.5" />
             Previous
           </Button>
 
-          <span className="text-sm text-ink-3 ">Page {currentPage}</span>
+          <span className="font-mono text-[12px] text-ink-3">
+            Page {currentPage}
+          </span>
 
           <Button
             variant="ghost"
             onClick={() => setCurrentPage(prev => prev + 1)}
             disabled={sortedSessions.length < itemsPerPage}
-            className="text-ink-3 hover:text-ink "
+            className="text-ink-3 hover:text-ink h-8 text-[12px]"
           >
             Next
-            <ChevronRight className="ml-1 h-4 w-4" />
+            <ChevronRight className="ml-1 h-3.5 w-3.5" />
           </Button>
         </div>
       )}

--- a/src/app/client-portal/sessions/page.tsx
+++ b/src/app/client-portal/sessions/page.tsx
@@ -97,9 +97,9 @@ export default function ClientSessionsPage() {
 
   const getSentimentColor = (score?: number) => {
     if (score == null) return null
-    if (score >= 7) return 'bg-emerald-500'
-    if (score >= 4) return 'bg-amber-500'
-    return 'bg-gray-400'
+    if (score >= 7) return 'bg-forest'
+    if (score >= 4) return 'bg-amber-token'
+    return 'bg-line'
   }
 
   const getSentimentLabel = (score?: number) => {
@@ -141,9 +141,9 @@ export default function ClientSessionsPage() {
           {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}
-              className="flex items-stretch border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 overflow-hidden"
+              className="flex items-stretch border border-line rounded-xl bg-surface-1 overflow-hidden"
             >
-              <div className="w-24 md:w-32 bg-gray-50 dark:bg-gray-800 p-4 flex flex-col items-center justify-center border-r border-gray-100 dark:border-gray-800">
+              <div className="w-24 md:w-32 bg-paper p-4 flex flex-col items-center justify-center border-r border-line ">
                 <Skeleton className="h-8 w-10 mb-1" />
                 <Skeleton className="h-3 w-14" />
               </div>
@@ -172,7 +172,7 @@ export default function ClientSessionsPage() {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center py-12">
-          <p className="text-red-500 mb-4">
+          <p className="text-vermillion mb-4">
             Error:{' '}
             {error instanceof Error ? error.message : 'Failed to load sessions'}
           </p>
@@ -189,10 +189,8 @@ export default function ClientSessionsPage() {
       {/* Header with Stats */}
       <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-            Your Sessions
-          </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-3xl font-bold text-ink ">Your Sessions</h1>
+          <p className="text-ink-3 mt-1">
             Review your coaching sessions and track your progress
           </p>
         </div>
@@ -200,34 +198,26 @@ export default function ClientSessionsPage() {
         {/* Stats — from dashboard for accuracy */}
         <div className="flex items-center gap-6 md:gap-8">
           <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">
-              {totalSessions}
-            </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Sessions</p>
+            <p className="text-2xl font-bold text-ink ">{totalSessions}</p>
+            <p className="text-xs text-ink-3 ">Sessions</p>
           </div>
-          <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+          <div className="h-8 w-px bg-surface-3 " />
           <div className="text-center">
             <div className="flex items-center justify-center gap-1">
-              <Timer className="h-3.5 w-3.5 text-gray-400" />
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                {avgDuration}
-              </p>
+              <Timer className="h-3.5 w-3.5 text-ink-4" />
+              <p className="text-2xl font-bold text-ink ">{avgDuration}</p>
             </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Avg Min</p>
+            <p className="text-xs text-ink-3 ">Avg Min</p>
           </div>
           {streakDays > 0 && (
             <>
-              <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+              <div className="h-8 w-px bg-surface-3 " />
               <div className="text-center">
                 <div className="flex items-center justify-center gap-1">
-                  <Flame className="h-3.5 w-3.5 text-orange-500" />
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {streakDays}
-                  </p>
+                  <Flame className="h-3.5 w-3.5 text-amber-token" />
+                  <p className="text-2xl font-bold text-ink ">{streakDays}</p>
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Week Streak
-                </p>
+                <p className="text-xs text-ink-3 ">Week Streak</p>
               </div>
             </>
           )}
@@ -237,18 +227,18 @@ export default function ClientSessionsPage() {
       {/* Search & Sort Bar */}
       <div className="flex items-center gap-3 mb-6">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4 " />
           <Input
             type="text"
             placeholder="Search by date, topic, or summary..."
             value={searchTerm}
             onChange={e => setSearchTerm(e.target.value)}
-            className="pl-10 h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500"
+            className="pl-10 h-11 bg-surface-1 border-line text-ink placeholder:text-ink-4 "
           />
         </div>
         <Select value={sortBy} onValueChange={v => setSortBy(v as SortOption)}>
-          <SelectTrigger className="w-[160px] h-11 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
-            <ArrowUpDown className="h-3.5 w-3.5 mr-2 text-gray-400" />
+          <SelectTrigger className="w-[160px] h-11 bg-surface-1 border-line ">
+            <ArrowUpDown className="h-3.5 w-3.5 mr-2 text-ink-4" />
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -261,24 +251,20 @@ export default function ClientSessionsPage() {
 
       {/* Sessions List */}
       {sortedSessions.length === 0 ? (
-        <Card className="border-gray-200 dark:border-gray-700">
+        <Card className="border-line ">
           <CardContent className="py-16 text-center">
-            <MessageSquare className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+            <MessageSquare className="h-12 w-12 text-ink-2 mx-auto mb-4" />
             {searchTerm ? (
               <>
-                <h3 className="font-medium text-gray-900 dark:text-white mb-2">
-                  No sessions found
-                </h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <h3 className="font-medium text-ink mb-2">No sessions found</h3>
+                <p className="text-sm text-ink-3 ">
                   No sessions matching &quot;{searchTerm}&quot;
                 </p>
               </>
             ) : (
               <>
-                <h3 className="font-medium text-gray-900 dark:text-white mb-2">
-                  No sessions yet
-                </h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <h3 className="font-medium text-ink mb-2">No sessions yet</h3>
+                <p className="text-sm text-ink-3 ">
                   Your coaching sessions will appear here after your first call.
                 </p>
               </>
@@ -299,16 +285,16 @@ export default function ClientSessionsPage() {
                   className="block group"
                 >
                   <div
-                    className={`flex items-stretch rounded-xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all overflow-hidden ${getStatusBorder(session)}`}
+                    className={`flex items-stretch rounded-xl bg-surface-1 border border-line hover:border-line-strong hover:shadow-sm transition-all overflow-hidden ${getStatusBorder(session)}`}
                   >
                     {/* Date Column */}
-                    <div className="w-24 md:w-32 flex-shrink-0 bg-gray-50 dark:bg-gray-800 p-4 flex flex-col items-center justify-center border-r border-gray-100 dark:border-gray-800">
-                      <span className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <div className="w-24 md:w-32 flex-shrink-0 bg-paper p-4 flex flex-col items-center justify-center border-r border-line ">
+                      <span className="text-2xl font-bold text-ink ">
                         {session.session_date
                           ? formatDate(session.session_date, 'd')
                           : '-'}
                       </span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      <span className="text-xs text-ink-3 uppercase tracking-wide">
                         {session.session_date
                           ? formatDate(session.session_date, 'MMM yyyy')
                           : ''}
@@ -320,12 +306,12 @@ export default function ClientSessionsPage() {
                       {/* Top Row */}
                       <div className="flex items-start justify-between gap-4 mb-2">
                         <div className="flex items-center gap-3 flex-wrap">
-                          <span className="text-sm font-medium text-gray-900 dark:text-white">
+                          <span className="text-sm font-medium text-ink ">
                             {session.session_date
                               ? formatDate(session.session_date, 'EEEE')
                               : 'Session'}
                           </span>
-                          <span className="text-xs text-gray-400 dark:text-gray-500">
+                          <span className="text-xs text-ink-4 ">
                             {formatRelativeTime(session.session_date)}
                           </span>
                           {/* Sentiment dot */}
@@ -348,7 +334,7 @@ export default function ClientSessionsPage() {
                         <div className="flex items-center gap-2 flex-shrink-0">
                           <Badge
                             variant="secondary"
-                            className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs"
+                            className="bg-surface-3 text-ink-3 text-xs"
                           >
                             <Clock className="h-3 w-3 mr-1" />
                             {session.duration_minutes || 0} min
@@ -356,7 +342,7 @@ export default function ClientSessionsPage() {
                           {session.engagement_level && (
                             <Badge
                               variant="secondary"
-                              className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs capitalize"
+                              className="bg-surface-3 text-ink-3 text-xs capitalize"
                             >
                               {session.engagement_level}
                             </Badge>
@@ -364,7 +350,7 @@ export default function ClientSessionsPage() {
                           {session.is_group_session && (
                             <Badge
                               variant="secondary"
-                              className="bg-purple-50 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 text-xs"
+                              className="bg-indigo-bg text-indigo text-xs"
                             >
                               <Users className="h-3 w-3 mr-1" />
                               Group
@@ -375,11 +361,11 @@ export default function ClientSessionsPage() {
 
                       {/* Summary */}
                       {session.summary ? (
-                        <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2 mb-3">
+                        <p className="text-sm text-ink-3 line-clamp-2 mb-3">
                           {session.summary}
                         </p>
                       ) : (
-                        <p className="text-sm text-gray-400 dark:text-gray-500 italic mb-3">
+                        <p className="text-sm text-ink-4 italic mb-3">
                           No summary available
                         </p>
                       )}
@@ -396,13 +382,13 @@ export default function ClientSessionsPage() {
                                 .map((topic, idx) => (
                                   <span
                                     key={idx}
-                                    className="inline-flex px-2.5 py-1 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs rounded-md"
+                                    className="inline-flex px-2.5 py-1 bg-surface-3 text-ink-3 text-xs rounded-md"
                                   >
                                     {topic}
                                   </span>
                                 ))}
                               {session.key_topics.length > 3 && (
-                                <span className="text-xs text-gray-400 dark:text-gray-500">
+                                <span className="text-xs text-ink-4 ">
                                   +{session.key_topics.length - 3} more
                                 </span>
                               )}
@@ -411,7 +397,7 @@ export default function ClientSessionsPage() {
                         </div>
 
                         {/* Stats */}
-                        <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400 flex-shrink-0">
+                        <div className="flex items-center gap-4 text-xs text-ink-3 flex-shrink-0">
                           {session.tasks_assigned > 0 && (
                             <span className="flex items-center gap-1">
                               <FileText className="h-3.5 w-3.5" />
@@ -430,8 +416,8 @@ export default function ClientSessionsPage() {
                     </div>
 
                     {/* Arrow */}
-                    <div className="flex items-center px-4 bg-gray-50 dark:bg-gray-800 border-l border-gray-100 dark:border-gray-800 group-hover:bg-gray-100 dark:group-hover:bg-gray-700 transition-colors">
-                      <ArrowRight className="h-4 w-4 text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
+                    <div className="flex items-center px-4 bg-paper border-l border-line group-hover:bg-surface-3 transition-colors">
+                      <ArrowRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 transition-colors" />
                     </div>
                   </div>
                 </Link>
@@ -443,26 +429,24 @@ export default function ClientSessionsPage() {
 
       {/* Pagination */}
       {sessions.length > 0 && (
-        <div className="flex items-center justify-between mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
+        <div className="flex items-center justify-between mt-8 pt-6 border-t border-line ">
           <Button
             variant="ghost"
             onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
             disabled={currentPage === 1}
-            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            className="text-ink-3 hover:text-ink "
           >
             <ChevronLeft className="mr-1 h-4 w-4" />
             Previous
           </Button>
 
-          <span className="text-sm text-gray-500 dark:text-gray-400">
-            Page {currentPage}
-          </span>
+          <span className="text-sm text-ink-3 ">Page {currentPage}</span>
 
           <Button
             variant="ghost"
             onClick={() => setCurrentPage(prev => prev + 1)}
             disabled={sortedSessions.length < itemsPerPage}
-            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            className="text-ink-3 hover:text-ink "
           >
             Next
             <ChevronRight className="ml-1 h-4 w-4" />

--- a/src/app/clients/[clientId]/components/active-commitments-card.tsx
+++ b/src/app/clients/[clientId]/components/active-commitments-card.tsx
@@ -39,8 +39,8 @@ export function ActiveCommitmentsCard({
 
   if (isLoading) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700 shadow-sm">
-        <CardHeader className="border-b border-gray-100 dark:border-gray-700">
+      <Card className="border-line shadow-sm">
+        <CardHeader className="border-b border-line ">
           <div className="flex items-center gap-3">
             <Skeleton className="h-9 w-9 rounded-lg" />
             <div className="flex-1">
@@ -59,18 +59,18 @@ export function ActiveCommitmentsCard({
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 shadow-sm">
-      <CardHeader className="border-b border-gray-100 dark:border-gray-700">
+    <Card className="border-line shadow-sm">
+      <CardHeader className="border-b border-line ">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-green-50 dark:bg-green-900/30 rounded-lg">
-              <Target className="h-5 w-5 text-green-600 dark:text-green-400" />
+            <div className="p-2 bg-forest-bg rounded-lg">
+              <Target className="h-5 w-5 text-forest " />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              <h2 className="text-lg font-semibold text-ink ">
                 Client Commitments
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-3 ">
                 {allCommitments.length} total commitments
               </p>
             </div>
@@ -80,7 +80,7 @@ export function ActiveCommitmentsCard({
               variant="ghost"
               size="sm"
               onClick={onViewAll}
-              className="hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="hover:bg-paper "
             >
               View All
               <ArrowRight className="h-4 w-4 ml-1" />
@@ -91,11 +91,9 @@ export function ActiveCommitmentsCard({
       <CardContent className="pt-6">
         {allCommitments.length === 0 ? (
           <div className="text-center py-8">
-            <Target className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-            <h3 className="text-gray-900 dark:text-white font-medium mb-1">
-              No commitments yet
-            </h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <Target className="h-12 w-12 text-ink-2 mx-auto mb-3" />
+            <h3 className="text-ink font-medium mb-1">No commitments yet</h3>
+            <p className="text-sm text-ink-3 ">
               Create commitments to track progress and accountability
             </p>
           </div>
@@ -112,15 +110,15 @@ export function ActiveCommitmentsCard({
               return (
                 <div
                   key={commitment.id}
-                  className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
+                  className="p-4 border border-line rounded-lg hover:border-line-strong transition-colors"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
-                      <h4 className="font-medium text-gray-900 dark:text-white mb-1 truncate">
+                      <h4 className="font-medium text-ink mb-1 truncate">
                         {commitment.title}
                       </h4>
                       {commitment.description && (
-                        <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
+                        <p className="text-sm text-ink-3 line-clamp-2 mb-2">
                           {commitment.description}
                         </p>
                       )}
@@ -130,15 +128,15 @@ export function ActiveCommitmentsCard({
                           className={cn(
                             'text-xs',
                             commitment.type === 'commitment' &&
-                              'bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-900/30 dark:border-blue-800 dark:text-blue-400',
+                              'bg-ds-accent-bg border-ds-accent text-ds-accent ',
                             commitment.type === 'habit' &&
-                              'bg-purple-50 border-purple-200 text-purple-700 dark:bg-purple-900/30 dark:border-purple-800 dark:text-purple-400',
+                              'bg-indigo-bg border-indigo text-indigo ',
                             commitment.type === 'mp_outcome' &&
-                              'bg-orange-50 border-orange-200 text-orange-700 dark:bg-orange-900/30 dark:border-orange-800 dark:text-orange-400',
+                              'bg-amber-token-bg border-amber-token text-amber-token ',
                             commitment.type === 'learning' &&
-                              'bg-green-50 border-green-200 text-green-700 dark:bg-green-900/30 dark:border-green-800 dark:text-green-400',
+                              'bg-forest-bg border-forest text-forest ',
                             commitment.type === 'sprint' &&
-                              'bg-indigo-50 border-indigo-200 text-indigo-700 dark:bg-indigo-900/30 dark:border-indigo-800 dark:text-indigo-400',
+                              'bg-indigo-bg border-indigo text-indigo ',
                           )}
                         >
                           {commitmentTypeLabels[commitment.type] ||
@@ -148,11 +146,9 @@ export function ActiveCommitmentsCard({
                           <div
                             className={cn(
                               'flex items-center gap-1 text-xs',
-                              isOverdue && 'text-red-600',
-                              isDueSoon && 'text-orange-600',
-                              !isOverdue &&
-                                !isDueSoon &&
-                                'text-gray-600 dark:text-gray-400',
+                              isOverdue && 'text-vermillion',
+                              isDueSoon && 'text-amber-token',
+                              !isOverdue && !isDueSoon && 'text-ink-3 ',
                             )}
                           >
                             <Clock className="h-3 w-3" />
@@ -169,12 +165,12 @@ export function ActiveCommitmentsCard({
                     </div>
                     {commitment.progress_percentage > 0 && (
                       <div className="flex flex-col items-end gap-1">
-                        <div className="flex items-center gap-1 text-sm font-medium text-green-600 dark:text-green-400">
+                        <div className="flex items-center gap-1 text-sm font-medium text-forest ">
                           <TrendingUp className="h-3 w-3" />
                           <span>{commitment.progress_percentage}%</span>
                         </div>
                         {commitment.progress_percentage >= 100 && (
-                          <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          <CheckCircle2 className="h-4 w-4 text-forest" />
                         )}
                       </div>
                     )}
@@ -183,7 +179,7 @@ export function ActiveCommitmentsCard({
               )
             })}
             {allCommitments.length > 5 && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 text-center pt-2">
+              <p className="text-sm text-ink-3 text-center pt-2">
                 +{allCommitments.length - 5} more commitments
               </p>
             )}

--- a/src/app/clients/[clientId]/components/chat-mode-selector.tsx
+++ b/src/app/clients/[clientId]/components/chat-mode-selector.tsx
@@ -87,10 +87,10 @@ export function ChatModeSelector({
     <>
       <Card className="p-6">
         <div className="text-center mb-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          <h3 className="text-lg font-semibold text-ink mb-2">
             Choose Your Chat Experience
           </h3>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-ink-3 ">
             Select how you&apos;d like to interact with{' '}
             {clientName || 'your client'}
             &apos;s AI assistant
@@ -100,19 +100,17 @@ export function ChatModeSelector({
         <div className="grid md:grid-cols-2 gap-4">
           {/* Classic Chat Mode */}
           <Card
-            className="p-4 cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-gray-300 dark:hover:border-gray-500"
+            className="p-4 cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-line-strong "
             onClick={() => handleModeSelect('classic')}
           >
             <div className="flex flex-col items-center text-center space-y-3">
-              <div className="h-12 w-12 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center">
-                <MessageSquare className="h-6 w-6 text-gray-700 dark:text-gray-300" />
+              <div className="h-12 w-12 rounded-lg bg-surface-3 flex items-center justify-center">
+                <MessageSquare className="h-6 w-6 text-ink-2 " />
               </div>
 
               <div>
-                <h4 className="font-semibold text-gray-900 dark:text-white mb-1">
-                  Classic Chat
-                </h4>
-                <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
+                <h4 className="font-semibold text-ink mb-1">Classic Chat</h4>
+                <p className="text-xs text-ink-3 mb-2">
                   Text-based conversation with optional voice input
                 </p>
               </div>
@@ -129,16 +127,14 @@ export function ChatModeSelector({
                 </Badge>
               </div>
 
-              <div className="w-full pt-3 border-t dark:border-gray-700">
+              <div className="w-full pt-3 border-t ">
                 <div className="flex items-center justify-between text-xs">
-                  <span className="text-gray-500 dark:text-gray-400">
-                    Response time
-                  </span>
+                  <span className="text-ink-3 ">Response time</span>
                   <span className="font-medium">2-3 seconds</span>
                 </div>
                 <div className="flex items-center justify-between text-xs mt-1">
-                  <span className="text-gray-500 dark:text-gray-400">Cost</span>
-                  <span className="font-medium text-green-600">Low</span>
+                  <span className="text-ink-3 ">Cost</span>
+                  <span className="font-medium text-forest">Low</span>
                 </div>
               </div>
 
@@ -151,17 +147,14 @@ export function ChatModeSelector({
 
           {/* Realtime Voice Mode */}
           <Card
-            className="p-4 cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-violet-300 relative"
+            className="p-4 cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-indigo relative"
             onClick={() => handleModeSelect('realtime')}
           >
             <div className="absolute top-2 right-2">
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger>
-                    <Badge
-                      variant="default"
-                      className="text-xs bg-gradient-to-r from-violet-500 to-purple-600"
-                    >
+                    <Badge variant="default" className="text-xs  ">
                       <Zap className="h-3 w-3 mr-1" />
                       Premium
                     </Badge>
@@ -174,51 +167,44 @@ export function ChatModeSelector({
             </div>
 
             <div className="flex flex-col items-center text-center space-y-3">
-              <div className="h-12 w-12 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center shadow-lg">
-                <Headphones className="h-6 w-6 text-white" />
+              <div className="h-12 w-12 rounded-lg bg-surface-3 flex items-center justify-center shadow-lg">
+                <Headphones className="h-6 w-6 text-ink-on-dark" />
               </div>
 
               <div>
-                <h4 className="font-semibold text-gray-900 dark:text-white mb-1">
-                  Realtime Voice
-                </h4>
-                <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
+                <h4 className="font-semibold text-ink mb-1">Realtime Voice</h4>
+                <p className="text-xs text-ink-3 mb-2">
                   Natural speech-to-speech conversation
                 </p>
               </div>
 
               <div className="flex flex-wrap gap-1 justify-center">
-                <Badge className="text-xs bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800">
+                <Badge className="text-xs bg-indigo-bg text-indigo border-indigo ">
                   <Sparkles className="h-3 w-3 mr-1" />
                   GPT-4o
                 </Badge>
-                <Badge className="text-xs bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800">
+                <Badge className="text-xs bg-indigo-bg text-indigo border-indigo ">
                   Native Audio
                 </Badge>
-                <Badge className="text-xs bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800">
+                <Badge className="text-xs bg-indigo-bg text-indigo border-indigo ">
                   Live RAG
                 </Badge>
               </div>
 
-              <div className="w-full pt-3 border-t dark:border-gray-700">
+              <div className="w-full pt-3 border-t ">
                 <div className="flex items-center justify-between text-xs">
-                  <span className="text-gray-500 dark:text-gray-400">
-                    Response time
-                  </span>
-                  <span className="font-medium text-violet-600 dark:text-violet-400">
-                    ~300ms
-                  </span>
+                  <span className="text-ink-3 ">Response time</span>
+                  <span className="font-medium text-indigo ">~300ms</span>
                 </div>
                 <div className="flex items-center justify-between text-xs mt-1">
-                  <span className="text-gray-500 dark:text-gray-400">Cost</span>
-                  <span className="font-medium text-orange-600">$0.06/min</span>
+                  <span className="text-ink-3 ">Cost</span>
+                  <span className="font-medium text-amber-token">
+                    $0.06/min
+                  </span>
                 </div>
               </div>
 
-              <Button
-                className="w-full mt-2 bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
-                size="sm"
-              >
+              <Button className="w-full mt-2  hover:" size="sm">
                 <Headphones className="h-4 w-4 mr-2" />
                 Start Voice Chat
               </Button>
@@ -232,17 +218,17 @@ export function ChatModeSelector({
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              <Headphones className="h-5 w-5 text-violet-600" />
+              <Headphones className="h-5 w-5 text-indigo" />
               Enable Realtime Voice Chat
             </DialogTitle>
           </DialogHeader>
 
           <div className="space-y-4">
-            <div className="bg-violet-50 dark:bg-violet-900/30 border border-violet-200 dark:border-violet-800 rounded-lg p-3">
-              <h4 className="font-medium text-sm text-violet-900 dark:text-violet-300 mb-2">
+            <div className="bg-indigo-bg border border-indigo rounded-lg p-3">
+              <h4 className="font-medium text-sm text-indigo mb-2">
                 Premium Features
               </h4>
-              <ul className="space-y-1 text-xs text-violet-700 dark:text-violet-300">
+              <ul className="space-y-1 text-xs text-indigo ">
                 <li className="flex items-start gap-2">
                   <Sparkles className="h-3 w-3 mt-0.5 flex-shrink-0" />
                   <span>Ultra-low latency (~300ms) responses</span>
@@ -262,27 +248,27 @@ export function ChatModeSelector({
               </ul>
             </div>
 
-            <div className="bg-orange-50 dark:bg-orange-900/30 border border-orange-200 dark:border-orange-800 rounded-lg p-3">
+            <div className="bg-amber-token-bg border border-amber-token rounded-lg p-3">
               <div className="flex items-start gap-2">
-                <DollarSign className="h-4 w-4 text-orange-600 dark:text-orange-400 mt-0.5 flex-shrink-0" />
+                <DollarSign className="h-4 w-4 text-amber-token mt-0.5 flex-shrink-0" />
                 <div className="text-xs">
-                  <p className="font-medium text-orange-900 dark:text-orange-300 mb-1">
+                  <p className="font-medium text-amber-token mb-1">
                     Usage Costs
                   </p>
-                  <p className="text-orange-700 dark:text-orange-400">
+                  <p className="text-amber-token ">
                     Voice input: $0.06/minute • Voice output: $0.24/minute
                   </p>
-                  <p className="text-orange-600 dark:text-orange-400 mt-1">
+                  <p className="text-amber-token mt-1">
                     Typical 5-minute conversation: ~$0.30-$0.50
                   </p>
                 </div>
               </div>
             </div>
 
-            <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+            <div className="bg-paper border border-line rounded-lg p-3">
               <div className="flex items-start gap-2">
-                <Info className="h-4 w-4 text-gray-600 dark:text-gray-400 mt-0.5 flex-shrink-0" />
-                <div className="text-xs text-gray-600 dark:text-gray-400">
+                <Info className="h-4 w-4 text-ink-3 mt-0.5 flex-shrink-0" />
+                <div className="text-xs text-ink-3 ">
                   <p className="mb-1">
                     Requires microphone access and a stable internet connection.
                   </p>
@@ -299,10 +285,7 @@ export function ChatModeSelector({
               >
                 Cancel
               </Button>
-              <Button
-                onClick={confirmRealtimeMode}
-                className="flex-1 bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
-              >
+              <Button onClick={confirmRealtimeMode} className="flex-1  hover:">
                 <Headphones className="h-4 w-4 mr-2" />
                 Enable Voice Chat
               </Button>

--- a/src/app/clients/[clientId]/components/chat-tab.tsx
+++ b/src/app/clients/[clientId]/components/chat-tab.tsx
@@ -13,21 +13,21 @@ export function ChatTab({ clientId, clientName, isViewer }: ChatTabProps) {
   if (isViewer) {
     return (
       <div className="flex items-center justify-center min-h-[500px]">
-        <Card className="border-gray-200 shadow-sm max-w-md w-full">
+        <Card className="border-line shadow-sm max-w-md w-full">
           <CardContent className="pt-12 pb-12">
             <div className="flex flex-col items-center justify-center text-center">
-              <div className="p-4 bg-blue-50 rounded-full mb-4">
-                <Lock className="h-8 w-8 text-blue-600" />
+              <div className="p-4 bg-ds-accent-bg rounded-full mb-4">
+                <Lock className="h-8 w-8 text-ds-accent" />
               </div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-semibold text-ink mb-2">
                 Restricted Access
               </h3>
-              <p className="text-sm text-gray-600 mb-4">
+              <p className="text-sm text-ink-3 mb-4">
                 Chat functionality is not available with viewer permissions.
               </p>
               <Badge
                 variant="outline"
-                className="bg-blue-50 border-blue-200 text-blue-700"
+                className="bg-ds-accent-bg border-ds-accent text-ds-accent"
               >
                 <Eye className="h-3 w-3 mr-1.5" />
                 View Only Mode

--- a/src/app/clients/[clientId]/components/client-chat-realtime.tsx
+++ b/src/app/clients/[clientId]/components/client-chat-realtime.tsx
@@ -184,7 +184,7 @@ export function ClientChatRealtime({
     return (
       <Card className="flex flex-col h-full">
         <div className="flex items-center justify-center flex-1">
-          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
         </div>
       </Card>
     )
@@ -195,11 +195,11 @@ export function ClientChatRealtime({
       <Card className="flex flex-col h-full p-4">
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center max-w-sm">
-            <MessageSquare className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+            <MessageSquare className="h-10 w-10 text-ink-2 mx-auto mb-3" />
+            <h3 className="text-sm font-medium text-ink mb-1">
               No Knowledge Base Yet
             </h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-ink-3 ">
               The AI assistant will be available after analyzing coaching
               sessions.
             </p>
@@ -210,24 +210,24 @@ export function ClientChatRealtime({
   }
 
   return (
-    <Card className="flex flex-col h-full bg-gradient-to-b from-white to-gray-50/50 dark:from-gray-900 dark:to-gray-900">
+    <Card className="flex flex-col h-full  ">
       {/* Header */}
-      <div className="border-b dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3">
+      <div className="border-b bg-surface-1 px-4 py-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="relative">
-              <div className="h-10 w-10 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center shadow-lg">
-                <Headphones className="h-5 w-5 text-white" />
+              <div className="h-10 w-10 rounded-lg bg-surface-3 flex items-center justify-center shadow-lg">
+                <Headphones className="h-5 w-5 text-ink-on-dark" />
               </div>
               <div
                 className={cn(
-                  'absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-white',
-                  isConnected ? 'bg-green-500' : 'bg-red-500',
+                  'absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-paper',
+                  isConnected ? 'bg-forest' : 'bg-vermillion',
                 )}
               />
             </div>
             <div>
-              <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+              <h3 className="text-base font-semibold text-ink ">
                 Realtime Voice Chat
               </h3>
               <div className="flex items-center gap-2 mt-0.5">
@@ -254,7 +254,7 @@ export function ClientChatRealtime({
 
           <div className="flex items-center gap-2">
             {/* Mode Toggle */}
-            <div className="flex bg-gray-100 dark:bg-gray-800 rounded-lg p-0.5">
+            <div className="flex bg-surface-3 rounded-lg p-0.5">
               <Button
                 size="sm"
                 variant={mode === 'voice' ? 'default' : 'ghost'}
@@ -294,13 +294,13 @@ export function ClientChatRealtime({
         {messages.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full py-8">
             <div className="text-center max-w-md">
-              <div className="h-16 w-16 rounded-full bg-gradient-to-br from-violet-100 to-purple-100 mx-auto mb-4 flex items-center justify-center">
-                <Bot className="h-8 w-8 text-violet-600" />
+              <div className="h-16 w-16 rounded-full  mx-auto mb-4 flex items-center justify-center">
+                <Bot className="h-8 w-8 text-indigo" />
               </div>
-              <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              <h4 className="text-lg font-semibold text-ink mb-2">
                 Ready for conversation
               </h4>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              <p className="text-sm text-ink-3 mb-4">
                 {mode === 'voice'
                   ? `Hold the record button and speak naturally about ${
                       clientName || 'your client'
@@ -310,7 +310,7 @@ export function ClientChatRealtime({
               {stats.suggested_questions &&
                 stats.suggested_questions.length > 0 && (
                   <div className="space-y-2 mt-6">
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Try asking
                     </p>
                     {stats.suggested_questions.slice(0, 2).map((q, idx) => (
@@ -321,7 +321,7 @@ export function ClientChatRealtime({
                         onClick={() => (mode === 'text' ? setInput(q) : null)}
                         className="text-xs text-left justify-start h-auto py-2 px-3 w-full"
                       >
-                        <Sparkles className="h-3 w-3 mr-2 flex-shrink-0 text-violet-500" />
+                        <Sparkles className="h-3 w-3 mr-2 flex-shrink-0 text-indigo" />
                         <span className="line-clamp-2">{q}</span>
                       </Button>
                     ))}
@@ -341,8 +341,8 @@ export function ClientChatRealtime({
               >
                 {message.role === 'assistant' && (
                   <div className="flex-shrink-0">
-                    <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center shadow-sm">
-                      <Bot className="h-4 w-4 text-white" />
+                    <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                      <Bot className="h-4 w-4 text-ink-on-dark" />
                     </div>
                   </div>
                 )}
@@ -357,17 +357,15 @@ export function ClientChatRealtime({
                     className={cn(
                       'rounded-xl px-4 py-2.5 shadow-sm',
                       message.role === 'user'
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                        : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700',
+                        ? 'bg-ink text-ink-on-dark '
+                        : 'bg-surface-1 border border-line ',
                     )}
                   >
                     {message.isVoice && (
                       <div
                         className={cn(
                           'flex items-center gap-1.5 mb-1.5 text-xs',
-                          message.role === 'user'
-                            ? 'text-gray-400'
-                            : 'text-gray-500',
+                          message.role === 'user' ? 'text-ink-4' : 'text-ink-3',
                         )}
                       >
                         <Volume2 className="h-3 w-3" />
@@ -388,7 +386,7 @@ export function ClientChatRealtime({
                     message.sources.length > 0 && (
                       <button
                         onClick={() => toggleSources(message.id)}
-                        className="inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+                        className="inline-flex items-center gap-1.5 text-xs text-ink-3 hover:text-ink-2 "
                       >
                         <BookOpen className="h-3 w-3" />
                         {showSources[message.id] ? 'Hide' : 'Show'} sources
@@ -406,13 +404,11 @@ export function ClientChatRealtime({
                       {message.sources.map((source: any, idx: number) => (
                         <div
                           key={idx}
-                          className="bg-gray-50 dark:bg-gray-800 rounded-lg p-2.5 text-xs"
+                          className="bg-paper rounded-lg p-2.5 text-xs"
                         >
                           <div className="flex justify-between mb-1">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              {source.date}
-                            </span>
-                            <span className="text-gray-500 dark:text-gray-400">
+                            <span className="text-ink-3 ">{source.date}</span>
+                            <span className="text-ink-3 ">
                               {(source.relevance * 100).toFixed(0)}% match
                             </span>
                           </div>
@@ -437,8 +433,8 @@ export function ClientChatRealtime({
 
                 {message.role === 'user' && (
                   <div className="flex-shrink-0">
-                    <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-700 to-gray-900 flex items-center justify-center shadow-sm">
-                      <User className="h-4 w-4 text-white" />
+                    <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                      <User className="h-4 w-4 text-ink-on-dark" />
                     </div>
                   </div>
                 )}
@@ -449,8 +445,8 @@ export function ClientChatRealtime({
             {isRecording && (
               <div className="flex gap-3 justify-start">
                 <div className="h-8 w-8" />
-                <div className="bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg px-3 py-2 flex items-center gap-2">
-                  <div className="h-2 w-2 rounded-full bg-red-500 animate-pulse" />
+                <div className="bg-vermillion-bg text-vermillion rounded-lg px-3 py-2 flex items-center gap-2">
+                  <div className="h-2 w-2 rounded-full bg-vermillion animate-pulse" />
                   <span className="text-sm">Listening...</span>
                   {interimTranscript && (
                     <span className="text-sm italic ml-2">
@@ -464,7 +460,7 @@ export function ClientChatRealtime({
             {isSpeaking && (
               <div className="flex gap-3 justify-start">
                 <div className="h-8 w-8" />
-                <div className="bg-violet-50 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 rounded-lg px-3 py-2 flex items-center gap-2">
+                <div className="bg-indigo-bg text-indigo rounded-lg px-3 py-2 flex items-center gap-2">
                   <Volume2 className="h-4 w-4 animate-pulse" />
                   <span className="text-sm">Speaking...</span>
                 </div>
@@ -477,7 +473,7 @@ export function ClientChatRealtime({
       </ScrollArea>
 
       {/* Input Area */}
-      <div className="border-t dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
+      <div className="border-t bg-surface-1 p-4">
         {mode === 'voice' ? (
           <div className="flex flex-col items-center gap-3">
             <TooltipProvider>
@@ -550,7 +546,7 @@ export function ClientChatRealtime({
               </div>
             </TooltipProvider>
 
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-ink-3 ">
               Hold the button and speak naturally
             </p>
           </div>
@@ -562,7 +558,7 @@ export function ClientChatRealtime({
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={`Ask about ${clientName || 'this client'}...`}
-              className="w-full min-h-[44px] max-h-[120px] pl-4 pr-12 py-3 text-sm border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent bg-white dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              className="w-full min-h-[44px] max-h-[120px] pl-4 pr-12 py-3 text-sm border border-line rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-indigo focus:border-transparent bg-surface-1 "
               disabled={!isConnected}
               rows={1}
             />

--- a/src/app/clients/[clientId]/components/client-chat-unified.tsx
+++ b/src/app/clients/[clientId]/components/client-chat-unified.tsx
@@ -291,7 +291,7 @@ export function ClientChatUnified({
     return (
       <div className="flex flex-col h-full">
         <div className="flex items-center justify-center flex-1">
-          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
         </div>
       </div>
     )
@@ -304,17 +304,17 @@ export function ClientChatUnified({
       <div className="flex flex-col h-full p-4">
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center max-w-sm">
-            <MessageSquare className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+            <MessageSquare className="h-10 w-10 text-ink-2 mx-auto mb-3" />
+            <h3 className="text-sm font-medium text-ink mb-1">
               Knowledge Base Not Available
             </h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            <p className="text-xs text-ink-3 mb-3">
               {hasSessionData
                 ? 'The knowledge base is currently being indexed. Please try again in a few moments.'
                 : 'The AI assistant will be available after analyzing coaching sessions.'}
             </p>
             {!hasSessionData && (
-              <p className="text-xs text-gray-400 dark:text-gray-500">
+              <p className="text-xs text-ink-4 ">
                 Upload or record coaching sessions to enable AI-powered
                 insights.
               </p>
@@ -335,21 +335,21 @@ export function ClientChatUnified({
   }
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+    <div className="flex flex-col h-full bg-surface-1 rounded-xl shadow-sm border border-line overflow-hidden">
       {/* Header */}
-      <div className="bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 border-b border-gray-200 dark:border-gray-700">
+      <div className=" border-b border-line ">
         <div className="px-5 py-4">
           {/* Title Row */}
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-white dark:bg-gray-800 shadow-sm flex items-center justify-center border border-gray-200 dark:border-gray-700">
-                <MessageSquare className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+              <div className="h-10 w-10 rounded-lg bg-surface-1 shadow-sm flex items-center justify-center border border-line ">
+                <MessageSquare className="h-5 w-5 text-ink-2 " />
               </div>
               <div>
-                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                <h3 className="text-base font-semibold text-ink ">
                   {clientName ? `Chat with ${clientName}'s AI` : 'AI Assistant'}
                 </h3>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                <p className="text-xs text-ink-3 mt-0.5">
                   Powered by your coaching session insights
                 </p>
               </div>
@@ -365,7 +365,7 @@ export function ClientChatUnified({
                       size="sm"
                       variant="outline"
                       onClick={() => setShowRealtimeModal(true)}
-                      className="h-9 px-3 bg-violet-50 hover:bg-violet-100 border-violet-200 text-violet-700"
+                      className="h-9 px-3 bg-indigo-bg hover:bg-indigo-bg border-indigo text-indigo"
                     >
                       <Headphones className="h-3.5 w-3.5 mr-1.5" />
                       <span className="text-sm font-medium">Voice Chat</span>
@@ -387,30 +387,30 @@ export function ClientChatUnified({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="h-9 px-3 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 border-gray-200 dark:border-gray-700 shadow-sm"
+                      className="h-9 px-3 bg-surface-1 hover:bg-paper border-line shadow-sm"
                     >
                       {selectedProvider === 'openai' && (
-                        <Brain className="h-3.5 w-3.5 mr-1.5 text-gray-600 dark:text-gray-400" />
+                        <Brain className="h-3.5 w-3.5 mr-1.5 text-ink-3 " />
                       )}
                       {selectedProvider === 'gemini' && (
-                        <Sparkles className="h-3.5 w-3.5 mr-1.5 text-gray-600 dark:text-gray-400" />
+                        <Sparkles className="h-3.5 w-3.5 mr-1.5 text-ink-3 " />
                       )}
                       {selectedProvider === 'claude' && (
-                        <Zap className="h-3.5 w-3.5 mr-1.5 text-gray-600 dark:text-gray-400" />
+                        <Zap className="h-3.5 w-3.5 mr-1.5 text-ink-3 " />
                       )}
-                      <span className="text-sm font-medium capitalize text-gray-700 dark:text-gray-300">
+                      <span className="text-sm font-medium capitalize text-ink-2 ">
                         {selectedProvider}
                       </span>
-                      <ChevronDown className="h-3 w-3 ml-1.5 text-gray-400 dark:text-gray-500" />
+                      <ChevronDown className="h-3 w-3 ml-1.5 text-ink-4 " />
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-80 p-4" align="end">
                     <div className="space-y-3">
                       <div>
-                        <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
+                        <h4 className="text-sm font-semibold text-ink ">
                           AI Model
                         </h4>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <p className="text-xs text-ink-3 mt-1">
                           Choose which AI model to power your conversations
                         </p>
                       </div>
@@ -432,7 +432,7 @@ export function ClientChatUnified({
                 size="sm"
                 variant="ghost"
                 onClick={handleClearChat}
-                className="h-9 w-9 p-0 rounded-lg text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="h-9 w-9 p-0 rounded-lg text-ink-3 hover:text-ink hover:bg-surface-3 "
                 title="Clear chat"
               >
                 <RotateCw className="h-3.5 w-3.5" />
@@ -443,15 +443,15 @@ export function ClientChatUnified({
           {/* Stats Bar */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-800 rounded-full border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div className="h-1.5 w-1.5 rounded-full bg-green-500"></div>
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-1 rounded-full border border-line shadow-sm">
+                <div className="h-1.5 w-1.5 rounded-full bg-forest"></div>
+                <span className="text-xs font-medium text-ink-2 ">
                   {stats.unique_sessions} sessions
                 </span>
               </div>
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-800 rounded-full border border-gray-200 dark:border-gray-700 shadow-sm">
-                <Database className="h-3 w-3 text-gray-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-1 rounded-full border border-line shadow-sm">
+                <Database className="h-3 w-3 text-ink-3" />
+                <span className="text-xs font-medium text-ink-2 ">
                   {stats.total_chunks} insights
                 </span>
               </div>
@@ -461,18 +461,18 @@ export function ClientChatUnified({
       </div>
 
       {/* Messages Area */}
-      <ScrollArea className="flex-1 bg-gray-50/50 dark:bg-gray-900/50">
+      <ScrollArea className="flex-1 bg-paper/50 ">
         <div className="p-5 space-y-4">
           {messages.length === 0 ? (
             <div>
               <div className="text-center py-8">
-                <div className="h-14 w-14 rounded-full bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 mx-auto mb-4 flex items-center justify-center shadow-sm">
-                  <Bot className="h-7 w-7 text-gray-600 dark:text-gray-400" />
+                <div className="h-14 w-14 rounded-full  mx-auto mb-4 flex items-center justify-center shadow-sm">
+                  <Bot className="h-7 w-7 text-ink-3 " />
                 </div>
-                <p className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+                <p className="text-sm font-medium text-ink mb-1">
                   Ready to assist you
                 </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-3 ">
                   Ask me anything about {clientName || 'your client'}
                 </p>
               </div>
@@ -480,20 +480,20 @@ export function ClientChatUnified({
               {/* Suggested Questions */}
               {suggestedQuestions.length > 0 && (
                 <div className="space-y-2">
-                  <p className="text-xs text-gray-500 uppercase tracking-wider text-center">
+                  <p className="text-xs text-ink-3 uppercase tracking-wider text-center">
                     Suggested Questions
                   </p>
                   {suggestedQuestions.slice(0, 3).map((question, idx) => (
                     <button
                       key={idx}
                       onClick={() => handleSuggestedQuestion(question)}
-                      className="w-full text-left p-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all group"
+                      className="w-full text-left p-3 rounded-lg bg-surface-1 border border-line hover:border-line-strong hover:shadow-sm transition-all group"
                     >
                       <div className="flex items-start gap-2.5">
-                        <div className="h-6 w-6 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0 group-hover:bg-gray-200 dark:group-hover:bg-gray-600 transition-colors">
-                          <Sparkles className="h-3 w-3 text-gray-600 dark:text-gray-400" />
+                        <div className="h-6 w-6 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 group-hover:bg-surface-3 transition-colors">
+                          <Sparkles className="h-3 w-3 text-ink-3 " />
                         </div>
-                        <span className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed font-medium">
+                        <span className="text-xs text-ink-2 leading-relaxed font-medium">
                           {question}
                         </span>
                       </div>
@@ -517,8 +517,8 @@ export function ClientChatUnified({
                   >
                     {isAssistant && (
                       <div className="flex-shrink-0">
-                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center shadow-sm">
-                          <Bot className="h-4 w-4 text-gray-700" />
+                        <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                          <Bot className="h-4 w-4 text-ink-2" />
                         </div>
                       </div>
                     )}
@@ -533,15 +533,15 @@ export function ClientChatUnified({
                         className={cn(
                           'rounded-lg px-3.5 py-2.5 shadow-sm',
                           isAssistant
-                            ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700'
-                            : 'bg-gray-900 dark:bg-gray-700 text-white border border-gray-800 dark:border-gray-600',
+                            ? 'bg-surface-1 text-ink border border-line '
+                            : 'bg-ink text-ink-on-dark border border-line ',
                         )}
                       >
                         {message.isVoice && (
                           <div
                             className={cn(
                               'flex items-center gap-1.5 mb-1.5 text-xs',
-                              isAssistant ? 'text-gray-500' : 'text-gray-400',
+                              isAssistant ? 'text-ink-3' : 'text-ink-4',
                             )}
                           >
                             <Volume2 className="h-3 w-3" />
@@ -565,7 +565,7 @@ export function ClientChatUnified({
                           <div className="space-y-1">
                             <button
                               onClick={() => toggleSources(idx)}
-                              className="inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-2 py-1 rounded transition-colors"
+                              className="inline-flex items-center gap-1.5 text-xs text-ink-3 hover:text-ink-2 bg-surface-3 hover:bg-surface-3 px-2 py-1 rounded transition-colors"
                             >
                               <BookOpen className="h-3 w-3" />
                               <span>
@@ -587,15 +587,15 @@ export function ClientChatUnified({
                                   (source: any, sourceIdx: number) => (
                                     <div
                                       key={sourceIdx}
-                                      className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-2.5"
+                                      className="bg-surface-1 rounded-lg border border-line p-2.5"
                                     >
                                       <div className="flex items-start justify-between mb-1">
-                                        <span className="text-xs text-gray-600 dark:text-gray-400">
+                                        <span className="text-xs text-ink-3 ">
                                           {formatDate(
                                             source.date || source.timestamp,
                                           )}
                                         </span>
-                                        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                                        <span className="text-xs font-medium text-ink-3 ">
                                           {(
                                             source.relevance_score * 100
                                           ).toFixed(0)}
@@ -603,7 +603,7 @@ export function ClientChatUnified({
                                         </span>
                                       </div>
                                       {source.content && (
-                                        <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed line-clamp-3">
+                                        <p className="text-xs text-ink-2 leading-relaxed line-clamp-3">
                                           {source.content}
                                         </p>
                                       )}
@@ -618,8 +618,8 @@ export function ClientChatUnified({
 
                     {!isAssistant && (
                       <div className="flex-shrink-0">
-                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-800 to-gray-900 flex items-center justify-center shadow-sm">
-                          <User className="h-4 w-4 text-white" />
+                        <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                          <User className="h-4 w-4 text-ink-on-dark" />
                         </div>
                       </div>
                     )}
@@ -630,14 +630,12 @@ export function ClientChatUnified({
               {/* Loading state */}
               {isLoading && (
                 <div className="flex gap-2 justify-start">
-                  <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center shadow-sm">
-                    <Bot className="h-4 w-4 text-gray-700" />
+                  <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                    <Bot className="h-4 w-4 text-ink-2" />
                   </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg px-4 py-3 border border-gray-200 dark:border-gray-700 shadow-sm flex items-center gap-2">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-600 dark:text-gray-400" />
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      Thinking...
-                    </span>
+                  <div className="bg-surface-1 rounded-lg px-4 py-3 border border-line shadow-sm flex items-center gap-2">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-ink-3 " />
+                    <span className="text-xs text-ink-3 ">Thinking...</span>
                   </div>
                 </div>
               )}
@@ -645,8 +643,8 @@ export function ClientChatUnified({
               {/* Voice status indicators */}
               {isListening && (
                 <div className="flex gap-2 justify-end">
-                  <div className="bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg px-3 py-2 flex items-center gap-2">
-                    <div className="h-2 w-2 rounded-full bg-red-500 animate-pulse" />
+                  <div className="bg-vermillion-bg text-vermillion rounded-lg px-3 py-2 flex items-center gap-2">
+                    <div className="h-2 w-2 rounded-full bg-vermillion animate-pulse" />
                     <span className="text-sm">Listening...</span>
                     {interimTranscript && (
                       <span className="text-sm italic ml-2">
@@ -660,7 +658,7 @@ export function ClientChatUnified({
               {isSpeaking && (
                 <div className="flex gap-2 justify-start">
                   <div className="h-8 w-8" />
-                  <div className="bg-violet-50 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 rounded-lg px-3 py-2 flex items-center gap-2">
+                  <div className="bg-indigo-bg text-indigo rounded-lg px-3 py-2 flex items-center gap-2">
                     <Volume2 className="h-4 w-4 animate-pulse" />
                     <span className="text-sm">Speaking...</span>
                   </div>
@@ -674,7 +672,7 @@ export function ClientChatUnified({
       </ScrollArea>
 
       {/* Input Area */}
-      <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <div className="border-t border-line p-4  ">
         <div className="flex gap-2">
           {/* Voice/Text Toggle */}
           <TooltipProvider>
@@ -687,8 +685,8 @@ export function ClientChatUnified({
                   className={cn(
                     'h-10 w-10 p-0 rounded-lg transition-all flex-shrink-0',
                     inputMode === 'voice'
-                      ? 'bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900'
-                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800',
+                      ? 'bg-ink hover:bg-ink-2 text-ink-on-dark '
+                      : 'text-ink-3 hover:text-ink hover:bg-surface-3 ',
                   )}
                   disabled={isListening}
                 >
@@ -718,7 +716,7 @@ export function ClientChatUnified({
                 onChange={e => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={`Ask about ${clientName || 'this client'}...`}
-                className="w-full min-h-[40px] max-h-[120px] pl-4 pr-12 py-2.5 text-sm border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-gray-400 dark:focus:ring-gray-600 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-gray-500 bg-white dark:bg-gray-800 dark:text-white shadow-sm"
+                className="w-full min-h-[40px] max-h-[120px] pl-4 pr-12 py-2.5 text-sm border border-line rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-line-strong focus:border-transparent placeholder:text-ink-4 bg-surface-1 shadow-sm"
                 disabled={isLoading}
                 rows={1}
               />
@@ -726,7 +724,7 @@ export function ClientChatUnified({
                 onClick={() => handleSend()}
                 disabled={!input.trim() || isLoading}
                 size="sm"
-                className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 h-7 w-7 p-0 rounded-lg shadow-sm transition-all disabled:opacity-50"
+                className="absolute right-2 top-1/2 -translate-y-1/2 bg-ink hover:bg-ink-2 text-ink-on-dark h-7 w-7 p-0 rounded-lg shadow-sm transition-all disabled:opacity-50"
               >
                 {isLoading ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -771,7 +769,7 @@ export function ClientChatUnified({
                 </Button>
               )}
 
-              <span className="text-xs text-gray-500 dark:text-gray-400">
+              <span className="text-xs text-ink-3 ">
                 {isListening ? 'Release to send' : 'Hold to speak'}
               </span>
             </div>
@@ -780,13 +778,13 @@ export function ClientChatUnified({
 
         {/* Status Bar */}
         <div className="flex items-center justify-between mt-2">
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-ink-3 ">
             {inputMode === 'voice'
               ? 'Classic Voice • Text-to-speech enabled'
               : 'Enter to send • Shift+Enter for new line'}
           </p>
           {messages.length > 0 && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">
+            <span className="text-xs text-ink-4 ">
               {messages.length} messages
             </span>
           )}

--- a/src/app/clients/[clientId]/components/client-chat-widget.tsx
+++ b/src/app/clients/[clientId]/components/client-chat-widget.tsx
@@ -197,13 +197,13 @@ export function ClientChatWidget({
   const getConfidenceColor = (confidence?: string) => {
     switch (confidence) {
       case 'high':
-        return 'text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+        return 'text-ink-2 bg-paper border-line '
       case 'medium':
-        return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+        return 'text-ink-3 bg-paper border-line '
       case 'low':
-        return 'text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+        return 'text-ink-3 bg-paper border-line '
       default:
-        return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+        return 'text-ink-3 bg-paper border-line '
     }
   }
 
@@ -263,7 +263,7 @@ export function ClientChatWidget({
     return (
       <div className="flex flex-col h-full">
         <div className="flex items-center justify-center flex-1">
-          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
         </div>
       </div>
     )
@@ -274,11 +274,11 @@ export function ClientChatWidget({
       <div className="flex flex-col h-full p-4">
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center max-w-sm">
-            <MessageSquare className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+            <MessageSquare className="h-10 w-10 text-ink-2 mx-auto mb-3" />
+            <h3 className="text-sm font-medium text-ink mb-1">
               No Knowledge Base Yet
             </h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-ink-3 ">
               The AI assistant will be available after analyzing coaching
               sessions.
             </p>
@@ -289,21 +289,21 @@ export function ClientChatWidget({
   }
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+    <div className="flex flex-col h-full bg-surface-1 rounded-xl shadow-sm border border-line overflow-hidden">
       {/* Modern Header */}
-      <div className="bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 border-b border-gray-200 dark:border-gray-700">
+      <div className=" border-b border-line ">
         <div className="px-5 py-4">
           {/* Title Row */}
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-white dark:bg-gray-800 shadow-sm flex items-center justify-center border border-gray-200 dark:border-gray-700">
-                <MessageSquare className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+              <div className="h-10 w-10 rounded-lg bg-surface-1 shadow-sm flex items-center justify-center border border-line ">
+                <MessageSquare className="h-5 w-5 text-ink-2 " />
               </div>
               <div>
-                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                <h3 className="text-base font-semibold text-ink ">
                   {clientName ? `Chat with ${clientName}'s AI` : 'AI Assistant'}
                 </h3>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                <p className="text-xs text-ink-3 mt-0.5">
                   Powered by your coaching session insights
                 </p>
               </div>
@@ -318,30 +318,30 @@ export function ClientChatWidget({
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-9 px-3 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 border-gray-200 dark:border-gray-700 shadow-sm"
+                  className="h-9 px-3 bg-surface-1 hover:bg-paper border-line shadow-sm"
                 >
                   {selectedProvider === 'openai' && (
-                    <Brain className="h-3.5 w-3.5 mr-1.5 text-gray-600 dark:text-gray-400" />
+                    <Brain className="h-3.5 w-3.5 mr-1.5 text-ink-3 " />
                   )}
                   {selectedProvider === 'gemini' && (
-                    <Sparkles className="h-3.5 w-3.5 mr-1.5 text-gray-600 dark:text-gray-400" />
+                    <Sparkles className="h-3.5 w-3.5 mr-1.5 text-ink-3 " />
                   )}
                   {selectedProvider === 'claude' && (
-                    <Zap className="h-3.5 w-3.5 mr-1.5 text-gray-600 dark:text-gray-400" />
+                    <Zap className="h-3.5 w-3.5 mr-1.5 text-ink-3 " />
                   )}
-                  <span className="text-sm font-medium capitalize text-gray-700 dark:text-gray-300">
+                  <span className="text-sm font-medium capitalize text-ink-2 ">
                     {selectedProvider}
                   </span>
-                  <ChevronDown className="h-3 w-3 ml-1.5 text-gray-400 dark:text-gray-500" />
+                  <ChevronDown className="h-3 w-3 ml-1.5 text-ink-4 " />
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-80 p-4" align="end">
                 <div className="space-y-3">
                   <div>
-                    <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
+                    <h4 className="text-sm font-semibold text-ink ">
                       AI Model
                     </h4>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    <p className="text-xs text-ink-3 mt-1">
                       Choose which AI model to power your conversations
                     </p>
                   </div>
@@ -361,15 +361,15 @@ export function ClientChatWidget({
           {/* Stats Bar - Modern Pills */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-800 rounded-full border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div className="h-1.5 w-1.5 rounded-full bg-green-500"></div>
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-1 rounded-full border border-line shadow-sm">
+                <div className="h-1.5 w-1.5 rounded-full bg-forest"></div>
+                <span className="text-xs font-medium text-ink-2 ">
                   {stats.unique_sessions} sessions
                 </span>
               </div>
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-800 rounded-full border border-gray-200 dark:border-gray-700 shadow-sm">
-                <Database className="h-3 w-3 text-gray-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-1 rounded-full border border-line shadow-sm">
+                <Database className="h-3 w-3 text-ink-3" />
+                <span className="text-xs font-medium text-ink-2 ">
                   {stats.total_chunks} insights
                 </span>
               </div>
@@ -379,7 +379,7 @@ export function ClientChatWidget({
                     <Badge
                       key={idx}
                       variant="secondary"
-                      className="text-xs bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-0 font-normal"
+                      className="text-xs bg-surface-3 text-ink-3 border-0 font-normal"
                     >
                       {topic.topic}
                     </Badge>
@@ -398,8 +398,8 @@ export function ClientChatWidget({
                   className={cn(
                     'h-8 px-2.5 rounded-lg transition-all',
                     voiceEnabled
-                      ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100'
-                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800',
+                      ? 'bg-ink text-ink-on-dark hover:bg-ink-2 '
+                      : 'text-ink-3 hover:text-ink hover:bg-surface-3 ',
                   )}
                 >
                   <Mic className="h-3.5 w-3.5 mr-1.5" />
@@ -412,7 +412,7 @@ export function ClientChatWidget({
                 size="sm"
                 variant="ghost"
                 onClick={() => setMessages([])}
-                className="h-8 w-8 p-0 rounded-lg text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="h-8 w-8 p-0 rounded-lg text-ink-3 hover:text-ink hover:bg-surface-3 "
                 title="Clear chat"
               >
                 <RotateCw className="h-3.5 w-3.5" />
@@ -423,18 +423,18 @@ export function ClientChatWidget({
       </div>
 
       {/* Messages Area - Clean Background */}
-      <ScrollArea className="flex-1 bg-gray-50/50 dark:bg-gray-900/50">
+      <ScrollArea className="flex-1 bg-paper/50 ">
         <div className="p-5 space-y-4">
           {messages.length === 0 ? (
             <div>
               <div className="text-center py-8">
-                <div className="h-14 w-14 rounded-full bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 mx-auto mb-4 flex items-center justify-center shadow-sm">
-                  <Bot className="h-7 w-7 text-gray-600 dark:text-gray-400" />
+                <div className="h-14 w-14 rounded-full  mx-auto mb-4 flex items-center justify-center shadow-sm">
+                  <Bot className="h-7 w-7 text-ink-3 " />
                 </div>
-                <p className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+                <p className="text-sm font-medium text-ink mb-1">
                   Ready to assist you
                 </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-3 ">
                   Ask me anything about {clientName || 'your client'}
                 </p>
               </div>
@@ -442,20 +442,20 @@ export function ClientChatWidget({
               {/* Suggested Questions */}
               {suggestedQuestions.length > 0 && (
                 <div className="space-y-2">
-                  <p className="text-xs text-gray-500 uppercase tracking-wider text-center">
+                  <p className="text-xs text-ink-3 uppercase tracking-wider text-center">
                     Suggested Questions
                   </p>
                   {suggestedQuestions.slice(0, 3).map((question, idx) => (
                     <button
                       key={idx}
                       onClick={() => handleSuggestedQuestion(question)}
-                      className="w-full text-left p-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all group"
+                      className="w-full text-left p-3 rounded-lg bg-surface-1 border border-line hover:border-line-strong hover:shadow-sm transition-all group"
                     >
                       <div className="flex items-start gap-2.5">
-                        <div className="h-6 w-6 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0 group-hover:bg-gray-200 dark:group-hover:bg-gray-600 transition-colors">
-                          <Sparkles className="h-3 w-3 text-gray-600 dark:text-gray-400" />
+                        <div className="h-6 w-6 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 group-hover:bg-surface-3 transition-colors">
+                          <Sparkles className="h-3 w-3 text-ink-3 " />
                         </div>
-                        <span className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed font-medium">
+                        <span className="text-xs text-ink-2 leading-relaxed font-medium">
                           {question}
                         </span>
                       </div>
@@ -480,8 +480,8 @@ export function ClientChatWidget({
                   >
                     {isAssistant && (
                       <div className="flex-shrink-0">
-                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center shadow-sm">
-                          <Bot className="h-4 w-4 text-gray-700" />
+                        <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                          <Bot className="h-4 w-4 text-ink-2" />
                         </div>
                       </div>
                     )}
@@ -496,8 +496,8 @@ export function ClientChatWidget({
                         className={cn(
                           'rounded-lg px-3.5 py-2.5 shadow-sm',
                           isAssistant
-                            ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700'
-                            : 'bg-gray-900 dark:bg-gray-700 text-white border border-gray-800 dark:border-gray-600',
+                            ? 'bg-surface-1 text-ink border border-line '
+                            : 'bg-ink text-ink-on-dark border border-line ',
                         )}
                       >
                         {isAssistant ? (
@@ -516,7 +516,7 @@ export function ClientChatWidget({
                           <div className="space-y-1">
                             <button
                               onClick={() => toggleSources(idx)}
-                              className="inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-2 py-1 rounded transition-colors"
+                              className="inline-flex items-center gap-1.5 text-xs text-ink-3 hover:text-ink-2 bg-surface-3 hover:bg-surface-3 px-2 py-1 rounded transition-colors"
                             >
                               <BookOpen className="h-3 w-3" />
                               <span>
@@ -538,15 +538,15 @@ export function ClientChatWidget({
                                   (source: any, sourceIdx: number) => (
                                     <div
                                       key={sourceIdx}
-                                      className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-2.5"
+                                      className="bg-surface-1 rounded-lg border border-line p-2.5"
                                     >
                                       <div className="flex items-start justify-between mb-1">
-                                        <span className="text-xs text-gray-600 dark:text-gray-400">
+                                        <span className="text-xs text-ink-3 ">
                                           {formatDate(
                                             source.date || source.timestamp,
                                           )}
                                         </span>
-                                        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                                        <span className="text-xs font-medium text-ink-3 ">
                                           {(
                                             source.relevance_score * 100
                                           ).toFixed(0)}
@@ -554,7 +554,7 @@ export function ClientChatWidget({
                                         </span>
                                       </div>
                                       {source.content && (
-                                        <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed line-clamp-3">
+                                        <p className="text-xs text-ink-2 leading-relaxed line-clamp-3">
                                           {source.content}
                                         </p>
                                       )}
@@ -585,7 +585,7 @@ export function ClientChatWidget({
                                 {messageData.provider && (
                                   <Badge
                                     variant="outline"
-                                    className="text-xs capitalize bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 py-0"
+                                    className="text-xs capitalize bg-surface-1 border-line text-ink-3 py-0"
                                   >
                                     {messageData.provider}
                                   </Badge>
@@ -598,8 +598,8 @@ export function ClientChatWidget({
 
                     {!isAssistant && (
                       <div className="flex-shrink-0">
-                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-800 to-gray-900 flex items-center justify-center shadow-sm">
-                          <User className="h-4 w-4 text-white" />
+                        <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                          <User className="h-4 w-4 text-ink-on-dark" />
                         </div>
                       </div>
                     )}
@@ -609,14 +609,12 @@ export function ClientChatWidget({
 
               {isLoading && (
                 <div className="flex gap-2 justify-start">
-                  <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center shadow-sm">
-                    <Bot className="h-4 w-4 text-gray-700" />
+                  <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                    <Bot className="h-4 w-4 text-ink-2" />
                   </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg px-4 py-3 border border-gray-200 dark:border-gray-700 shadow-sm flex items-center gap-2">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-600 dark:text-gray-400" />
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      Thinking...
-                    </span>
+                  <div className="bg-surface-1 rounded-lg px-4 py-3 border border-line shadow-sm flex items-center gap-2">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-ink-3 " />
+                    <span className="text-xs text-ink-3 ">Thinking...</span>
                   </div>
                 </div>
               )}
@@ -628,7 +626,7 @@ export function ClientChatWidget({
       </ScrollArea>
 
       {/* Input Area - Modern Style */}
-      <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <div className="border-t border-line p-4  ">
         {/* Voice Controls */}
         {voiceEnabled && (
           <div className="mb-2 flex items-center gap-2">
@@ -638,13 +636,13 @@ export function ClientChatWidget({
               className={cn(
                 'gap-2',
                 isListening
-                  ? 'bg-red-500 hover:bg-red-600 text-white'
-                  : 'bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900',
+                  ? 'bg-vermillion hover:bg-vermillion text-ink-on-dark'
+                  : 'bg-ink hover:bg-ink-2 text-ink-on-dark ',
               )}
             >
               {isListening ? (
                 <>
-                  <div className="h-3 w-3 rounded-full bg-white animate-pulse" />
+                  <div className="h-3 w-3 rounded-full bg-surface-1 animate-pulse" />
                   Stop Recording
                 </>
               ) : (
@@ -659,21 +657,21 @@ export function ClientChatWidget({
               <Button
                 size="sm"
                 onClick={stopSpeaking}
-                className="gap-2 bg-orange-500 hover:bg-orange-600 text-white"
+                className="gap-2 bg-amber-token hover:bg-amber-token text-ink-on-dark"
               >
-                <div className="h-3 w-3 rounded-full bg-white animate-pulse" />
+                <div className="h-3 w-3 rounded-full bg-surface-1 animate-pulse" />
                 Stop Speaking
               </Button>
             )}
 
             {isListening && interimTranscript && (
-              <span className="text-sm text-gray-500 dark:text-gray-400 italic">
+              <span className="text-sm text-ink-3 italic">
                 {interimTranscript}
               </span>
             )}
 
             {isSpeaking && !isListening && (
-              <span className="text-sm text-orange-600 font-medium animate-pulse">
+              <span className="text-sm text-amber-token font-medium animate-pulse">
                 AI is speaking...
               </span>
             )}
@@ -691,7 +689,7 @@ export function ClientChatWidget({
                 ? `Speak or type to ask about ${clientName || 'this client'}...`
                 : `Ask about ${clientName || 'this client'}...`
             }
-            className="w-full min-h-[44px] max-h-[120px] pl-4 pr-12 py-3 text-sm border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-gray-400 dark:focus:ring-gray-600 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-gray-500 bg-white dark:bg-gray-800 dark:text-white shadow-sm"
+            className="w-full min-h-[44px] max-h-[120px] pl-4 pr-12 py-3 text-sm border border-line rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-line-strong focus:border-transparent placeholder:text-ink-4 bg-surface-1 shadow-sm"
             disabled={isLoading || isListening}
             rows={1}
           />
@@ -699,7 +697,7 @@ export function ClientChatWidget({
             onClick={() => handleSend()}
             disabled={!input.trim() || isLoading || isListening}
             size="sm"
-            className="absolute right-2 bottom-2 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 h-8 w-8 p-0 rounded-lg shadow-sm transition-all disabled:opacity-50"
+            className="absolute right-2 bottom-2 bg-ink hover:bg-ink-2 text-ink-on-dark h-8 w-8 p-0 rounded-lg shadow-sm transition-all disabled:opacity-50"
           >
             {isLoading ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -709,13 +707,13 @@ export function ClientChatWidget({
           </Button>
         </div>
         <div className="flex items-center justify-between mt-2">
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-ink-3 ">
             {voiceEnabled
               ? 'Hold Space to talk • Esc to stop AI'
               : 'Enter to send • Shift+Enter for new line'}
           </p>
           {messages.length > 0 && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">
+            <span className="text-xs text-ink-4 ">
               {messages.length} messages
             </span>
           )}

--- a/src/app/clients/[clientId]/components/client-header.tsx
+++ b/src/app/clients/[clientId]/components/client-header.tsx
@@ -37,13 +37,13 @@ export default function ClientHeader({
   onDelete,
 }: ClientHeaderProps) {
   return (
-    <div className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm">
+    <div className="border-b border-line bg-surface-1 shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <Button
           variant="ghost"
           size="sm"
           onClick={onBack}
-          className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 mb-2"
+          className="text-ink-3 hover:text-ink hover:bg-surface-3 mb-2"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back to Clients
@@ -52,22 +52,20 @@ export default function ClientHeader({
         {/* Client Profile Header */}
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-6">
-            <Avatar className="h-16 w-16 bg-gray-900 dark:bg-white border-2 border-gray-200 dark:border-gray-700 shadow-md">
-              <AvatarFallback className="bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-xl font-bold">
+            <Avatar className="h-16 w-16 bg-ink border-2 border-line shadow-md">
+              <AvatarFallback className="bg-ink text-ink-on-dark text-xl font-bold">
                 {getClientInitials(client.name)}
               </AvatarFallback>
             </Avatar>
 
             <div>
               <div className="flex items-center gap-3">
-                <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {client.name}
-                </h1>
+                <h1 className="text-2xl font-bold text-ink ">{client.name}</h1>
                 {/* Ownership indicator */}
                 {client.is_my_client === false && client.coach_name && (
                   <Badge
                     variant="outline"
-                    className="bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-400"
+                    className="bg-ds-accent-bg border-ds-accent text-ds-accent "
                   >
                     <Users className="h-3 w-3 mr-1" />
                     {client.coach_name}&apos;s Client
@@ -76,14 +74,14 @@ export default function ClientHeader({
               </div>
 
               {client.meta_performance_vision && (
-                <div className="mt-3 p-4 bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20 border-l-4 border-purple-500 rounded-r-lg">
+                <div className="mt-3 p-4  border-l-4 border-indigo rounded-r-lg">
                   <div className="flex items-start gap-2">
-                    <Sparkles className="h-4 w-4 text-purple-600 dark:text-purple-400 mt-0.5 flex-shrink-0" />
+                    <Sparkles className="h-4 w-4 text-indigo mt-0.5 flex-shrink-0" />
                     <div className="flex-1">
-                      <p className="text-xs font-semibold text-purple-900 dark:text-purple-300 uppercase tracking-wider mb-1">
+                      <p className="text-xs font-semibold text-indigo uppercase tracking-wider mb-1">
                         Meta Performance Vision
                       </p>
-                      <p className="text-sm text-gray-800 dark:text-gray-300 italic leading-relaxed">
+                      <p className="text-sm text-ink-2 italic leading-relaxed">
                         &ldquo;{client.meta_performance_vision}&rdquo;
                       </p>
                     </div>
@@ -92,29 +90,23 @@ export default function ClientHeader({
               )}
 
               {client.notes && (
-                <p className="text-sm text-gray-600 dark:text-gray-400 max-w-2xl mt-2">
+                <p className="text-sm text-ink-3 max-w-2xl mt-2">
                   {client.notes}
                 </p>
               )}
               <div className="flex items-center gap-3 mt-2">
-                <Badge
-                  variant="secondary"
-                  className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-                >
+                <Badge variant="secondary" className="bg-surface-3 text-ink-2 ">
                   <Calendar className="h-3 w-3 mr-1" />
                   Added {formatDate(client.created_at)}
                 </Badge>
-                <Badge
-                  variant="secondary"
-                  className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-                >
+                <Badge variant="secondary" className="bg-surface-3 text-ink-2 ">
                   <Activity className="h-3 w-3 mr-1" />
                   {totalSessions} Sessions
                 </Badge>
                 {avgDuration > 0 && (
                   <Badge
                     variant="secondary"
-                    className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                    className="bg-surface-3 text-ink-2 "
                   >
                     <Clock className="h-3 w-3 mr-1" />
                     {avgDuration.toFixed(0)}m avg
@@ -123,7 +115,7 @@ export default function ClientHeader({
                 {client.invitation_status === 'accepted' && (
                   <Badge
                     variant="secondary"
-                    className="bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400"
+                    className="bg-forest-bg text-forest "
                   >
                     <UserCheck className="h-3 w-3 mr-1" />
                     Portal Active
@@ -132,7 +124,7 @@ export default function ClientHeader({
                 {client.invitation_status === 'invited' && (
                   <Badge
                     variant="secondary"
-                    className="bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400"
+                    className="bg-indigo-bg text-indigo "
                   >
                     <Send className="h-3 w-3 mr-1" />
                     Invited
@@ -148,7 +140,7 @@ export default function ClientHeader({
                 <Button
                   onClick={onEdit}
                   variant="outline"
-                  className="border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+                  className="border-line-strong hover:bg-paper "
                 >
                   <Edit className="h-4 w-4 mr-2" />
                   Edit
@@ -156,7 +148,7 @@ export default function ClientHeader({
                 <Button
                   variant="outline"
                   onClick={onDelete}
-                  className="border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
+                  className="border-vermillion text-vermillion hover:bg-vermillion-bg "
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Delete
@@ -166,7 +158,7 @@ export default function ClientHeader({
             {isViewer && (
               <Badge
                 variant="outline"
-                className="bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400 px-3 py-2"
+                className="bg-ds-accent-bg border-ds-accent text-ds-accent px-3 py-2"
               >
                 <Eye className="h-3.5 w-3.5 mr-1.5" />
                 View Only Access

--- a/src/app/clients/[clientId]/components/client-persona-modern.tsx
+++ b/src/app/clients/[clientId]/components/client-persona-modern.tsx
@@ -61,7 +61,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
     return (
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {[1, 2, 3, 4, 5, 6].map(i => (
-          <Card key={i} className="border-gray-200">
+          <Card key={i} className="border-line">
             <CardHeader>
               <Skeleton className="h-6 w-32" />
             </CardHeader>
@@ -81,12 +81,12 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
     return (
       <div className="text-center py-16">
         <div className="max-w-md mx-auto">
-          <div className="p-6 bg-gray-50 rounded-2xl">
-            <Brain className="h-16 w-16 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">
+          <div className="p-6 bg-paper rounded-2xl">
+            <Brain className="h-16 w-16 text-ink-4 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold text-ink mb-2">
               Building Client Persona
             </h3>
-            <p className="text-gray-600">
+            <p className="text-ink-3">
               The AI is learning about your client. Persona insights will appear
               here after analyzing coaching sessions.
             </p>
@@ -100,16 +100,25 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
   return (
     <Tabs defaultValue="overview" className="space-y-6">
-      <TabsList className="bg-gray-100 p-1 rounded-lg">
-        <TabsTrigger value="overview" className="data-[state=active]:bg-white">
+      <TabsList className="bg-surface-3 p-1 rounded-lg">
+        <TabsTrigger
+          value="overview"
+          className="data-[state=active]:bg-surface-1"
+        >
           <Brain className="h-4 w-4 mr-2" />
           Overview
         </TabsTrigger>
-        <TabsTrigger value="history" className="data-[state=active]:bg-white">
+        <TabsTrigger
+          value="history"
+          className="data-[state=active]:bg-surface-1"
+        >
           <Clock className="h-4 w-4 mr-2" />
           Change History
         </TabsTrigger>
-        <TabsTrigger value="timeline" className="data-[state=active]:bg-white">
+        <TabsTrigger
+          value="timeline"
+          className="data-[state=active]:bg-surface-1"
+        >
           <TrendingUp className="h-4 w-4 mr-2" />
           Evolution Timeline
         </TabsTrigger>
@@ -118,24 +127,24 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
       <TabsContent value="overview" className="space-y-8">
         {/* Meta Performance Vision */}
         {client?.meta_performance_vision && (
-          <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-8 text-white">
-            <div className="absolute top-0 right-0 w-64 h-64 bg-white opacity-5 rounded-full -mr-32 -mt-32" />
-            <div className="absolute bottom-0 left-0 w-48 h-48 bg-white opacity-5 rounded-full -ml-24 -mb-24" />
+          <div className="relative overflow-hidden rounded-2xl bg-ink p-8 text-ink-on-dark">
+            <div className="absolute top-0 right-0 w-64 h-64 bg-surface-1 opacity-5 rounded-full -mr-32 -mt-32" />
+            <div className="absolute bottom-0 left-0 w-48 h-48 bg-surface-1 opacity-5 rounded-full -ml-24 -mb-24" />
 
             <div className="relative">
               <div className="flex items-center gap-3 mb-4">
-                <div className="p-3 bg-white/10 rounded-xl backdrop-blur-sm">
+                <div className="p-3 bg-surface-1/10 rounded-xl backdrop-blur-sm">
                   <Sparkles className="h-6 w-6" />
                 </div>
                 <div>
                   <h2 className="text-xl font-bold">Meta Performance Vision</h2>
-                  <p className="text-gray-300 text-sm">
+                  <p className="text-ink-2 text-sm">
                     Ultimate transformation and legacy
                   </p>
                 </div>
               </div>
 
-              <p className="text-lg leading-relaxed text-gray-100 italic">
+              <p className="text-lg leading-relaxed text-ink-2 italic">
                 &ldquo;{client.meta_performance_vision}&rdquo;
               </p>
             </div>
@@ -144,7 +153,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
         {/* Hero Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-gradient-to-br from-gray-900 to-gray-800 rounded-xl p-4 text-white">
+          <div className=" rounded-xl p-4 text-ink-on-dark">
             <div className="flex items-center justify-between mb-2">
               <Activity className="h-5 w-5 opacity-60" />
               <span className="text-2xl font-bold">
@@ -154,37 +163,37 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
             <p className="text-xs opacity-80">Sessions Analyzed</p>
           </div>
 
-          <div className="bg-white border border-gray-200 rounded-xl p-4">
+          <div className="bg-surface-1 border border-line rounded-xl p-4">
             <div className="flex items-center justify-between mb-2">
-              <Target className="h-5 w-5 text-gray-600" />
-              <span className="text-2xl font-bold text-gray-900">
+              <Target className="h-5 w-5 text-ink-3" />
+              <span className="text-2xl font-bold text-ink">
                 {confidencePercentage.toFixed(0)}%
               </span>
             </div>
             <Progress value={confidencePercentage} className="h-1.5 mb-1" />
-            <p className="text-xs text-gray-600">Confidence Score</p>
+            <p className="text-xs text-ink-3">Confidence Score</p>
           </div>
 
-          <div className="bg-white border border-gray-200 rounded-xl p-4">
+          <div className="bg-surface-1 border border-line rounded-xl p-4">
             <div className="flex items-center justify-between mb-2">
-              <TrendingUp className="h-5 w-5 text-gray-600" />
-              <span className="text-lg font-bold text-gray-900">
+              <TrendingUp className="h-5 w-5 text-ink-3" />
+              <span className="text-lg font-bold text-ink">
                 {persona.patterns.strengths.length +
                   persona.progress.achievements.length}
               </span>
             </div>
-            <p className="text-xs text-gray-600">Strengths & Wins</p>
+            <p className="text-xs text-ink-3">Strengths & Wins</p>
           </div>
 
-          <div className="bg-white border border-gray-200 rounded-xl p-4">
+          <div className="bg-surface-1 border border-line rounded-xl p-4">
             <div className="flex items-center justify-between mb-2">
-              <Flag className="h-5 w-5 text-gray-600" />
-              <span className="text-lg font-bold text-gray-900">
+              <Flag className="h-5 w-5 text-ink-3" />
+              <span className="text-lg font-bold text-ink">
                 {persona.goals.primary_goals.length +
                   persona.goals.short_term_goals.length}
               </span>
             </div>
-            <p className="text-xs text-gray-600">
+            <p className="text-xs text-ink-3">
               Active Meta Performance Outcomes
             </p>
           </div>
@@ -194,25 +203,25 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
           {/* Profile Card */}
           {(persona.demographics.occupation ||
             persona.demographics.location) && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <User className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <User className="h-4 w-4 text-ink-3" />
                   Profile
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
                 {persona.demographics.occupation && (
-                  <div className="p-3 bg-gray-50 rounded-lg">
+                  <div className="p-3 bg-paper rounded-lg">
                     <div className="flex items-start gap-3">
-                      <div className="p-2 bg-white rounded-lg shadow-sm">
-                        <Briefcase className="h-4 w-4 text-gray-600" />
+                      <div className="p-2 bg-surface-1 rounded-lg shadow-sm">
+                        <Briefcase className="h-4 w-4 text-ink-3" />
                       </div>
                       <div>
-                        <p className="text-xs text-gray-500 uppercase tracking-wider mb-0.5">
+                        <p className="text-xs text-ink-3 uppercase tracking-wider mb-0.5">
                           Role
                         </p>
-                        <p className="text-sm font-medium text-gray-900 capitalize">
+                        <p className="text-sm font-medium text-ink capitalize">
                           {persona.demographics.occupation}
                         </p>
                       </div>
@@ -220,7 +229,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   </div>
                 )}
                 {persona.demographics.location && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <div className="flex items-center gap-2 text-sm text-ink-3">
                     <MapPin className="h-3.5 w-3.5" />
                     <span>{persona.demographics.location}</span>
                   </div>
@@ -231,10 +240,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Primary Goals - Visual Cards */}
           {persona.goals.primary_goals.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-2">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-2">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Rocket className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Rocket className="h-4 w-4 text-ink-3" />
                   Primary Objectives
                 </CardTitle>
               </CardHeader>
@@ -242,12 +251,12 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   {persona.goals.primary_goals.map((goal, index) => (
                     <div key={index} className="group relative">
-                      <div className="absolute inset-0 bg-gradient-to-r from-gray-100 to-gray-50 rounded-lg transform transition-transform group-hover:scale-105" />
+                      <div className="absolute inset-0  rounded-lg transform transition-transform group-hover:scale-105" />
                       <div className="relative p-4 flex items-start gap-3">
-                        <div className="p-2 bg-gray-900 rounded-lg flex-shrink-0">
-                          <Target className="h-4 w-4 text-white" />
+                        <div className="p-2 bg-ink rounded-lg flex-shrink-0">
+                          <Target className="h-4 w-4 text-ink-on-dark" />
                         </div>
-                        <p className="text-sm font-medium text-gray-900 leading-relaxed">
+                        <p className="text-sm font-medium text-ink leading-relaxed">
                           {goal}
                         </p>
                       </div>
@@ -260,10 +269,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Personality Traits - Circular Design */}
           {persona.personality.personality_traits.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Brain className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Brain className="h-4 w-4 text-ink-3" />
                   Personality Profile
                 </CardTitle>
               </CardHeader>
@@ -276,12 +285,12 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                         className={cn(
                           'px-3 py-1.5 rounded-full text-xs font-medium',
                           index === 0
-                            ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
+                            ? 'bg-ink text-ink-on-dark '
                             : index === 1
-                              ? 'bg-gray-700 text-white'
+                              ? 'bg-ink-2 text-ink-on-dark'
                               : index === 2
-                                ? 'bg-gray-200 text-gray-800'
-                                : 'bg-gray-100 text-gray-700',
+                                ? 'bg-surface-3 text-ink-2'
+                                : 'bg-surface-3 text-ink-2',
                         )}
                       >
                         {trait}
@@ -290,10 +299,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   )}
                 </div>
                 {persona.personality.communication_style && (
-                  <div className="mt-4 p-3 bg-gray-50 rounded-lg text-center">
-                    <MessageSquare className="h-4 w-4 text-gray-500 mx-auto mb-1" />
-                    <p className="text-xs text-gray-500">Communication Style</p>
-                    <p className="text-sm font-semibold text-gray-900 capitalize">
+                  <div className="mt-4 p-3 bg-paper rounded-lg text-center">
+                    <MessageSquare className="h-4 w-4 text-ink-3 mx-auto mb-1" />
+                    <p className="text-xs text-ink-3">Communication Style</p>
+                    <p className="text-sm font-semibold text-ink capitalize">
                       {persona.personality.communication_style}
                     </p>
                   </div>
@@ -304,10 +313,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Main Challenges - Problem Cards */}
           {persona.challenges.main_challenges.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-2">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-2">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Mountain className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Mountain className="h-4 w-4 text-ink-3" />
                   Current Challenges
                 </CardTitle>
               </CardHeader>
@@ -318,14 +327,12 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                     .map((challenge, index) => (
                       <div
                         key={index}
-                        className="flex items-start gap-3 p-3 bg-gradient-to-r from-gray-50 to-white rounded-lg border border-gray-200"
+                        className="flex items-start gap-3 p-3  rounded-lg border border-line"
                       >
-                        <div className="p-1.5 bg-gray-100 rounded">
-                          <AlertCircle className="h-3.5 w-3.5 text-gray-600" />
+                        <div className="p-1.5 bg-surface-3 rounded">
+                          <AlertCircle className="h-3.5 w-3.5 text-ink-3" />
                         </div>
-                        <p className="text-sm text-gray-700 flex-1">
-                          {challenge}
-                        </p>
+                        <p className="text-sm text-ink-2 flex-1">{challenge}</p>
                       </div>
                     ))}
                 </div>
@@ -335,10 +342,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Core Values - Icon Grid */}
           {persona.personality.values.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Heart className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Heart className="h-4 w-4 text-ink-3" />
                   Core Values
                 </CardTitle>
               </CardHeader>
@@ -347,7 +354,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   {persona.personality.values.map((value, index) => (
                     <div
                       key={index}
-                      className="p-3 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-lg text-center"
+                      className="p-3 bg-ink text-ink-on-dark rounded-lg text-center"
                     >
                       <Star className="h-4 w-4 mx-auto mb-1 opacity-60" />
                       <p className="text-xs font-medium">{value}</p>
@@ -360,10 +367,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Strengths - Power Cards */}
           {persona.patterns.strengths.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-2">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-2">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Zap className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Zap className="h-4 w-4 text-ink-3" />
                   Key Strengths
                 </CardTitle>
               </CardHeader>
@@ -372,10 +379,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   {persona.patterns.strengths.map((strength, index) => (
                     <div
                       key={index}
-                      className="flex items-center gap-3 p-3 bg-gradient-to-r from-gray-50 to-white rounded-lg border border-gray-200"
+                      className="flex items-center gap-3 p-3  rounded-lg border border-line"
                     >
-                      <CheckCircle2 className="h-4 w-4 text-gray-700 flex-shrink-0" />
-                      <p className="text-sm text-gray-700">{strength}</p>
+                      <CheckCircle2 className="h-4 w-4 text-ink-2 flex-shrink-0" />
+                      <p className="text-sm text-ink-2">{strength}</p>
                     </div>
                   ))}
                 </div>
@@ -385,10 +392,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Growth Areas - Development Focus */}
           {persona.patterns.growth_areas.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <ArrowUp className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <ArrowUp className="h-4 w-4 text-ink-3" />
                   Growth Opportunities
                 </CardTitle>
               </CardHeader>
@@ -397,9 +404,9 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   {persona.patterns.growth_areas.map((area, index) => (
                     <div
                       key={index}
-                      className="p-3 border-l-2 border-gray-400 bg-gray-50 rounded-r-lg"
+                      className="p-3 border-l-2 border-line-strong bg-paper rounded-r-lg"
                     >
-                      <p className="text-sm text-gray-700">{area}</p>
+                      <p className="text-sm text-ink-2">{area}</p>
                     </div>
                   ))}
                 </div>
@@ -409,16 +416,16 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Short-term Goals - Timeline */}
           {persona.goals.short_term_goals.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Flag className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Flag className="h-4 w-4 text-ink-3" />
                   Short-term Roadmap
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="relative">
-                  <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-gray-200" />
+                  <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-surface-3" />
                   <div className="space-y-4">
                     {persona.goals.short_term_goals.map((goal, index) => (
                       <div key={index} className="flex gap-4">
@@ -426,13 +433,13 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                           <div
                             className={cn(
                               'w-8 h-8 rounded-full flex items-center justify-center',
-                              index === 0 ? 'bg-gray-900' : 'bg-gray-200',
+                              index === 0 ? 'bg-ink' : 'bg-surface-3',
                             )}
                           >
                             <span
                               className={cn(
                                 'text-xs font-bold',
-                                index === 0 ? 'text-white' : 'text-gray-600',
+                                index === 0 ? 'text-ink-on-dark' : 'text-ink-3',
                               )}
                             >
                               {index + 1}
@@ -440,7 +447,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                           </div>
                         </div>
                         <div className="flex-1 pb-2">
-                          <p className="text-sm text-gray-700">{goal}</p>
+                          <p className="text-sm text-ink-2">{goal}</p>
                         </div>
                       </div>
                     ))}
@@ -453,10 +460,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
           {/* Breakthrough Moments & Achievements */}
           {(persona.progress.achievements.length > 0 ||
             persona.progress.breakthrough_moments.length > 0) && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Trophy className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Trophy className="h-4 w-4 text-ink-3" />
                   Milestones & Breakthroughs
                 </CardTitle>
               </CardHeader>
@@ -464,17 +471,17 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {persona.progress.achievements.length > 0 && (
                     <div>
-                      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                      <h4 className="text-xs font-semibold text-ink-3 uppercase tracking-wider mb-3">
                         Achievements
                       </h4>
                       <div className="space-y-2">
                         {persona.progress.achievements.map(
                           (achievement, index) => (
                             <div key={index} className="flex items-start gap-2">
-                              <div className="p-1 bg-gray-100 rounded mt-0.5">
-                                <Award className="h-3 w-3 text-gray-600" />
+                              <div className="p-1 bg-surface-3 rounded mt-0.5">
+                                <Award className="h-3 w-3 text-ink-3" />
                               </div>
-                              <p className="text-sm text-gray-700">
+                              <p className="text-sm text-ink-2">
                                 {achievement}
                               </p>
                             </div>
@@ -485,7 +492,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   )}
                   {persona.progress.breakthrough_moments.length > 0 && (
                     <div>
-                      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                      <h4 className="text-xs font-semibold text-ink-3 uppercase tracking-wider mb-3">
                         Breakthrough Moments
                       </h4>
                       <div className="space-y-2">
@@ -493,7 +500,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                           (moment, index) => (
                             <div
                               key={index}
-                              className="p-3 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-lg"
+                              className="p-3 bg-ink text-ink-on-dark rounded-lg"
                             >
                               <div className="flex items-start gap-2">
                                 <Lightbulb className="h-4 w-4 opacity-80 flex-shrink-0 mt-0.5" />
@@ -512,10 +519,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
 
           {/* Recurring Themes - Tag Cloud */}
           {persona.patterns.recurring_themes.length > 0 && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Sparkles className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Sparkles className="h-4 w-4 text-ink-3" />
                   Recurring Themes
                 </CardTitle>
               </CardHeader>
@@ -528,10 +535,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                       className={cn(
                         'px-3 py-1.5',
                         index < 2
-                          ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
+                          ? 'bg-ink text-ink-on-dark border-line '
                           : index < 4
-                            ? 'bg-gray-200 text-gray-800 border-gray-200'
-                            : 'bg-gray-100 text-gray-700 border-gray-100',
+                            ? 'bg-surface-3 text-ink-2 border-line'
+                            : 'bg-surface-3 text-ink-2 border-line',
                       )}
                     >
                       {theme}
@@ -545,10 +552,10 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
           {/* Fears & Obstacles - Warning Cards */}
           {(persona.challenges.fears.length > 0 ||
             persona.challenges.obstacles.length > 0) && (
-            <Card className="border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
+            <Card className="border-line shadow-sm hover:shadow-lg transition-all duration-300 lg:col-span-3">
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                  <Shield className="h-4 w-4 text-gray-600" />
+                <CardTitle className="text-sm font-semibold text-ink flex items-center gap-2">
+                  <Shield className="h-4 w-4 text-ink-3" />
                   Concerns & Obstacles
                 </CardTitle>
               </CardHeader>
@@ -556,7 +563,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {persona.challenges.fears.length > 0 && (
                     <div>
-                      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1">
+                      <h4 className="text-xs font-semibold text-ink-3 uppercase tracking-wider mb-3 flex items-center gap-1">
                         <AlertCircle className="h-3 w-3" />
                         Fears
                       </h4>
@@ -564,9 +571,9 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                         {persona.challenges.fears.map((fear, index) => (
                           <div
                             key={index}
-                            className="p-3 bg-gray-50 rounded-lg border-l-2 border-gray-400"
+                            className="p-3 bg-paper rounded-lg border-l-2 border-line-strong"
                           >
-                            <p className="text-sm text-gray-700">{fear}</p>
+                            <p className="text-sm text-ink-2">{fear}</p>
                           </div>
                         ))}
                       </div>
@@ -574,7 +581,7 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                   )}
                   {persona.challenges.obstacles.length > 0 && (
                     <div>
-                      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1">
+                      <h4 className="text-xs font-semibold text-ink-3 uppercase tracking-wider mb-3 flex items-center gap-1">
                         <XCircle className="h-3 w-3" />
                         Obstacles
                       </h4>
@@ -582,9 +589,9 @@ export function ClientPersonaModern({ clientId }: ClientPersonaProps) {
                         {persona.challenges.obstacles.map((obstacle, index) => (
                           <div
                             key={index}
-                            className="p-3 bg-gray-50 rounded-lg border-l-2 border-gray-300"
+                            className="p-3 bg-paper rounded-lg border-l-2 border-line-strong"
                           >
-                            <p className="text-sm text-gray-700">{obstacle}</p>
+                            <p className="text-sm text-ink-2">{obstacle}</p>
                           </div>
                         ))}
                       </div>

--- a/src/app/clients/[clientId]/components/client-persona.tsx
+++ b/src/app/clients/[clientId]/components/client-persona.tsx
@@ -54,7 +54,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
     return (
       <div className="space-y-6">
         {[1, 2, 3, 4].map(i => (
-          <Card key={i} className="border-gray-200">
+          <Card key={i} className="border-line">
             <CardHeader>
               <Skeleton className="h-6 w-32" />
             </CardHeader>
@@ -74,11 +74,11 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
   if (!persona) {
     return (
       <div className="text-center py-12">
-        <Brain className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-gray-900 mb-2">
+        <Brain className="h-12 w-12 text-ink-4 mx-auto mb-4" />
+        <h3 className="text-lg font-medium text-ink mb-2">
           No Persona Data Yet
         </h3>
-        <p className="text-gray-500">
+        <p className="text-ink-3">
           Persona will be built as sessions are analyzed
         </p>
       </div>
@@ -90,34 +90,34 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
   return (
     <div className="space-y-6">
       {/* Metadata Bar */}
-      <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
+      <div className="bg-paper rounded-lg p-4 border border-line">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-6">
             <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
+              <p className="text-xs text-ink-3 uppercase tracking-wider">
                 Sessions Analyzed
               </p>
-              <p className="text-lg font-semibold text-gray-900">
+              <p className="text-lg font-semibold text-ink">
                 {persona.metadata.sessions_analyzed}
               </p>
             </div>
             <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider">
+              <p className="text-xs text-ink-3 uppercase tracking-wider">
                 Confidence Score
               </p>
               <div className="flex items-center gap-2">
                 <Progress value={confidencePercentage} className="w-24 h-2" />
-                <span className="text-sm font-medium text-gray-700">
+                <span className="text-sm font-medium text-ink-2">
                   {confidencePercentage.toFixed(0)}%
                 </span>
               </div>
             </div>
             {persona.metadata.last_updated && (
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                <p className="text-xs text-ink-3 uppercase tracking-wider">
                   Last Updated
                 </p>
-                <p className="text-sm text-gray-700">
+                <p className="text-sm text-ink-2">
                   {formatDate(persona.metadata.last_updated)}
                 </p>
               </div>
@@ -131,10 +131,10 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
         persona.demographics.occupation ||
         persona.demographics.location ||
         persona.demographics.family_situation) && (
-        <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-          <CardHeader className="bg-gradient-to-r from-gray-50 to-white border-b border-gray-100">
-            <CardTitle className="text-base font-semibold text-gray-900 flex items-center gap-2">
-              <User className="h-5 w-5 text-gray-600" />
+        <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
+          <CardHeader className=" border-b border-line">
+            <CardTitle className="text-base font-semibold text-ink flex items-center gap-2">
+              <User className="h-5 w-5 text-ink-3" />
               Profile Overview
             </CardTitle>
           </CardHeader>
@@ -142,12 +142,12 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {persona.demographics.age_range && (
                 <div className="flex items-start gap-3">
-                  <Calendar className="h-4 w-4 text-gray-400 mt-0.5" />
+                  <Calendar className="h-4 w-4 text-ink-4 mt-0.5" />
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Age Range
                     </p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-ink">
                       {persona.demographics.age_range}
                     </p>
                   </div>
@@ -155,12 +155,12 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
               )}
               {persona.demographics.occupation && (
                 <div className="flex items-start gap-3">
-                  <Briefcase className="h-4 w-4 text-gray-400 mt-0.5" />
+                  <Briefcase className="h-4 w-4 text-ink-4 mt-0.5" />
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Occupation
                     </p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-ink">
                       {persona.demographics.occupation}
                     </p>
                   </div>
@@ -168,12 +168,12 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
               )}
               {persona.demographics.location && (
                 <div className="flex items-start gap-3">
-                  <MapPin className="h-4 w-4 text-gray-400 mt-0.5" />
+                  <MapPin className="h-4 w-4 text-ink-4 mt-0.5" />
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Location
                     </p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-ink">
                       {persona.demographics.location}
                     </p>
                   </div>
@@ -181,12 +181,12 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
               )}
               {persona.demographics.family_situation && (
                 <div className="flex items-start gap-3">
-                  <Users className="h-4 w-4 text-gray-400 mt-0.5" />
+                  <Users className="h-4 w-4 text-ink-4 mt-0.5" />
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Family
                     </p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-ink">
                       {persona.demographics.family_situation}
                     </p>
                   </div>
@@ -201,17 +201,17 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
       {(persona.goals.primary_goals.length > 0 ||
         persona.goals.short_term_goals.length > 0 ||
         persona.goals.long_term_goals.length > 0) && (
-        <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-          <CardHeader className="bg-gradient-to-r from-gray-50 to-white border-b border-gray-100">
-            <CardTitle className="text-base font-semibold text-gray-900 flex items-center gap-2">
-              <Target className="h-5 w-5 text-gray-600" />
+        <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
+          <CardHeader className=" border-b border-line">
+            <CardTitle className="text-base font-semibold text-ink flex items-center gap-2">
+              <Target className="h-5 w-5 text-ink-3" />
               Vision & Aspirations
             </CardTitle>
           </CardHeader>
           <CardContent className="pt-6 space-y-4">
             {persona.goals.primary_goals.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2 flex items-center gap-1">
+                <h4 className="text-sm font-medium text-ink-2 mb-2 flex items-center gap-1">
                   <Sparkles className="h-3.5 w-3.5" />
                   Primary Vision
                 </h4>
@@ -220,7 +220,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     <Badge
                       key={index}
                       variant="secondary"
-                      className="bg-gray-100 text-gray-700"
+                      className="bg-surface-3 text-ink-2"
                     >
                       {goal}
                     </Badge>
@@ -230,16 +230,16 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.goals.short_term_goals.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Short-term Meta Performance Outcomes (3 months)
                 </h4>
                 <ul className="space-y-1">
                   {persona.goals.short_term_goals.map((goal, index) => (
                     <li
                       key={index}
-                      className="text-sm text-gray-600 flex items-start gap-2"
+                      className="text-sm text-ink-3 flex items-start gap-2"
                     >
-                      <span className="text-gray-400 mt-0.5">•</span>
+                      <span className="text-ink-4 mt-0.5">•</span>
                       <span>{goal}</span>
                     </li>
                   ))}
@@ -248,16 +248,16 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.goals.long_term_goals.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Long-term Meta Performance Outcomes (6+ months)
                 </h4>
                 <ul className="space-y-1">
                   {persona.goals.long_term_goals.map((goal, index) => (
                     <li
                       key={index}
-                      className="text-sm text-gray-600 flex items-start gap-2"
+                      className="text-sm text-ink-3 flex items-start gap-2"
                     >
-                      <span className="text-gray-400 mt-0.5">•</span>
+                      <span className="text-ink-4 mt-0.5">•</span>
                       <span>{goal}</span>
                     </li>
                   ))}
@@ -272,17 +272,17 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
       {(persona.challenges.main_challenges.length > 0 ||
         persona.challenges.obstacles.length > 0 ||
         persona.patterns.growth_areas.length > 0) && (
-        <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-          <CardHeader className="bg-gradient-to-r from-gray-50 to-white border-b border-gray-100">
-            <CardTitle className="text-base font-semibold text-gray-900 flex items-center gap-2">
-              <AlertCircle className="h-5 w-5 text-gray-600" />
+        <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
+          <CardHeader className=" border-b border-line">
+            <CardTitle className="text-base font-semibold text-ink flex items-center gap-2">
+              <AlertCircle className="h-5 w-5 text-ink-3" />
               Challenges & Growth Areas
             </CardTitle>
           </CardHeader>
           <CardContent className="pt-6 space-y-4">
             {persona.challenges.main_challenges.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Main Challenges
                 </h4>
                 <div className="space-y-2">
@@ -290,9 +290,9 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     (challenge, index) => (
                       <div
                         key={index}
-                        className="bg-gray-50 rounded-lg p-3 border border-gray-100"
+                        className="bg-paper rounded-lg p-3 border border-line"
                       >
-                        <p className="text-sm text-gray-700">{challenge}</p>
+                        <p className="text-sm text-ink-2">{challenge}</p>
                       </div>
                     ),
                   )}
@@ -301,7 +301,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.patterns.growth_areas.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Growth Areas
                 </h4>
                 <div className="flex flex-wrap gap-2">
@@ -309,7 +309,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     <Badge
                       key={index}
                       variant="outline"
-                      className="border-gray-300 text-gray-600"
+                      className="border-line-strong text-ink-3"
                     >
                       {area}
                     </Badge>
@@ -319,16 +319,16 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.challenges.obstacles.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Obstacles
                 </h4>
                 <ul className="space-y-1">
                   {persona.challenges.obstacles.map((obstacle, index) => (
                     <li
                       key={index}
-                      className="text-sm text-gray-600 flex items-start gap-2"
+                      className="text-sm text-ink-3 flex items-start gap-2"
                     >
-                      <Shield className="h-3.5 w-3.5 text-gray-400 mt-0.5" />
+                      <Shield className="h-3.5 w-3.5 text-ink-4 mt-0.5" />
                       <span>{obstacle}</span>
                     </li>
                   ))}
@@ -344,10 +344,10 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
         persona.personality.learning_style ||
         persona.personality.personality_traits.length > 0 ||
         persona.personality.values.length > 0) && (
-        <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-          <CardHeader className="bg-gradient-to-r from-gray-50 to-white border-b border-gray-100">
-            <CardTitle className="text-base font-semibold text-gray-900 flex items-center gap-2">
-              <Brain className="h-5 w-5 text-gray-600" />
+        <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
+          <CardHeader className=" border-b border-line">
+            <CardTitle className="text-base font-semibold text-ink flex items-center gap-2">
+              <Brain className="h-5 w-5 text-ink-3" />
               Personality & Style
             </CardTitle>
           </CardHeader>
@@ -355,12 +355,12 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {persona.personality.communication_style && (
                 <div className="flex items-start gap-3">
-                  <MessageSquare className="h-4 w-4 text-gray-400 mt-0.5" />
+                  <MessageSquare className="h-4 w-4 text-ink-4 mt-0.5" />
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Communication Style
                     </p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-ink">
                       {persona.personality.communication_style}
                     </p>
                   </div>
@@ -368,12 +368,12 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
               )}
               {persona.personality.learning_style && (
                 <div className="flex items-start gap-3">
-                  <BookOpen className="h-4 w-4 text-gray-400 mt-0.5" />
+                  <BookOpen className="h-4 w-4 text-ink-4 mt-0.5" />
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                    <p className="text-xs text-ink-3 uppercase tracking-wider">
                       Learning Style
                     </p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-ink">
                       {persona.personality.learning_style}
                     </p>
                   </div>
@@ -382,7 +382,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             </div>
             {persona.personality.personality_traits.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Personality Traits
                 </h4>
                 <div className="flex flex-wrap gap-2">
@@ -390,7 +390,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     (trait, index) => (
                       <Badge
                         key={index}
-                        className="bg-gray-100 text-gray-700 border-0"
+                        className="bg-surface-3 text-ink-2 border-0"
                       >
                         {trait}
                       </Badge>
@@ -401,7 +401,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.personality.values.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2 flex items-center gap-1">
+                <h4 className="text-sm font-medium text-ink-2 mb-2 flex items-center gap-1">
                   <Heart className="h-3.5 w-3.5" />
                   Core Values
                 </h4>
@@ -410,7 +410,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     <Badge
                       key={index}
                       variant="secondary"
-                      className="bg-gray-50 text-gray-700 border border-gray-200"
+                      className="bg-paper text-ink-2 border border-line"
                     >
                       {value}
                     </Badge>
@@ -425,17 +425,17 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
       {/* Strengths & Patterns */}
       {(persona.patterns.strengths.length > 0 ||
         persona.patterns.recurring_themes.length > 0) && (
-        <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-          <CardHeader className="bg-gradient-to-r from-gray-50 to-white border-b border-gray-100">
-            <CardTitle className="text-base font-semibold text-gray-900 flex items-center gap-2">
-              <TrendingUp className="h-5 w-5 text-gray-600" />
+        <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
+          <CardHeader className=" border-b border-line">
+            <CardTitle className="text-base font-semibold text-ink flex items-center gap-2">
+              <TrendingUp className="h-5 w-5 text-ink-3" />
               Strengths & Patterns
             </CardTitle>
           </CardHeader>
           <CardContent className="pt-6 space-y-4">
             {persona.patterns.strengths.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2 flex items-center gap-1">
+                <h4 className="text-sm font-medium text-ink-2 mb-2 flex items-center gap-1">
                   <Zap className="h-3.5 w-3.5" />
                   Strengths
                 </h4>
@@ -443,9 +443,9 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                   {persona.patterns.strengths.map((strength, index) => (
                     <div
                       key={index}
-                      className="bg-gray-50 rounded-lg p-3 border border-gray-200"
+                      className="bg-paper rounded-lg p-3 border border-line"
                     >
-                      <p className="text-sm text-gray-700">{strength}</p>
+                      <p className="text-sm text-ink-2">{strength}</p>
                     </div>
                   ))}
                 </div>
@@ -453,7 +453,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.patterns.recurring_themes.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Recurring Themes
                 </h4>
                 <div className="flex flex-wrap gap-2">
@@ -461,7 +461,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     <Badge
                       key={index}
                       variant="outline"
-                      className="border-gray-300 text-gray-600"
+                      className="border-line-strong text-ink-3"
                     >
                       {theme}
                     </Badge>
@@ -476,24 +476,24 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
       {/* Progress & Achievements */}
       {(persona.progress.achievements.length > 0 ||
         persona.progress.breakthrough_moments.length > 0) && (
-        <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-          <CardHeader className="bg-gradient-to-r from-gray-50 to-white border-b border-gray-100">
-            <CardTitle className="text-base font-semibold text-gray-900 flex items-center gap-2">
-              <Award className="h-5 w-5 text-gray-600" />
+        <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
+          <CardHeader className=" border-b border-line">
+            <CardTitle className="text-base font-semibold text-ink flex items-center gap-2">
+              <Award className="h-5 w-5 text-ink-3" />
               Progress & Achievements
             </CardTitle>
           </CardHeader>
           <CardContent className="pt-6 space-y-4">
             {persona.progress.achievements.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Achievements
                 </h4>
                 <div className="space-y-2">
                   {persona.progress.achievements.map((achievement, index) => (
                     <div key={index} className="flex items-start gap-2">
-                      <Award className="h-4 w-4 text-gray-600 mt-0.5 flex-shrink-0" />
-                      <p className="text-sm text-gray-700">{achievement}</p>
+                      <Award className="h-4 w-4 text-ink-3 mt-0.5 flex-shrink-0" />
+                      <p className="text-sm text-ink-2">{achievement}</p>
                     </div>
                   ))}
                 </div>
@@ -501,7 +501,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
             )}
             {persona.progress.breakthrough_moments.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700 mb-2">
+                <h4 className="text-sm font-medium text-ink-2 mb-2">
                   Breakthrough Moments
                 </h4>
                 <div className="space-y-2">
@@ -509,7 +509,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                     (moment, index) => (
                       <div
                         key={index}
-                        className="bg-gray-900 dark:bg-white rounded-lg p-3 text-white dark:text-gray-900"
+                        className="bg-ink rounded-lg p-3 text-ink-on-dark "
                       >
                         <p className="text-sm">{moment}</p>
                       </div>

--- a/src/app/clients/[clientId]/components/client-profile-section.tsx
+++ b/src/app/clients/[clientId]/components/client-profile-section.tsx
@@ -80,18 +80,18 @@ export function ClientProfileSection({
     return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
   }
   return (
-    <Card className="border-gray-200 dark:border-gray-700">
-      <CardHeader className="border-b border-gray-200 dark:border-gray-700">
+    <Card className="border-line ">
+      <CardHeader className="border-b border-line ">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <CardTitle className="text-lg font-semibold flex items-center gap-2">
-              <User2 className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <User2 className="h-5 w-5 text-ink-3 " />
               Client Profile
             </CardTitle>
             {client.invitation_status === 'invited' && (
               <Badge
                 variant="secondary"
-                className="bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 text-xs"
+                className="bg-indigo-bg text-indigo text-xs"
               >
                 Invited
               </Badge>
@@ -99,7 +99,7 @@ export function ClientProfileSection({
             {client.invitation_status === 'accepted' && (
               <Badge
                 variant="secondary"
-                className="bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 text-xs"
+                className="bg-forest-bg text-forest text-xs"
               >
                 <UserCheck className="h-3 w-3 mr-1" />
                 Portal Active
@@ -128,7 +128,7 @@ export function ClientProfileSection({
                 {client.invitation_status === 'invited' && onCancelInvite && (
                   <DropdownMenuItem
                     onClick={onCancelInvite}
-                    className="text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/30"
+                    className="text-vermillion focus:text-vermillion focus:bg-vermillion-bg "
                   >
                     <XCircle className="h-4 w-4 mr-2" />
                     Cancel Invitation
@@ -137,7 +137,7 @@ export function ClientProfileSection({
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={onDelete}
-                  className="text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/30"
+                  className="text-vermillion focus:text-vermillion focus:bg-vermillion-bg "
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Delete Client
@@ -153,7 +153,7 @@ export function ClientProfileSection({
           {/* Client Info */}
           <div className="flex items-start gap-4">
             <div className="flex-shrink-0">
-              <div className="h-20 w-20 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center text-2xl font-semibold text-primary">
+              <div className="h-20 w-20 rounded-full bg-surface-3 flex items-center justify-center text-2xl font-semibold text-primary">
                 {client.name
                   .split(' ')
                   .map((n: string) => n[0])
@@ -164,27 +164,27 @@ export function ClientProfileSection({
             </div>
 
             <div className="flex-1 min-w-0">
-              <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+              <h3 className="text-xl font-semibold text-ink mb-2">
                 {client.name}
               </h3>
 
               {/* Contact Info */}
-              <div className="space-y-1.5 text-sm text-gray-600 dark:text-gray-400">
+              <div className="space-y-1.5 text-sm text-ink-3 ">
                 {client.email && (
                   <div className="flex items-center gap-2">
-                    <Mail className="h-4 w-4 text-gray-400" />
+                    <Mail className="h-4 w-4 text-ink-4" />
                     <span className="truncate">{client.email}</span>
                   </div>
                 )}
                 {client.phone && (
                   <div className="flex items-center gap-2">
-                    <Phone className="h-4 w-4 text-gray-400" />
+                    <Phone className="h-4 w-4 text-ink-4" />
                     <span>{client.phone}</span>
                   </div>
                 )}
                 {client.created_at && (
                   <div className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4 text-gray-400" />
+                    <Calendar className="h-4 w-4 text-ink-4" />
                     <span>
                       Client since {formatDate(client.created_at, 'MMM yyyy')}
                     </span>
@@ -201,21 +201,21 @@ export function ClientProfileSection({
               ) : persona ? (
                 <div className="mt-3 space-y-1.5 text-sm">
                   {persona.demographics?.occupation && (
-                    <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-                      <Briefcase className="h-4 w-4 text-gray-400" />
+                    <div className="flex items-center gap-2 text-ink-3 ">
+                      <Briefcase className="h-4 w-4 text-ink-4" />
                       <span>{persona.demographics.occupation}</span>
                     </div>
                   )}
                   {persona.demographics?.location && (
-                    <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-                      <MapPin className="h-4 w-4 text-gray-400" />
+                    <div className="flex items-center gap-2 text-ink-3 ">
+                      <MapPin className="h-4 w-4 text-ink-4" />
                       <span>{persona.demographics.location}</span>
                     </div>
                   )}
                   {persona.personality?.values &&
                     persona.personality.values.length > 0 && (
-                      <div className="flex items-start gap-2 text-gray-600 dark:text-gray-400">
-                        <Heart className="h-4 w-4 text-gray-400 mt-0.5" />
+                      <div className="flex items-start gap-2 text-ink-3 ">
+                        <Heart className="h-4 w-4 text-ink-4 mt-0.5" />
                         <span className="flex-1">
                           {persona.personality.values.slice(0, 3).join(', ')}
                         </span>
@@ -239,8 +239,8 @@ export function ClientProfileSection({
 
           {/* AI Insights from Persona */}
           {persona && persona.patterns && (
-            <div className="pt-4 border-t border-gray-100 dark:border-gray-700">
-              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+            <div className="pt-4 border-t border-line ">
+              <h4 className="text-sm font-semibold text-ink-2 mb-2 flex items-center gap-2">
                 <Sparkles className="h-4 w-4 text-primary" />
                 AI Insights
               </h4>
@@ -248,10 +248,10 @@ export function ClientProfileSection({
                 {persona.patterns.strengths &&
                   persona.patterns.strengths.length > 0 && (
                     <div>
-                      <span className="text-xs font-semibold text-green-700 dark:text-green-400">
+                      <span className="text-xs font-semibold text-forest ">
                         Strengths:
                       </span>
-                      <p className="text-gray-600 dark:text-gray-400 mt-0.5">
+                      <p className="text-ink-3 mt-0.5">
                         {persona.patterns.strengths.slice(0, 2).join(', ')}
                       </p>
                     </div>
@@ -259,10 +259,10 @@ export function ClientProfileSection({
                 {persona.patterns.growth_areas &&
                   persona.patterns.growth_areas.length > 0 && (
                     <div>
-                      <span className="text-xs font-semibold text-orange-700 dark:text-orange-400">
+                      <span className="text-xs font-semibold text-amber-token ">
                         Growth Areas:
                       </span>
-                      <p className="text-gray-600 dark:text-gray-400 mt-0.5">
+                      <p className="text-ink-3 mt-0.5">
                         {persona.patterns.growth_areas.slice(0, 2).join(', ')}
                       </p>
                     </div>
@@ -272,21 +272,19 @@ export function ClientProfileSection({
           )}
 
           {/* Coaching Statistics */}
-          <div className="pt-4 border-t border-gray-100 dark:border-gray-700">
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+          <div className="pt-4 border-t border-line ">
+            <h4 className="text-sm font-semibold text-ink-2 mb-3">
               Coaching Statistics
             </h4>
             <div className="grid grid-cols-2 gap-4">
               {/* Total Sessions */}
               <div className="flex items-start gap-3">
-                <div className="p-2 rounded-lg bg-blue-50 dark:bg-blue-900/30">
-                  <MessageSquare className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                <div className="p-2 rounded-lg bg-ds-accent-bg ">
+                  <MessageSquare className="h-4 w-4 text-ds-accent " />
                 </div>
                 <div>
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    Total Sessions
-                  </p>
-                  <p className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <p className="text-xs text-ink-3 ">Total Sessions</p>
+                  <p className="text-lg font-semibold text-ink ">
                     {totalSessions}
                   </p>
                 </div>
@@ -294,14 +292,12 @@ export function ClientProfileSection({
 
               {/* Avg Duration */}
               <div className="flex items-start gap-3">
-                <div className="p-2 rounded-lg bg-purple-50 dark:bg-purple-900/30">
-                  <Clock className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+                <div className="p-2 rounded-lg bg-indigo-bg ">
+                  <Clock className="h-4 w-4 text-indigo " />
                 </div>
                 <div>
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    Avg Duration
-                  </p>
-                  <p className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <p className="text-xs text-ink-3 ">Avg Duration</p>
+                  <p className="text-lg font-semibold text-ink ">
                     {formatDuration(avgDuration)}
                   </p>
                 </div>
@@ -309,14 +305,12 @@ export function ClientProfileSection({
 
               {/* Avg Score */}
               <div className="flex items-start gap-3">
-                <div className="p-2 rounded-lg bg-green-50 dark:bg-green-900/30">
-                  <TrendingUp className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <div className="p-2 rounded-lg bg-forest-bg ">
+                  <TrendingUp className="h-4 w-4 text-forest " />
                 </div>
                 <div>
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    Avg Score
-                  </p>
-                  <p className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <p className="text-xs text-ink-3 ">Avg Score</p>
+                  <p className="text-lg font-semibold text-ink ">
                     {avgScore !== null ? `${avgScore.toFixed(1)}/10` : 'N/A'}
                   </p>
                 </div>
@@ -324,17 +318,15 @@ export function ClientProfileSection({
 
               {/* Commitments */}
               <div className="flex items-start gap-3">
-                <div className="p-2 rounded-lg bg-orange-50 dark:bg-orange-900/30">
-                  <CheckCircle2 className="h-4 w-4 text-orange-600 dark:text-orange-400" />
+                <div className="p-2 rounded-lg bg-amber-token-bg ">
+                  <CheckCircle2 className="h-4 w-4 text-amber-token " />
                 </div>
                 <div>
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    Commitments
-                  </p>
-                  <p className="text-lg font-semibold text-gray-900 dark:text-white">
+                  <p className="text-xs text-ink-3 ">Commitments</p>
+                  <p className="text-lg font-semibold text-ink ">
                     {completedCommitments}/{totalCommitments}
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <p className="text-xs text-ink-3 ">
                     {commitmentCompletionRate}% complete
                   </p>
                 </div>
@@ -345,7 +337,7 @@ export function ClientProfileSection({
             {activeGoals > 0 && (
               <div className="flex items-center gap-2 mt-3 p-2 bg-primary/5 rounded-lg">
                 <Target className="h-4 w-4 text-primary" />
-                <span className="text-sm text-gray-700 dark:text-gray-300">
+                <span className="text-sm text-ink-2 ">
                   <strong>{activeGoals}</strong> active vision
                   {activeGoals !== 1 ? 's' : ''}
                 </span>
@@ -355,11 +347,11 @@ export function ClientProfileSection({
 
           {/* Meta Performance Vision */}
           {client.meta_performance_vision && (
-            <div className="pt-4 border-t border-gray-100 dark:border-gray-700">
-              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+            <div className="pt-4 border-t border-line ">
+              <h4 className="text-sm font-semibold text-ink-2 mb-2">
                 Meta Performance Vision
               </h4>
-              <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+              <p className="text-sm text-ink-3 leading-relaxed">
                 {client.meta_performance_vision}
               </p>
             </div>
@@ -367,11 +359,9 @@ export function ClientProfileSection({
 
           {/* Notes */}
           {client.notes && (
-            <div className="pt-4 border-t border-gray-100 dark:border-gray-700">
-              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                Notes
-              </h4>
-              <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed whitespace-pre-wrap">
+            <div className="pt-4 border-t border-line ">
+              <h4 className="text-sm font-semibold text-ink-2 mb-2">Notes</h4>
+              <p className="text-sm text-ink-3 leading-relaxed whitespace-pre-wrap">
                 {client.notes}
               </p>
             </div>

--- a/src/app/clients/[clientId]/components/client-resources-tab.tsx
+++ b/src/app/clients/[clientId]/components/client-resources-tab.tsx
@@ -141,10 +141,10 @@ export function ClientResourcesTab({
       {/* Header with actions */}
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <h3 className="text-lg font-semibold text-ink ">
             Resources ({resources.length})
           </h3>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+          <p className="text-sm text-ink-3 mt-0.5">
             Resources shared with {clientName || 'this client'}
           </p>
         </div>
@@ -175,7 +175,7 @@ export function ClientResourcesTab({
       {/* Search */}
       {resources.length > 0 && (
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-4" />
           <Input
             placeholder="Search resources..."
             value={searchQuery}
@@ -188,7 +188,7 @@ export function ClientResourcesTab({
       {/* Resources */}
       {resources.length > 0 && (
         <div>
-          <h4 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3 flex items-center gap-1.5">
+          <h4 className="text-sm font-medium text-ink-3 mb-3 flex items-center gap-1.5">
             <Share2 className="h-4 w-4" />
             Shared with {clientName || 'this client'}
           </h4>
@@ -207,13 +207,13 @@ export function ClientResourcesTab({
 
       {/* Empty state */}
       {resources.length === 0 && (
-        <Card className="border-2 border-dashed border-gray-300 dark:border-gray-600">
+        <Card className="border-2 border-dashed border-line-strong ">
           <CardContent className="flex flex-col items-center justify-center py-16">
-            <BookOpen className="h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            <BookOpen className="h-12 w-12 text-ink-2 mb-4" />
+            <h3 className="text-lg font-semibold text-ink mb-2">
               No Resources Shared
             </h3>
-            <p className="text-gray-500 dark:text-gray-400 text-center max-w-md mb-4">
+            <p className="text-ink-3 text-center max-w-md mb-4">
               No resources have been shared with {clientName || 'this client'}{' '}
               yet.
             </p>
@@ -286,8 +286,8 @@ export function ClientResourcesTab({
         <AlertDialogContent>
           <AlertDialogHeader>
             <div className="flex items-center gap-3 mb-2">
-              <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                <AlertTriangle className="h-5 w-5 text-red-600" />
+              <div className="p-2 bg-vermillion-bg rounded-full">
+                <AlertTriangle className="h-5 w-5 text-vermillion" />
               </div>
               <AlertDialogTitle>Delete Resource</AlertDialogTitle>
             </div>
@@ -306,7 +306,7 @@ export function ClientResourcesTab({
                 handleDeleteConfirm()
               }}
               disabled={deleteResourceMutation.isPending}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               {deleteResourceMutation.isPending ? (
                 <>
@@ -342,7 +342,7 @@ function ResourceMiniCard({
 
   return (
     <Card
-      className="border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+      className="border-line shadow-sm hover:shadow-md transition-shadow cursor-pointer"
       onClick={() => onView(resource)}
     >
       <CardContent className="py-3 px-4">
@@ -351,7 +351,7 @@ function ResourceMiniCard({
             <Icon className={`h-4 w-4 ${colors.text}`} />
           </div>
           <div className="flex-1 min-w-0">
-            <h4 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+            <h4 className="text-sm font-medium text-ink truncate">
               {resource.title}
             </h4>
             <div className="flex items-center gap-2 mt-0.5">
@@ -361,12 +361,12 @@ function ResourceMiniCard({
               >
                 {CATEGORY_LABELS[resource.category]}
               </Badge>
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-ink-4">
                 {formatDate(resource.created_at)}
               </span>
             </div>
           </div>
-          <div className="flex items-center gap-1 text-xs text-gray-400">
+          <div className="flex items-center gap-1 text-xs text-ink-4">
             <Eye className="h-3 w-3" />
             {resource.view_count}
           </div>
@@ -388,7 +388,7 @@ function ResourceMiniCard({
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => onDelete(resource)}
-                className="text-red-600"
+                className="text-vermillion"
               >
                 <Trash2 className="h-4 w-4 mr-2" />
                 Delete

--- a/src/app/clients/[clientId]/components/client-stats.tsx
+++ b/src/app/clients/[clientId]/components/client-stats.tsx
@@ -17,73 +17,71 @@ export default function ClientStats({
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="border-gray-200 hover:shadow-md transition-shadow">
+        <Card className="border-line hover:shadow-md transition-shadow">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                <p className="text-xs text-ink-3 uppercase tracking-wider">
                   Total Sessions
                 </p>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {stats.total_sessions}
                 </p>
               </div>
-              <div className="p-3 bg-gray-100 rounded-lg">
-                <MessageSquare className="h-5 w-5 text-gray-600" />
+              <div className="p-3 bg-surface-3 rounded-lg">
+                <MessageSquare className="h-5 w-5 text-ink-3" />
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border-gray-200 hover:shadow-md transition-shadow">
+        <Card className="border-line hover:shadow-md transition-shadow">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                <p className="text-xs text-ink-3 uppercase tracking-wider">
                   Total Time
                 </p>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {stats.total_duration_minutes}m
                 </p>
               </div>
-              <div className="p-3 bg-gray-100 rounded-lg">
-                <Clock className="h-5 w-5 text-gray-600" />
+              <div className="p-3 bg-surface-3 rounded-lg">
+                <Clock className="h-5 w-5 text-ink-3" />
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border-gray-200 hover:shadow-md transition-shadow">
+        <Card className="border-line hover:shadow-md transition-shadow">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                <p className="text-xs text-ink-3 uppercase tracking-wider">
                   Avg Duration
                 </p>
-                <p className="text-2xl font-bold text-gray-900">
-                  {avgDuration}m
-                </p>
+                <p className="text-2xl font-bold text-ink">{avgDuration}m</p>
               </div>
-              <div className="p-3 bg-gray-100 rounded-lg">
-                <TrendingUp className="h-5 w-5 text-gray-600" />
+              <div className="p-3 bg-surface-3 rounded-lg">
+                <TrendingUp className="h-5 w-5 text-ink-3" />
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="border-gray-200 hover:shadow-md transition-shadow">
+        <Card className="border-line hover:shadow-md transition-shadow">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                <p className="text-xs text-ink-3 uppercase tracking-wider">
                   Completed
                 </p>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {completedSessions}
                 </p>
               </div>
-              <div className="p-3 bg-gray-100 rounded-lg">
-                <Activity className="h-5 w-5 text-gray-600" />
+              <div className="p-3 bg-surface-3 rounded-lg">
+                <Activity className="h-5 w-5 text-ink-3" />
               </div>
             </div>
           </CardContent>

--- a/src/app/clients/[clientId]/components/client-summary-card.tsx
+++ b/src/app/clients/[clientId]/components/client-summary-card.tsx
@@ -22,38 +22,34 @@ export function ClientSummaryCard({
     : null
 
   return (
-    <Card className="border-gray-200 shadow-sm">
-      <CardHeader className="border-b border-gray-100">
+    <Card className="border-line shadow-sm">
+      <CardHeader className="border-b border-line">
         <div className="flex items-center gap-3">
-          <div className="p-2 bg-blue-50 rounded-lg">
-            <User className="h-5 w-5 text-blue-600" />
+          <div className="p-2 bg-ds-accent-bg rounded-lg">
+            <User className="h-5 w-5 text-ds-accent" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">
-              Client Summary
-            </h2>
-            <p className="text-sm text-gray-500">
-              Overall insights and progress
-            </p>
+            <h2 className="text-lg font-semibold text-ink">Client Summary</h2>
+            <p className="text-sm text-ink-3">Overall insights and progress</p>
           </div>
         </div>
       </CardHeader>
       <CardContent className="pt-6 space-y-6">
         {/* Quick Stats Grid */}
         <div className="grid grid-cols-2 gap-4">
-          <div className="p-4 bg-gray-50 rounded-lg">
+          <div className="p-4 bg-paper rounded-lg">
             <div className="flex items-center gap-2 mb-1">
-              <MessageSquare className="h-4 w-4 text-gray-500" />
-              <span className="text-sm text-gray-600">Total Sessions</span>
+              <MessageSquare className="h-4 w-4 text-ink-3" />
+              <span className="text-sm text-ink-3">Total Sessions</span>
             </div>
-            <p className="text-2xl font-bold text-gray-900">{totalSessions}</p>
+            <p className="text-2xl font-bold text-ink">{totalSessions}</p>
           </div>
-          <div className="p-4 bg-gray-50 rounded-lg">
+          <div className="p-4 bg-paper rounded-lg">
             <div className="flex items-center gap-2 mb-1">
-              <TrendingUp className="h-4 w-4 text-gray-500" />
-              <span className="text-sm text-gray-600">Avg Score</span>
+              <TrendingUp className="h-4 w-4 text-ink-3" />
+              <span className="text-sm text-ink-3">Avg Score</span>
             </div>
-            <p className="text-2xl font-bold text-gray-900">
+            <p className="text-2xl font-bold text-ink">
               {avgScore ? avgScore.toFixed(1) : 'N/A'}
             </p>
           </div>
@@ -61,12 +57,10 @@ export function ClientSummaryCard({
 
         {/* Last Session Date */}
         {lastSessionDate && (
-          <div className="pt-2 border-t border-gray-100">
-            <p className="text-sm text-gray-600">
+          <div className="pt-2 border-t border-line">
+            <p className="text-sm text-ink-3">
               Last session:{' '}
-              <span className="font-medium text-gray-900">
-                {lastSessionDate}
-              </span>
+              <span className="font-medium text-ink">{lastSessionDate}</span>
             </p>
           </div>
         )}
@@ -75,17 +69,15 @@ export function ClientSummaryCard({
         {focusAreas.length > 0 && (
           <div>
             <div className="flex items-center gap-2 mb-3">
-              <Target className="h-4 w-4 text-gray-500" />
-              <h3 className="text-sm font-medium text-gray-900">
-                Key Focus Areas
-              </h3>
+              <Target className="h-4 w-4 text-ink-3" />
+              <h3 className="text-sm font-medium text-ink">Key Focus Areas</h3>
             </div>
             <div className="flex flex-wrap gap-2">
               {focusAreas.slice(0, 6).map((area, index) => (
                 <Badge
                   key={index}
                   variant="outline"
-                  className="bg-blue-50 border-blue-200 text-blue-700 text-xs"
+                  className="bg-ds-accent-bg border-ds-accent text-ds-accent text-xs"
                 >
                   {area}
                 </Badge>
@@ -96,9 +88,9 @@ export function ClientSummaryCard({
 
         {/* Notes if available */}
         {client.notes && (
-          <div className="pt-2 border-t border-gray-100">
-            <h3 className="text-sm font-medium text-gray-900 mb-2">Notes</h3>
-            <p className="text-sm text-gray-600 line-clamp-3">{client.notes}</p>
+          <div className="pt-2 border-t border-line">
+            <h3 className="text-sm font-medium text-ink mb-2">Notes</h3>
+            <p className="text-sm text-ink-3 line-clamp-3">{client.notes}</p>
           </div>
         )}
       </CardContent>

--- a/src/app/clients/[clientId]/components/client-upcoming-sessions.tsx
+++ b/src/app/clients/[clientId]/components/client-upcoming-sessions.tsx
@@ -83,11 +83,9 @@ export function ClientUpcomingSessions({
   return (
     <div className="mb-6">
       <div className="flex items-center gap-2 mb-3">
-        <CalendarClock className="h-4 w-4 text-gray-400" />
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-          Upcoming Sessions
-        </h3>
-        <span className="text-xs text-gray-400 font-medium">
+        <CalendarClock className="h-4 w-4 text-ink-4" />
+        <h3 className="text-sm font-semibold text-ink ">Upcoming Sessions</h3>
+        <span className="text-xs text-ink-4 font-medium">
           {sessions.length}
         </span>
       </div>
@@ -102,7 +100,7 @@ export function ClientUpcomingSessions({
           return (
             <div
               key={session.id}
-              className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
+              className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-line bg-paper/50 hover:bg-paper transition-colors group"
             >
               {/* Title (editable) */}
               <div className="flex-1 min-w-0">
@@ -116,12 +114,12 @@ export function ClientUpcomingSessions({
                       if (e.key === 'Enter') handleTitleSave(session.id)
                       if (e.key === 'Escape') setEditingTitleId(null)
                     }}
-                    className="w-full text-sm font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-0.5 outline-none focus:border-gray-900 dark:focus:border-white"
+                    className="w-full text-sm font-medium bg-surface-1 border border-line-strong rounded px-2 py-0.5 outline-none focus:border-line "
                   />
                 ) : (
                   <button
                     onClick={() => startEditingTitle(session)}
-                    className="text-sm font-medium text-gray-900 dark:text-white truncate block text-left group/title hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                    className="text-sm font-medium text-ink truncate block text-left group/title hover:text-ink-3 transition-colors"
                     title="Click to edit title"
                   >
                     {session.title || 'Scheduled Session'}
@@ -140,9 +138,7 @@ export function ClientUpcomingSessions({
                 <PopoverTrigger asChild>
                   <button
                     className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
-                      isOverdue
-                        ? 'text-red-500'
-                        : 'text-gray-500 dark:text-gray-400'
+                      isOverdue ? 'text-vermillion' : 'text-ink-3 '
                     }`}
                     title="Click to reschedule"
                   >
@@ -169,7 +165,7 @@ export function ClientUpcomingSessions({
                 {session.questionnaire_completed ? (
                   <Badge
                     variant="secondary"
-                    className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-[10px] px-1.5 py-0 h-5"
+                    className="bg-forest-bg text-forest border-forest text-[10px] px-1.5 py-0 h-5"
                   >
                     <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
                     Answered
@@ -178,7 +174,7 @@ export function ClientUpcomingSessions({
                   <>
                     <Badge
                       variant="secondary"
-                      className="bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 text-[10px] px-1.5 py-0 h-5"
+                      className="bg-ds-accent-bg text-ds-accent border-ds-accent text-[10px] px-1.5 py-0 h-5"
                     >
                       <Mail className="h-2.5 w-2.5 mr-0.5" />
                       Sent
@@ -194,7 +190,7 @@ export function ClientUpcomingSessions({
                         }
                       }}
                       disabled={sendQuestionnaire.isPending}
-                      className="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                      className="text-[10px] text-ink-4 hover:text-ink-3 transition-colors disabled:opacity-50"
                       title="Resend questionnaire"
                     >
                       {sendQuestionnaire.isPending ? (
@@ -216,7 +212,7 @@ export function ClientUpcomingSessions({
                       }
                     }}
                     disabled={sendQuestionnaire.isPending}
-                    className="flex items-center gap-1 text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                    className="flex items-center gap-1 text-[10px] font-medium text-ink-3 hover:text-ink-2 transition-colors disabled:opacity-50"
                   >
                     <Send className="h-2.5 w-2.5" />
                     Send Q&A
@@ -228,7 +224,7 @@ export function ClientUpcomingSessions({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7 text-xs px-2 shrink-0 text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                className="h-7 text-xs px-2 shrink-0 text-ink-3 hover:text-ink "
                 onClick={() => router.push(`/sessions/${session.id}`)}
               >
                 Open

--- a/src/app/clients/[clientId]/components/dashboard-tab.tsx
+++ b/src/app/clients/[clientId]/components/dashboard-tab.tsx
@@ -24,17 +24,17 @@ export function DashboardTab({
     <div className="space-y-6">
       {/* Meta Performance Vision - Prominent Display */}
       {client.meta_performance_vision && (
-        <Card className="border-blue-200 bg-gradient-to-r from-blue-50 to-indigo-50 shadow-sm">
+        <Card className="border-ds-accent  shadow-sm">
           <CardContent className="pt-6">
             <div className="flex items-start gap-4">
-              <div className="p-3 bg-blue-100 rounded-full">
-                <Sparkles className="h-6 w-6 text-blue-600" />
+              <div className="p-3 bg-ds-accent-bg rounded-full">
+                <Sparkles className="h-6 w-6 text-ds-accent" />
               </div>
               <div className="flex-1">
-                <h2 className="text-lg font-semibold text-gray-900 mb-2 flex items-center gap-2">
+                <h2 className="text-lg font-semibold text-ink mb-2 flex items-center gap-2">
                   Meta Performance Vision
                 </h2>
-                <p className="text-gray-700 leading-relaxed">
+                <p className="text-ink-2 leading-relaxed">
                   {client.meta_performance_vision}
                 </p>
               </div>
@@ -61,13 +61,13 @@ export function DashboardTab({
 
       {/* Quick Actions or Additional Info */}
       {!client.meta_performance_vision && (
-        <Card className="border-gray-200 border-dashed bg-gray-50/50">
+        <Card className="border-line border-dashed bg-paper/50">
           <CardContent className="pt-6">
-            <div className="flex items-center gap-3 text-sm text-gray-600">
-              <Target className="h-5 w-5 text-gray-400" />
+            <div className="flex items-center gap-3 text-sm text-ink-3">
+              <Target className="h-5 w-5 text-ink-4" />
               <p>
-                <span className="font-medium text-gray-900">Tip:</span> Add a
-                Meta Performance Vision to help guide coaching focus and track
+                <span className="font-medium text-ink">Tip:</span> Add a Meta
+                Performance Vision to help guide coaching focus and track
                 long-term outcomes.
               </p>
             </div>

--- a/src/app/clients/[clientId]/components/empty-state-welcome.tsx
+++ b/src/app/clients/[clientId]/components/empty-state-welcome.tsx
@@ -27,101 +27,97 @@ export function EmptyStateWelcome({
     <div className="max-w-2xl mx-auto py-12">
       {/* Client Name Header */}
       <div className="mb-10">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
-          {client.name}
-        </h1>
-        <p className="text-gray-500 dark:text-gray-400">No sessions yet</p>
+        <h1 className="text-2xl font-bold text-ink mb-1">{client.name}</h1>
+        <p className="text-ink-3 ">No sessions yet</p>
       </div>
 
       {/* Primary Action - Start Session */}
       <div className="mb-8">
         <button
           onClick={onStartSession}
-          className="w-full group bg-gray-900 hover:bg-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700 rounded-xl p-6 text-left transition-all"
+          className="w-full group bg-ink hover:bg-ink-2 rounded-xl p-6 text-left transition-all"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-full bg-white/10 flex items-center justify-center">
-                <Mic className="h-6 w-6 text-white" />
+              <div className="w-12 h-12 rounded-full bg-surface-1/10 flex items-center justify-center">
+                <Mic className="h-6 w-6 text-ink-on-dark" />
               </div>
               <div>
-                <h3 className="text-lg font-semibold text-white mb-0.5">
+                <h3 className="text-lg font-semibold text-ink-on-dark mb-0.5">
                   Start Live Session
                 </h3>
-                <p className="text-sm text-gray-400">
+                <p className="text-sm text-ink-4">
                   Join a meeting with real-time AI insights
                 </p>
               </div>
             </div>
-            <ChevronRight className="h-5 w-5 text-gray-400 group-hover:text-white transition-colors" />
+            <ChevronRight className="h-5 w-5 text-ink-4 group-hover:text-ink-on-dark transition-colors" />
           </div>
         </button>
       </div>
 
       {/* Secondary Actions */}
       <div className="space-y-3">
-        <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-3">
+        <p className="text-xs font-medium text-ink-4 uppercase tracking-wide mb-3">
           Or choose another option
         </p>
 
         <button
           onClick={onScheduleSession}
-          className="w-full group flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all"
+          className="w-full group flex items-center justify-between p-4 rounded-lg border border-line hover:border-line-strong hover:bg-paper transition-all"
         >
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-              <CalendarClock className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center">
+              <CalendarClock className="h-5 w-5 text-ink-3 " />
             </div>
             <div className="text-left">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-white">
+              <h4 className="text-sm font-medium text-ink ">
                 Schedule Session
               </h4>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-ink-3 ">
                 Book a future session and send a questionnaire
               </p>
             </div>
           </div>
-          <ChevronRight className="h-4 w-4 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
+          <ChevronRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 transition-colors" />
         </button>
 
         <button
           onClick={onAddPastSession}
-          className="w-full group flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all"
+          className="w-full group flex items-center justify-between p-4 rounded-lg border border-line hover:border-line-strong hover:bg-paper transition-all"
         >
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-              <FileText className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center">
+              <FileText className="h-5 w-5 text-ink-3 " />
             </div>
             <div className="text-left">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-white">
+              <h4 className="text-sm font-medium text-ink ">
                 Add Past Session
               </h4>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Upload notes or recordings
-              </p>
+              <p className="text-xs text-ink-3 ">Upload notes or recordings</p>
             </div>
           </div>
-          <ChevronRight className="h-4 w-4 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
+          <ChevronRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 transition-colors" />
         </button>
 
         <button
           onClick={onSetGoals}
-          className="w-full group flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all"
+          className="w-full group flex items-center justify-between p-4 rounded-lg border border-line hover:border-line-strong hover:bg-paper transition-all"
         >
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-              <Target className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center">
+              <Target className="h-5 w-5 text-ink-3 " />
             </div>
             <div className="text-left">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-white">
+              <h4 className="text-sm font-medium text-ink ">
                 Set a meta performance vision
               </h4>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-ink-3 ">
                 Define outcomes to track progress
               </p>
             </div>
           </div>
-          <ChevronRight className="h-4 w-4 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
+          <ChevronRight className="h-4 w-4 text-ink-4 group-hover:text-ink-3 transition-colors" />
         </button>
       </div>
     </div>

--- a/src/app/clients/[clientId]/components/end-sprint-modal.tsx
+++ b/src/app/clients/[clientId]/components/end-sprint-modal.tsx
@@ -69,8 +69,8 @@ export function EndSprintModal({
       <AlertDialogContent>
         <AlertDialogHeader>
           <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 bg-orange-100 rounded-full">
-              <AlertTriangle className="h-5 w-5 text-orange-600" />
+            <div className="p-2 bg-amber-token-bg rounded-full">
+              <AlertTriangle className="h-5 w-5 text-amber-token" />
             </div>
             <AlertDialogTitle>End Sprint</AlertDialogTitle>
           </div>
@@ -83,7 +83,7 @@ export function EndSprintModal({
               ?
             </p>
 
-            <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-700">
+            <div className="bg-paper rounded-lg p-3 text-sm text-ink-2">
               <p>
                 <strong>Sprint Period:</strong>{' '}
                 {formatDate(sprint.start_date, 'MMM d, yyyy')} -{' '}
@@ -95,33 +95,33 @@ export function EndSprintModal({
             </div>
 
             {unfinishedCommitments.length > 0 && (
-              <div className="bg-orange-50 border border-orange-200 rounded-lg p-3">
-                <p className="text-sm font-semibold text-orange-900 mb-2">
+              <div className="bg-amber-token-bg border border-amber-token rounded-lg p-3">
+                <p className="text-sm font-semibold text-amber-token mb-2">
                   Unfinished Commitments ({unfinishedCommitments.length})
                 </p>
-                <p className="text-sm text-orange-700 mb-2">
+                <p className="text-sm text-amber-token mb-2">
                   The following commitments are not yet completed:
                 </p>
-                <ul className="text-sm text-orange-800 space-y-1 ml-4">
+                <ul className="text-sm text-amber-token space-y-1 ml-4">
                   {unfinishedCommitments.slice(0, 5).map((commitment: any) => (
                     <li key={commitment.id} className="list-disc">
                       {commitment.title}
                     </li>
                   ))}
                   {unfinishedCommitments.length > 5 && (
-                    <li className="list-none text-orange-600 font-medium">
+                    <li className="list-none text-amber-token font-medium">
                       +{unfinishedCommitments.length - 5} more...
                     </li>
                   )}
                 </ul>
-                <p className="text-xs text-orange-700 mt-2">
+                <p className="text-xs text-amber-token mt-2">
                   These commitments will be unlinked from this sprint and can be
                   added to future sprints.
                 </p>
               </div>
             )}
 
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-ink-3">
               This action will mark the sprint as completed. You can create a
               new sprint after ending this one.
             </p>
@@ -138,7 +138,7 @@ export function EndSprintModal({
           <Button
             onClick={handleEndSprint}
             disabled={isEnding}
-            className="bg-orange-600 hover:bg-orange-700 text-white"
+            className="bg-amber-token hover:bg-amber-token text-ink-on-dark"
           >
             {isEnding ? (
               <>

--- a/src/app/clients/[clientId]/components/goals-tree-view.tsx
+++ b/src/app/clients/[clientId]/components/goals-tree-view.tsx
@@ -114,9 +114,7 @@ function TreeNode({
           <Target
             className={cn(
               'h-4 w-4',
-              isCompleted
-                ? 'text-gray-400 dark:text-gray-500'
-                : 'text-gray-600 dark:text-gray-400',
+              isCompleted ? 'text-ink-4 ' : 'text-ink-3 ',
             )}
           />
         )
@@ -125,9 +123,7 @@ function TreeNode({
           <Zap
             className={cn(
               'h-4 w-4',
-              isCompleted
-                ? 'text-gray-400 dark:text-gray-500'
-                : 'text-blue-600',
+              isCompleted ? 'text-ink-4 ' : 'text-ds-accent',
             )}
           />
         )
@@ -136,9 +132,7 @@ function TreeNode({
           <Calendar
             className={cn(
               'h-4 w-4',
-              isCompleted
-                ? 'text-gray-400 dark:text-gray-500'
-                : 'text-green-600',
+              isCompleted ? 'text-ink-4 ' : 'text-forest',
             )}
           />
         )
@@ -149,13 +143,13 @@ function TreeNode({
     if (!data.status) return ''
     switch (data.status) {
       case 'active':
-        return 'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800'
+        return 'bg-forest-bg text-forest border-forest '
       case 'completed':
-        return 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent '
       case 'paused':
-        return 'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800'
+        return 'bg-amber-token-bg text-amber-token border-amber-token '
       default:
-        return 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 
@@ -163,7 +157,7 @@ function TreeNode({
     <div>
       <div
         className={cn(
-          'flex items-start gap-2 py-2 px-3 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors',
+          'flex items-start gap-2 py-2 px-3 rounded-lg cursor-pointer hover:bg-surface-3 transition-colors',
           isSelected && 'bg-primary/10 border border-primary/20',
         )}
         style={{ paddingLeft: `${indent + 12}px` }}
@@ -176,12 +170,12 @@ function TreeNode({
               e.stopPropagation()
               onToggle?.()
             }}
-            className="flex-shrink-0 p-0.5 mt-0.5 hover:bg-gray-200 dark:hover:bg-gray-800 rounded"
+            className="flex-shrink-0 p-0.5 mt-0.5 hover:bg-surface-3 rounded"
           >
             {isExpanded ? (
-              <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronDown className="h-4 w-4 text-ink-3 " />
             ) : (
-              <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronRight className="h-4 w-4 text-ink-3 " />
             )}
           </button>
         )}
@@ -195,9 +189,7 @@ function TreeNode({
         <span
           className={cn(
             'flex-1 text-sm font-medium break-words min-w-0',
-            isCompleted
-              ? 'text-gray-400 dark:text-gray-500 line-through'
-              : 'text-gray-900 dark:text-white',
+            isCompleted ? 'text-ink-4 line-through' : 'text-ink ',
           )}
         >
           {data.title}
@@ -205,7 +197,7 @@ function TreeNode({
 
         {/* Status Indicator (Green dot for active) */}
         {data.status === 'active' && (
-          <div className="w-2 h-2 rounded-full bg-green-500" title="Active" />
+          <div className="w-2 h-2 rounded-full bg-forest" title="Active" />
         )}
         {data.status && data.status !== 'active' && (
           <Badge variant="outline" className={cn('text-xs', getStatusColor())}>
@@ -217,8 +209,8 @@ function TreeNode({
         {(onEdit || onDelete || onComplete) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild onClick={e => e.stopPropagation()}>
-              <button className="flex-shrink-0 p-1 hover:bg-gray-200 dark:hover:bg-gray-800 rounded">
-                <MoreVertical className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <button className="flex-shrink-0 p-1 hover:bg-surface-3 rounded">
+                <MoreVertical className="h-4 w-4 text-ink-3 " />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -228,7 +220,7 @@ function TreeNode({
                     e.stopPropagation()
                     onComplete()
                   }}
-                  className="text-green-600 focus:text-green-600"
+                  className="text-forest focus:text-forest"
                 >
                   <CheckCircle2 className="h-4 w-4 mr-2" />
                   Mark Complete
@@ -256,7 +248,7 @@ function TreeNode({
                     e.stopPropagation()
                     onDelete()
                   }}
-                  className="text-red-600 focus:text-red-600"
+                  className="text-vermillion focus:text-vermillion"
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Delete{' '}
@@ -522,16 +514,16 @@ export function GoalsTreeView({
   // Empty state
   if (goals.length === 0) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700">
+      <Card className="border-line ">
         <CardContent className="p-12 text-center">
           <div className="max-w-md mx-auto">
-            <div className="h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mx-auto mb-4">
-              <Target className="h-8 w-8 text-gray-600 dark:text-gray-400" />
+            <div className="h-16 w-16 rounded-full bg-surface-3 flex items-center justify-center mx-auto mb-4">
+              <Target className="h-8 w-8 text-ink-3 " />
             </div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            <h3 className="text-lg font-semibold text-ink mb-2">
               No Vision Yet
             </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+            <p className="text-sm text-ink-3 mb-6">
               Create your first vision to get started with the tree view.
             </p>
             <Button onClick={onCreateNew} size="lg">
@@ -565,7 +557,7 @@ export function GoalsTreeView({
     <div className="space-y-3 h-full flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+        <h3 className="text-lg font-semibold text-ink ">
           Vision & Progress (Tree View)
         </h3>
         <Button variant="outline" size="sm" onClick={onCreateNew}>
@@ -584,7 +576,7 @@ export function GoalsTreeView({
         {/* Left Panel: Goals & Sprints */}
         <Card
           className={cn(
-            'border-gray-200 dark:border-gray-700 flex flex-col min-h-0',
+            'border-line flex flex-col min-h-0',
             sidebarCollapsed && 'hidden',
           )}
         >
@@ -592,8 +584,8 @@ export function GoalsTreeView({
             <ScrollArea className="h-[calc(100vh-220px)]">
               <div className="p-3 space-y-6">
                 {/* Vision Section */}
-                <div className="pb-4 border-b border-gray-200 dark:border-gray-700">
-                  <div className="flex items-center justify-between text-xs font-semibold text-gray-700 dark:text-gray-300 mb-3 px-2">
+                <div className="pb-4 border-b border-line ">
+                  <div className="flex items-center justify-between text-xs font-semibold text-ink-2 mb-3 px-2">
                     <span>VISION</span>
                     <div className="flex items-center gap-0.5">
                       <Tooltip>
@@ -606,13 +598,13 @@ export function GoalsTreeView({
                               'p-1 rounded transition-colors',
                               hideCompletedVisions
                                 ? 'text-primary bg-primary/10'
-                                : 'hover:bg-gray-200 dark:hover:bg-gray-800',
+                                : 'hover:bg-surface-3 ',
                             )}
                           >
                             {hideCompletedVisions ? (
                               <EyeOff className="h-3.5 w-3.5" />
                             ) : (
-                              <Eye className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400" />
+                              <Eye className="h-3.5 w-3.5 text-ink-3 " />
                             )}
                           </button>
                         </TooltipTrigger>
@@ -627,9 +619,9 @@ export function GoalsTreeView({
                           <TooltipTrigger asChild>
                             <button
                               onClick={onCreateGoal}
-                              className="p-1 hover:bg-gray-200 dark:hover:bg-gray-800 rounded transition-colors"
+                              className="p-1 hover:bg-surface-3 rounded transition-colors"
                             >
-                              <Plus className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400 cursor-pointer" />
+                              <Plus className="h-3.5 w-3.5 text-ink-3 cursor-pointer" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
@@ -688,7 +680,7 @@ export function GoalsTreeView({
 
                 {/* Outcomes Section - with Sprints as children */}
                 <div className="pb-4 border-b">
-                  <div className="flex items-center justify-between text-xs font-semibold text-gray-700 dark:text-gray-300 mb-3 px-2">
+                  <div className="flex items-center justify-between text-xs font-semibold text-ink-2 mb-3 px-2">
                     <span>META PERFORMANCE OUTCOMES</span>
                     <div className="flex items-center gap-0.5">
                       <Tooltip>
@@ -701,13 +693,13 @@ export function GoalsTreeView({
                               'p-1 rounded transition-colors',
                               hideCompletedOutcomes
                                 ? 'text-primary bg-primary/10'
-                                : 'hover:bg-gray-200 dark:hover:bg-gray-800',
+                                : 'hover:bg-surface-3 ',
                             )}
                           >
                             {hideCompletedOutcomes ? (
                               <EyeOff className="h-3.5 w-3.5" />
                             ) : (
-                              <Eye className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400" />
+                              <Eye className="h-3.5 w-3.5 text-ink-3 " />
                             )}
                           </button>
                         </TooltipTrigger>
@@ -722,9 +714,9 @@ export function GoalsTreeView({
                           <TooltipTrigger asChild>
                             <button
                               onClick={onCreateOutcome}
-                              className="p-1 hover:bg-gray-200 dark:hover:bg-gray-800 rounded transition-colors"
+                              className="p-1 hover:bg-surface-3 rounded transition-colors"
                             >
-                              <Plus className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400 cursor-pointer" />
+                              <Plus className="h-3.5 w-3.5 text-ink-3 cursor-pointer" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
@@ -791,7 +783,7 @@ export function GoalsTreeView({
 
                 {/* Sprint Timeline - with Outcomes as children */}
                 <div className="pb-4">
-                  <div className="flex items-center justify-between text-xs font-semibold text-gray-700 dark:text-gray-300 mb-3 px-2">
+                  <div className="flex items-center justify-between text-xs font-semibold text-ink-2 mb-3 px-2">
                     <span>SPRINTS</span>
                     <div className="flex items-center gap-0.5">
                       <Tooltip>
@@ -804,13 +796,13 @@ export function GoalsTreeView({
                               'p-1 rounded transition-colors',
                               hideCompletedSprints
                                 ? 'text-primary bg-primary/10'
-                                : 'hover:bg-gray-200 dark:hover:bg-gray-800',
+                                : 'hover:bg-surface-3 ',
                             )}
                           >
                             {hideCompletedSprints ? (
                               <EyeOff className="h-3.5 w-3.5" />
                             ) : (
-                              <Eye className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400" />
+                              <Eye className="h-3.5 w-3.5 text-ink-3 " />
                             )}
                           </button>
                         </TooltipTrigger>
@@ -825,9 +817,9 @@ export function GoalsTreeView({
                           <TooltipTrigger asChild>
                             <button
                               onClick={onCreateSprint}
-                              className="p-1 hover:bg-gray-200 dark:hover:bg-gray-800 rounded transition-colors"
+                              className="p-1 hover:bg-surface-3 rounded transition-colors"
                             >
-                              <Plus className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400 cursor-pointer" />
+                              <Plus className="h-3.5 w-3.5 text-ink-3 cursor-pointer" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
@@ -902,7 +894,7 @@ export function GoalsTreeView({
         <div
           className={cn('flex flex-col', !sidebarCollapsed && 'lg:col-span-2')}
         >
-          <Card className="border-gray-200 dark:border-gray-700 flex flex-col h-[calc(100vh-220px)]">
+          <Card className="border-line flex flex-col h-[calc(100vh-220px)]">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
@@ -923,7 +915,7 @@ export function GoalsTreeView({
                     <CardTitle className="text-sm font-semibold mb-1">
                       Commitments ({filteredCommitments.length})
                     </CardTitle>
-                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                    <p className="text-xs text-ink-3 ">
                       {getFilterDescription()}
                     </p>
                   </div>
@@ -995,7 +987,7 @@ export function GoalsTreeView({
                       <div className="space-y-3">
                         {/* Status Filter */}
                         <div className="space-y-1.5">
-                          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                          <span className="text-xs font-medium text-ink-2 ">
                             Status
                           </span>
                           <div className="flex flex-wrap gap-1">
@@ -1004,17 +996,17 @@ export function GoalsTreeView({
                               {
                                 value: 'active',
                                 label: 'To Do',
-                                color: 'bg-blue-400',
+                                color: 'bg-ds-accent',
                               },
                               {
                                 value: 'in_progress',
                                 label: 'In Progress',
-                                color: 'bg-yellow-400',
+                                color: 'bg-amber-token',
                               },
                               {
                                 value: 'completed',
                                 label: 'Done',
-                                color: 'bg-green-400',
+                                color: 'bg-forest',
                               },
                             ].map(opt => (
                               <Button
@@ -1030,13 +1022,13 @@ export function GoalsTreeView({
                                   'h-7 text-xs px-2.5',
                                   statusFilter === opt.value
                                     ? opt.value === 'all'
-                                      ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
+                                      ? 'bg-ink text-ink-on-dark '
                                       : opt.value === 'active'
-                                        ? 'bg-blue-600 text-white'
+                                        ? 'bg-ds-accent text-ink-on-dark'
                                         : opt.value === 'in_progress'
-                                          ? 'bg-yellow-600 text-white'
-                                          : 'bg-green-600 text-white'
-                                    : 'border-gray-200 text-gray-600 dark:border-gray-700 dark:text-gray-400',
+                                          ? 'bg-amber-token text-ink-on-dark'
+                                          : 'bg-forest text-ink-on-dark'
+                                    : 'border-line text-ink-3 ',
                                 )}
                               >
                                 {opt.color && (
@@ -1054,7 +1046,7 @@ export function GoalsTreeView({
                         </div>
                         {/* Priority Filter */}
                         <div className="space-y-1.5">
-                          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                          <span className="text-xs font-medium text-ink-2 ">
                             Priority
                           </span>
                           <div className="flex flex-wrap gap-1">
@@ -1063,22 +1055,22 @@ export function GoalsTreeView({
                               {
                                 value: 'low',
                                 label: 'Low',
-                                color: 'bg-gray-400',
+                                color: 'bg-line',
                               },
                               {
                                 value: 'medium',
                                 label: 'Medium',
-                                color: 'bg-yellow-400',
+                                color: 'bg-amber-token',
                               },
                               {
                                 value: 'high',
                                 label: 'High',
-                                color: 'bg-orange-400',
+                                color: 'bg-amber-token',
                               },
                               {
                                 value: 'urgent',
                                 label: 'Urgent',
-                                color: 'bg-red-500',
+                                color: 'bg-vermillion',
                               },
                             ].map(opt => (
                               <Button
@@ -1094,15 +1086,15 @@ export function GoalsTreeView({
                                   'h-7 text-xs px-2.5',
                                   priorityFilter === opt.value
                                     ? opt.value === 'all'
-                                      ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
+                                      ? 'bg-ink text-ink-on-dark '
                                       : opt.value === 'low'
-                                        ? 'bg-gray-600 text-white'
+                                        ? 'bg-ink-3 text-ink-on-dark'
                                         : opt.value === 'medium'
-                                          ? 'bg-yellow-600 text-white'
+                                          ? 'bg-amber-token text-ink-on-dark'
                                           : opt.value === 'high'
-                                            ? 'bg-orange-600 text-white'
-                                            : 'bg-red-600 text-white'
-                                    : 'border-gray-200 text-gray-600 dark:border-gray-700 dark:text-gray-400',
+                                            ? 'bg-amber-token text-ink-on-dark'
+                                            : 'bg-vermillion text-ink-on-dark'
+                                    : 'border-line text-ink-3 ',
                                 )}
                               >
                                 {opt.color && (
@@ -1124,7 +1116,7 @@ export function GoalsTreeView({
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="w-full h-7 text-xs text-gray-500"
+                            className="w-full h-7 text-xs text-ink-3"
                             onClick={() => {
                               setStatusFilter('all')
                               setPriorityFilter('all')
@@ -1139,10 +1131,8 @@ export function GoalsTreeView({
                 </div>
               </div>
               {/* Assignee Filter Buttons */}
-              <div className="flex items-center gap-1 mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
-                <span className="text-xs text-gray-500 dark:text-gray-400 mr-2">
-                  Show:
-                </span>
+              <div className="flex items-center gap-1 mt-3 pt-3 border-t border-line ">
+                <span className="text-xs text-ink-3 mr-2">Show:</span>
                 <Button
                   variant={assigneeFilter === 'all' ? 'default' : 'outline'}
                   size="sm"
@@ -1150,8 +1140,8 @@ export function GoalsTreeView({
                   className={cn(
                     'h-7 text-xs px-3',
                     assigneeFilter === 'all'
-                      ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
-                      : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800',
+                      ? 'bg-ink text-ink-on-dark '
+                      : 'border-line text-ink-3 hover:bg-paper ',
                   )}
                 >
                   All
@@ -1163,8 +1153,8 @@ export function GoalsTreeView({
                   className={cn(
                     'h-7 text-xs px-3',
                     assigneeFilter === 'client'
-                      ? 'bg-slate-600 text-white'
-                      : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800',
+                      ? 'bg-ink-3 text-ink-on-dark'
+                      : 'border-line text-ink-3 hover:bg-paper ',
                   )}
                 >
                   <User className="h-3 w-3 mr-1" />
@@ -1177,8 +1167,8 @@ export function GoalsTreeView({
                   className={cn(
                     'h-7 text-xs px-3',
                     assigneeFilter === 'coach'
-                      ? 'bg-amber-600 text-white'
-                      : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800',
+                      ? 'bg-amber-token text-ink-on-dark'
+                      : 'border-line text-ink-3 hover:bg-paper ',
                   )}
                 >
                   <Briefcase className="h-3 w-3 mr-1" />

--- a/src/app/clients/[clientId]/components/last-session-card.tsx
+++ b/src/app/clients/[clientId]/components/last-session-card.tsx
@@ -47,25 +47,23 @@ export function LastSessionCard({
 
   if (!lastSession) {
     return (
-      <Card className="border-gray-200 shadow-sm">
-        <CardHeader className="border-b border-gray-100">
+      <Card className="border-line shadow-sm">
+        <CardHeader className="border-b border-line">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-purple-50 rounded-lg">
-              <MessageSquare className="h-5 w-5 text-purple-600" />
+            <div className="p-2 bg-indigo-bg rounded-lg">
+              <MessageSquare className="h-5 w-5 text-indigo" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">
-                Last Session
-              </h2>
-              <p className="text-sm text-gray-500">Most recent coaching call</p>
+              <h2 className="text-lg font-semibold text-ink">Last Session</h2>
+              <p className="text-sm text-ink-3">Most recent coaching call</p>
             </div>
           </div>
         </CardHeader>
         <CardContent className="pt-6">
           <div className="text-center py-8">
-            <MessageSquare className="h-12 w-12 text-gray-300 mx-auto mb-3" />
-            <h3 className="text-gray-900 font-medium mb-1">No sessions yet</h3>
-            <p className="text-sm text-gray-500">
+            <MessageSquare className="h-12 w-12 text-ink-2 mx-auto mb-3" />
+            <h3 className="text-ink font-medium mb-1">No sessions yet</h3>
+            <p className="text-sm text-ink-3">
               Record your first session with {clientName} to see details here
             </p>
           </div>
@@ -76,8 +74,8 @@ export function LastSessionCard({
 
   if (isLoading) {
     return (
-      <Card className="border-gray-200 shadow-sm">
-        <CardHeader className="border-b border-gray-100">
+      <Card className="border-line shadow-sm">
+        <CardHeader className="border-b border-line">
           <div className="flex items-center gap-3">
             <Skeleton className="h-9 w-9 rounded-lg" />
             <div className="flex-1">
@@ -110,25 +108,23 @@ export function LastSessionCard({
   const score = summary?.final_overall_score
 
   return (
-    <Card className="border-gray-200 shadow-sm">
-      <CardHeader className="border-b border-gray-100">
+    <Card className="border-line shadow-sm">
+      <CardHeader className="border-b border-line">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-purple-50 rounded-lg">
-              <MessageSquare className="h-5 w-5 text-purple-600" />
+            <div className="p-2 bg-indigo-bg rounded-lg">
+              <MessageSquare className="h-5 w-5 text-indigo" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">
-                Last Session
-              </h2>
-              <p className="text-sm text-gray-500">Most recent coaching call</p>
+              <h2 className="text-lg font-semibold text-ink">Last Session</h2>
+              <p className="text-sm text-ink-3">Most recent coaching call</p>
             </div>
           </div>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => router.push(`/sessions/${lastSession.id}`)}
-            className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+            className="text-ds-accent hover:text-ds-accent hover:bg-ds-accent-bg"
           >
             View Details
             <ArrowRight className="h-4 w-4 ml-1" />
@@ -138,12 +134,12 @@ export function LastSessionCard({
       <CardContent className="pt-6 space-y-4">
         {/* Session Metadata */}
         <div className="flex items-center gap-6 text-sm flex-wrap">
-          <div className="flex items-center gap-2 text-gray-600">
+          <div className="flex items-center gap-2 text-ink-3">
             <Calendar className="h-4 w-4" />
             <span>{sessionDate}</span>
           </div>
           {duration && (
-            <div className="flex items-center gap-2 text-gray-600">
+            <div className="flex items-center gap-2 text-ink-3">
               <Clock className="h-4 w-4" />
               <span>{duration}</span>
             </div>
@@ -152,9 +148,11 @@ export function LastSessionCard({
             <Badge
               variant="outline"
               className={cn(
-                'bg-green-50 border-green-200 text-green-700',
-                score < 6 && 'bg-yellow-50 border-yellow-200 text-yellow-700',
-                score < 4 && 'bg-red-50 border-red-200 text-red-700',
+                'bg-forest-bg border-forest text-forest',
+                score < 6 &&
+                  'bg-amber-token-bg border-amber-token text-amber-token',
+                score < 4 &&
+                  'bg-vermillion-bg border-vermillion text-vermillion',
               )}
             >
               Score: {score.toFixed(1)}
@@ -164,12 +162,12 @@ export function LastSessionCard({
 
         {/* Session Summary */}
         {summary?.meeting_summary && (
-          <div className="pt-2 border-t border-gray-100">
+          <div className="pt-2 border-t border-line">
             <div className="flex items-center gap-2 mb-2">
-              <FileText className="h-4 w-4 text-gray-500" />
-              <h3 className="text-sm font-medium text-gray-900">Summary</h3>
+              <FileText className="h-4 w-4 text-ink-3" />
+              <h3 className="text-sm font-medium text-ink">Summary</h3>
             </div>
-            <p className="text-sm text-gray-600 line-clamp-3">
+            <p className="text-sm text-ink-3 line-clamp-3">
               {summary.meeting_summary}
             </p>
           </div>
@@ -177,10 +175,10 @@ export function LastSessionCard({
 
         {/* Key Topics/Insights */}
         {insights?.key_topics && insights.key_topics.length > 0 && (
-          <div className="pt-2 border-t border-gray-100">
+          <div className="pt-2 border-t border-line">
             <div className="flex items-center gap-2 mb-2">
-              <Lightbulb className="h-4 w-4 text-gray-500" />
-              <h3 className="text-sm font-medium text-gray-900">Key Topics</h3>
+              <Lightbulb className="h-4 w-4 text-ink-3" />
+              <h3 className="text-sm font-medium text-ink">Key Topics</h3>
             </div>
             <div className="flex flex-wrap gap-2">
               {insights.key_topics
@@ -189,7 +187,7 @@ export function LastSessionCard({
                   <Badge
                     key={idx}
                     variant="outline"
-                    className="bg-gray-50 border-gray-200 text-gray-700 text-xs"
+                    className="bg-paper border-line text-ink-2 text-xs"
                   >
                     {topic}
                   </Badge>
@@ -200,12 +198,10 @@ export function LastSessionCard({
 
         {/* Commitments from this session */}
         {activeCommitments.length > 0 && (
-          <div className="pt-2 border-t border-gray-100">
+          <div className="pt-2 border-t border-line">
             <div className="flex items-center gap-2 mb-2">
-              <Target className="h-4 w-4 text-gray-500" />
-              <h3 className="text-sm font-medium text-gray-900">
-                Commitments Made
-              </h3>
+              <Target className="h-4 w-4 text-ink-3" />
+              <h3 className="text-sm font-medium text-ink">Commitments Made</h3>
               <Badge variant="secondary" className="text-xs">
                 {activeCommitments.length}
               </Badge>
@@ -214,15 +210,15 @@ export function LastSessionCard({
               {activeCommitments.slice(0, 3).map(commitment => (
                 <li
                   key={commitment.id}
-                  className="text-sm text-gray-600 flex items-start gap-2"
+                  className="text-sm text-ink-3 flex items-start gap-2"
                 >
-                  <span className="text-gray-400 mt-1">•</span>
+                  <span className="text-ink-4 mt-1">•</span>
                   <span className="line-clamp-1">{commitment.title}</span>
                 </li>
               ))}
             </ul>
             {activeCommitments.length > 3 && (
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-ink-3 mt-1">
                 +{activeCommitments.length - 3} more
               </p>
             )}
@@ -230,15 +226,15 @@ export function LastSessionCard({
         )}
 
         {/* Status Badge */}
-        <div className="pt-2 border-t border-gray-100">
+        <div className="pt-2 border-t border-line">
           <Badge
             variant="outline"
             className={cn(
-              'bg-gray-50 border-gray-200 text-gray-700',
+              'bg-paper border-line text-ink-2',
               lastSession.status === 'completed' &&
-                'bg-green-50 border-green-200 text-green-700',
+                'bg-forest-bg border-forest text-forest',
               lastSession.status === 'in_progress' &&
-                'bg-blue-50 border-blue-200 text-blue-700',
+                'bg-ds-accent-bg border-ds-accent text-ds-accent',
             )}
           >
             {lastSession.status === 'completed'

--- a/src/app/clients/[clientId]/components/last-session-insights-card.tsx
+++ b/src/app/clients/[clientId]/components/last-session-insights-card.tsx
@@ -102,29 +102,29 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return <CheckCircle2 className="h-4 w-4 text-green-600" />
+        return <CheckCircle2 className="h-4 w-4 text-forest" />
       case 'in_progress':
-        return <PlayCircle className="h-4 w-4 text-blue-600" />
+        return <PlayCircle className="h-4 w-4 text-ds-accent" />
       default:
-        return <Circle className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+        return <Circle className="h-4 w-4 text-ink-3 " />
     }
   }
 
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'text-green-700 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-900/30 dark:border-green-800'
+        return 'text-forest bg-forest-bg border-forest '
       case 'in_progress':
-        return 'text-blue-700 bg-blue-50 border-blue-200 dark:text-blue-400 dark:bg-blue-900/30 dark:border-blue-800'
+        return 'text-ds-accent bg-ds-accent-bg border-ds-accent '
       default:
-        return 'text-gray-700 bg-gray-50 border-gray-200 dark:text-gray-300 dark:bg-gray-800 dark:border-gray-600'
+        return 'text-ink-2 bg-paper border-line '
     }
   }
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+    <div className="border border-line rounded-lg overflow-hidden">
       {/* Header - Always Visible */}
-      <div className="flex items-center justify-between gap-2 p-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+      <div className="flex items-center justify-between gap-2 p-3 hover:bg-paper transition-colors">
         <div className="flex items-center gap-2 flex-1 min-w-0">
           {/* Status Indicator Icon */}
           <div className="flex-shrink-0">
@@ -133,12 +133,12 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
 
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="flex-shrink-0 p-0.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+            className="flex-shrink-0 p-0.5 hover:bg-surface-3 rounded transition-colors"
           >
             {isExpanded ? (
-              <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronDown className="h-4 w-4 text-ink-3 " />
             ) : (
-              <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronRight className="h-4 w-4 text-ink-3 " />
             )}
           </button>
 
@@ -154,9 +154,8 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
           ) : (
             <p
               className={cn(
-                'text-sm font-medium flex-1 dark:text-gray-200',
-                commitment.status === 'completed' &&
-                  'line-through text-gray-500 dark:text-gray-500',
+                'text-sm font-medium flex-1 ',
+                commitment.status === 'completed' && 'line-through text-ink-3 ',
               )}
             >
               {commitment.title}
@@ -233,10 +232,10 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
 
       {/* Expanded Details */}
       {isExpanded && (
-        <div className="px-3 pb-3 pt-1 space-y-3 border-t border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+        <div className="px-3 pb-3 pt-1 space-y-3 border-t border-line bg-paper ">
           {/* Description */}
           <div>
-            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1 block">
+            <label className="text-xs font-semibold text-ink-2 mb-1 block">
               Description
             </label>
             {isEditing ? (
@@ -249,14 +248,14 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
                 placeholder="Add description..."
               />
             ) : (
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-ink-3 ">
                 {commitment.description || 'No description'}
               </p>
             )}
           </div>
 
           {/* Additional Info */}
-          <div className="flex flex-wrap gap-3 text-xs text-gray-600 dark:text-gray-400">
+          <div className="flex flex-wrap gap-3 text-xs text-ink-3 ">
             {commitment.priority && (
               <span>
                 Priority: <strong>{commitment.priority}</strong>
@@ -302,13 +301,11 @@ export function LastSessionInsightsCard({
 
   if (!session) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700">
+      <Card className="border-line ">
         <CardContent className="p-12 text-center">
-          <MessageSquare className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-          <h3 className="text-gray-900 dark:text-white font-medium mb-2">
-            No sessions yet
-          </h3>
-          <p className="text-gray-500 dark:text-gray-400 text-sm">
+          <MessageSquare className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+          <h3 className="text-ink font-medium mb-2">No sessions yet</h3>
+          <p className="text-ink-3 text-sm">
             Start your first coaching session to see insights here.
           </p>
         </CardContent>
@@ -319,11 +316,11 @@ export function LastSessionInsightsCard({
   const isLoading = detailsLoading || commitmentsLoading
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700">
-      <CardHeader className="border-b border-gray-200 dark:border-gray-700">
+    <Card className="border-line ">
+      <CardHeader className="border-b border-line ">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg font-semibold flex items-center gap-2">
-            <FileText className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <FileText className="h-5 w-5 text-ink-3 " />
             Last Session Insights
           </CardTitle>
           <Button
@@ -339,13 +336,13 @@ export function LastSessionInsightsCard({
 
       <CardContent className="p-6 pt-0 space-y-5">
         {/* Simplified Session Info Bar */}
-        <div className="flex items-center justify-between pb-3 border-b border-gray-100 dark:border-gray-700">
+        <div className="flex items-center justify-between pb-3 border-b border-line ">
           <div className="flex-1">
-            <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+            <h3 className="text-base font-semibold text-ink ">
               {session.title || 'Coaching Session'}
             </h3>
           </div>
-          <div className="flex items-center gap-3 text-sm text-gray-600 dark:text-gray-400">
+          <div className="flex items-center gap-3 text-sm text-ink-3 ">
             <span>
               {formatDate(session.started_at || session.created_at, 'MMM d')}
             </span>
@@ -357,7 +354,7 @@ export function LastSessionInsightsCard({
             </Badge>
             {sessionDetails?.sessionScore !== null &&
               sessionDetails?.sessionScore !== undefined && (
-                <div className="flex items-center gap-1 text-sm font-bold text-green-600 dark:text-green-400">
+                <div className="flex items-center gap-1 text-sm font-bold text-forest ">
                   <TrendingUp className="h-4 w-4" />
                   {sessionDetails.sessionScore.toFixed(1)}/10
                 </div>
@@ -377,10 +374,10 @@ export function LastSessionInsightsCard({
               sessionDetails?.meeting_summary?.meeting_summary ||
               session?.summary) && (
               <div>
-                <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                <h4 className="text-sm font-semibold text-ink-2 mb-2">
                   Session Summary
                 </h4>
-                <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                <p className="text-sm text-ink-3 leading-relaxed">
                   {sessionDetails?.summary ||
                     sessionDetails?.meeting_summary?.meeting_summary ||
                     session?.summary}
@@ -393,7 +390,7 @@ export function LastSessionInsightsCard({
               commitments.commitments &&
               commitments.commitments.length > 0 && (
                 <div>
-                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+                  <h4 className="text-sm font-semibold text-ink-2 mb-3 flex items-center gap-2">
                     <TargetIcon className="h-4 w-4" />
                     Commitments from This Session (
                     {commitments.commitments.length})
@@ -412,7 +409,7 @@ export function LastSessionInsightsCard({
 
             {/* Next Session Focus */}
             <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
-              <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+              <h4 className="text-sm font-semibold text-ink mb-2 flex items-center gap-2">
                 <TargetIcon className="h-4 w-4 text-primary" />
                 Next Session Focus
               </h4>
@@ -423,20 +420,20 @@ export function LastSessionInsightsCard({
                     .map((item: string, index: number) => (
                       <li
                         key={index}
-                        className="text-sm text-gray-700 dark:text-gray-300 flex items-start gap-2"
+                        className="text-sm text-ink-2 flex items-start gap-2"
                       >
                         <span className="text-primary mt-0.5">→</span>
                         <span>{item}</span>
                       </li>
                     ))}
                   {session.action_items.length > 3 && (
-                    <li className="text-xs text-gray-600 dark:text-gray-400 ml-5">
+                    <li className="text-xs text-ink-3 ml-5">
                       +{session.action_items.length - 3} more items
                     </li>
                   )}
                 </ul>
               ) : (
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-sm text-ink-3 ">
                   Review progress on current commitments and set new goals for
                   next session.
                 </p>

--- a/src/app/clients/[clientId]/components/overview-tab.tsx
+++ b/src/app/clients/[clientId]/components/overview-tab.tsx
@@ -151,14 +151,14 @@ export function OverviewTab({
       </div>
 
       {/* Simple Commitments Kanban Board */}
-      <Card className="border-gray-200 dark:border-gray-700">
+      <Card className="border-line ">
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <div>
               <CardTitle className="text-lg font-semibold">
                 Commitments ({totalCommitments})
               </CardTitle>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              <p className="text-sm text-ink-3 mt-1">
                 Track all commitments across outcomes and sprints
               </p>
             </div>
@@ -225,9 +225,7 @@ export function OverviewTab({
                 </Button>
               )}
               {isViewer && (
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  No commitments yet
-                </p>
+                <p className="text-sm text-ink-3 ">No commitments yet</p>
               )}
             </div>
           )}
@@ -235,11 +233,11 @@ export function OverviewTab({
       </Card>
 
       {/* Shared Resources Compact Card */}
-      <Card className="border-gray-200 dark:border-gray-700">
+      <Card className="border-line ">
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <BookOpen className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+              <BookOpen className="h-5 w-5 text-ink-2 " />
               <CardTitle className="text-lg font-semibold">
                 Shared Resources ({clientResourcesData?.total || 0})
               </CardTitle>
@@ -269,10 +267,10 @@ export function OverviewTab({
                 return (
                   <div
                     key={resource.id}
-                    className="flex items-center gap-3 p-2.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    className="flex items-center gap-3 p-2.5 rounded-lg hover:bg-paper transition-colors"
                   >
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                      <p className="text-sm font-medium text-ink truncate">
                         {resource.title}
                       </p>
                     </div>
@@ -282,7 +280,7 @@ export function OverviewTab({
                     >
                       {CATEGORY_LABELS[resource.category]}
                     </Badge>
-                    <span className="text-xs text-gray-400 shrink-0">
+                    <span className="text-xs text-ink-4 shrink-0">
                       {formatDate(resource.created_at)}
                     </span>
                   </div>
@@ -291,8 +289,8 @@ export function OverviewTab({
             </div>
           ) : (
             <div className="text-center py-6">
-              <BookOpen className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <BookOpen className="h-8 w-8 text-ink-2 mx-auto mb-2" />
+              <p className="text-sm text-ink-3 ">
                 No resources shared with {client.name} yet
               </p>
               {!isViewer && onShareResource && (

--- a/src/app/clients/[clientId]/components/session-card-compact.tsx
+++ b/src/app/clients/[clientId]/components/session-card-compact.tsx
@@ -60,20 +60,14 @@ export function SessionCardCompact({
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return (
-          <CheckCircle2 className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-        )
+        return <CheckCircle2 className="h-4 w-4 text-ink-2 " />
       case 'in_progress':
       case 'recording':
-        return (
-          <Circle className="h-4 w-4 text-gray-900 dark:text-white animate-pulse" />
-        )
+        return <Circle className="h-4 w-4 text-ink animate-pulse" />
       case 'error':
-        return (
-          <AlertCircle className="h-4 w-4 text-gray-800 dark:text-gray-200" />
-        )
+        return <AlertCircle className="h-4 w-4 text-ink-2 " />
       default:
-        return <Circle className="h-4 w-4 text-gray-400" />
+        return <Circle className="h-4 w-4 text-ink-4" />
     }
   }
 
@@ -82,26 +76,26 @@ export function SessionCardCompact({
     switch (status) {
       case 'completed':
         return (
-          <Badge className="bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white text-xs">
+          <Badge className="bg-ink text-ink-on-dark border-line text-xs">
             {statusText}
           </Badge>
         )
       case 'in_progress':
       case 'recording':
         return (
-          <Badge className="bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200 text-xs animate-pulse">
+          <Badge className="bg-ink-2 text-ink-on-dark border-line text-xs animate-pulse">
             {statusText}
           </Badge>
         )
       case 'error':
         return (
-          <Badge className="bg-gray-700 dark:bg-gray-300 text-white dark:text-gray-900 border-gray-700 dark:border-gray-300 text-xs">
+          <Badge className="bg-ink-2 text-ink-on-dark border-line text-xs">
             {statusText}
           </Badge>
         )
       default:
         return (
-          <Badge className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-700 text-xs">
+          <Badge className="bg-surface-3 text-ink-2 border-line text-xs">
             {statusText}
           </Badge>
         )
@@ -131,20 +125,18 @@ export function SessionCardCompact({
           {getStatusIcon(session.status)}
           <div>
             <div className="flex items-center gap-2">
-              <span className="font-semibold text-gray-900 dark:text-white">
+              <span className="font-semibold text-ink ">
                 {session.title || `${platformName} - ${formattedDate}`}
               </span>
               {showClient && clientName && (
                 <>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-gray-600 dark:text-gray-400">
-                    {clientName}
-                  </span>
+                  <span className="text-ink-4">•</span>
+                  <span className="text-ink-3 ">{clientName}</span>
                 </>
               )}
             </div>
             <div className="flex items-center gap-3 mt-1">
-              <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+              <div className="flex items-center gap-1 text-xs text-ink-3 ">
                 <Calendar className="h-3 w-3" />
                 <span>
                   {formatDate(sessionDate, 'EEEE')} •{' '}
@@ -153,8 +145,8 @@ export function SessionCardCompact({
               </div>
               {durationMinutes && (
                 <>
-                  <span className="text-gray-400">•</span>
-                  <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="text-ink-4">•</span>
+                  <div className="flex items-center gap-1 text-xs text-ink-3 ">
                     <Clock className="h-3 w-3" />
                     <span>{durationMinutes} minutes</span>
                   </div>
@@ -170,7 +162,7 @@ export function SessionCardCompact({
               variant="ghost"
               onClick={handleReanalyze}
               disabled={isReanalyzing}
-              className="h-7 px-2 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+              className="h-7 px-2 text-xs text-ink-3 hover:text-ink-2 hover:bg-surface-3 "
               title="Reanalyze session"
             >
               {isReanalyzing ? (
@@ -187,14 +179,14 @@ export function SessionCardCompact({
       {/* Summary Section */}
       {meetingSummary ? (
         <div className="pl-7">
-          <div className="p-3 bg-gradient-to-b from-gray-50 to-white dark:from-gray-800 dark:to-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <div className="p-3  border border-line rounded-lg">
             <div className="flex items-start gap-2">
-              <FileText className="h-4 w-4 text-gray-600 dark:text-gray-400 mt-0.5 flex-shrink-0" />
+              <FileText className="h-4 w-4 text-ink-3 mt-0.5 flex-shrink-0" />
               <div className="flex-1">
-                <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1 uppercase tracking-wider">
+                <p className="text-xs font-semibold text-ink-2 mb-1 uppercase tracking-wider">
                   Summary
                 </p>
-                <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed line-clamp-2">
+                <p className="text-sm text-ink-2 leading-relaxed line-clamp-2">
                   {meetingSummary}
                 </p>
               </div>
@@ -203,15 +195,13 @@ export function SessionCardCompact({
         </div>
       ) : session.status === 'completed' ? (
         <div className="pl-7">
-          <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg">
-            <p className="text-sm text-gray-600 dark:text-gray-400 italic">
-              Processing summary...
-            </p>
+          <div className="p-3 bg-paper border border-line rounded-lg">
+            <p className="text-sm text-ink-3 italic">Processing summary...</p>
           </div>
         </div>
       ) : session.status === 'in_progress' || session.status === 'recording' ? (
         <div className="pl-7">
-          <div className="p-3 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-lg">
+          <div className="p-3 bg-ink text-ink-on-dark rounded-lg">
             <div className="flex items-center gap-2">
               <Activity className="h-4 w-4 animate-pulse" />
               <p className="text-sm font-medium">

--- a/src/app/clients/[clientId]/components/session-card.tsx
+++ b/src/app/clients/[clientId]/components/session-card.tsx
@@ -112,27 +112,27 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
 
   return (
     <>
-      <div className="bg-white border-b border-gray-100 hover:bg-gray-50 transition-colors relative group">
+      <div className="bg-surface-1 border-b border-line hover:bg-paper transition-colors relative group">
         <Link href={`/sessions/${session.id}`} className="block p-6">
           <div className="space-y-4">
             {/* Header with date and status */}
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Calendar className="h-4 w-4 text-gray-600" />
+                <div className="p-2 bg-surface-3 rounded-lg">
+                  <Calendar className="h-4 w-4 text-ink-3" />
                 </div>
                 <div>
-                  <h4 className="font-medium text-gray-900">
+                  <h4 className="font-medium text-ink">
                     {formatDate(session.started_at || session.created_at)}
                   </h4>
                   <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-ink-3">
                       {formatTime(session.started_at || session.created_at)}
                     </span>
                     {duration && (
                       <>
-                        <span className="text-gray-300">•</span>
-                        <span className="text-sm text-gray-500 flex items-center gap-1">
+                        <span className="text-ink-2">•</span>
+                        <span className="text-sm text-ink-3 flex items-center gap-1">
                           <Clock className="h-3 w-3" />
                           {duration} min
                         </span>
@@ -142,17 +142,17 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <ChevronRight className="h-5 w-5 text-gray-400" />
+                <ChevronRight className="h-5 w-5 text-ink-4" />
               </div>
             </div>
 
             {/* Summary Section */}
             {(session.summary || meetingSummary?.meeting_summary) && (
-              <div className="bg-gray-50 rounded-lg p-4 border border-gray-100">
+              <div className="bg-paper rounded-lg p-4 border border-line">
                 <div className="flex items-start gap-2">
-                  <FileText className="h-4 w-4 text-gray-500 mt-0.5 flex-shrink-0" />
+                  <FileText className="h-4 w-4 text-ink-3 mt-0.5 flex-shrink-0" />
                   <div className="flex-1 space-y-2">
-                    <p className="text-sm text-gray-700 line-clamp-3">
+                    <p className="text-sm text-ink-2 line-clamp-3">
                       {session.summary || meetingSummary?.meeting_summary}
                     </p>
                   </div>
@@ -169,7 +169,7 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
                     <Badge
                       key={index}
                       variant="secondary"
-                      className="bg-gray-100 text-gray-700 border-0 text-xs"
+                      className="bg-surface-3 text-ink-2 border-0 text-xs"
                     >
                       {topic}
                     </Badge>
@@ -177,7 +177,7 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
                 {session.key_topics.length > 5 && (
                   <Badge
                     variant="outline"
-                    className="border-gray-200 text-gray-500 text-xs"
+                    className="border-line text-ink-3 text-xs"
                   >
                     +{session.key_topics.length - 5} more
                   </Badge>
@@ -189,8 +189,8 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
             {session.action_items && session.action_items.length > 0 && (
               <div className="space-y-1.5">
                 <div className="flex items-center gap-1.5">
-                  <Brain className="h-3.5 w-3.5 text-gray-500" />
-                  <span className="text-xs font-medium text-gray-600 uppercase tracking-wider">
+                  <Brain className="h-3.5 w-3.5 text-ink-3" />
+                  <span className="text-xs font-medium text-ink-3 uppercase tracking-wider">
                     Commitments
                   </span>
                 </div>
@@ -200,14 +200,14 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
                     .map((item: string, index: number) => (
                       <li
                         key={index}
-                        className="text-sm text-gray-600 flex items-start gap-1.5"
+                        className="text-sm text-ink-3 flex items-start gap-1.5"
                       >
-                        <span className="text-gray-400 mt-0.5">•</span>
+                        <span className="text-ink-4 mt-0.5">•</span>
                         <span className="line-clamp-1">{item}</span>
                       </li>
                     ))}
                   {session.action_items.length > 2 && (
-                    <li className="text-sm text-gray-500 italic">
+                    <li className="text-sm text-ink-3 italic">
                       +{session.action_items.length - 2} more commitments
                     </li>
                   )}
@@ -218,9 +218,9 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
             {/* Score if available */}
             {meetingSummary?.final_overall_score && (
               <div className="flex items-center gap-2 pt-2">
-                <div className="px-2.5 py-1 bg-gray-100 rounded-md">
-                  <span className="text-xs text-gray-500">Score: </span>
-                  <span className="text-sm font-medium text-gray-900">
+                <div className="px-2.5 py-1 bg-surface-3 rounded-md">
+                  <span className="text-xs text-ink-3">Score: </span>
+                  <span className="text-sm font-medium text-ink">
                     {meetingSummary.final_overall_score.toFixed(1)}/10
                   </span>
                 </div>
@@ -264,7 +264,7 @@ export default function SessionCard({ session, onDelete }: SessionCardProps) {
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                className="text-red-600 focus:text-red-700"
+                className="text-vermillion focus:text-vermillion"
                 onClick={e => {
                   e.preventDefault()
                   setShowDeleteDialog(true)

--- a/src/app/clients/[clientId]/components/sessions-list.tsx
+++ b/src/app/clients/[clientId]/components/sessions-list.tsx
@@ -36,37 +36,37 @@ export default function SessionsList({
   onSessionDeleted,
 }: SessionsListProps) {
   return (
-    <Card className="border-gray-200 shadow-sm rounded-xl overflow-hidden">
-      <CardHeader className="border-b border-gray-100 flex flex-row items-center justify-between bg-gray-50">
-        <CardTitle className="text-lg font-medium text-gray-900">
+    <Card className="border-line shadow-sm rounded-xl overflow-hidden">
+      <CardHeader className="border-b border-line flex flex-row items-center justify-between bg-paper">
+        <CardTitle className="text-lg font-medium text-ink">
           Coaching Sessions
         </CardTitle>
         <Button
           onClick={onUploadClick}
           size="sm"
           variant="outline"
-          className="border-gray-300 hover:bg-gray-100 text-gray-700"
+          className="border-line-strong hover:bg-surface-3 text-ink-2"
         >
           <Upload className="h-4 w-4 mr-2" />
           Upload Recording
         </Button>
       </CardHeader>
-      <CardContent className="p-0 bg-white">
+      <CardContent className="p-0 bg-surface-1">
         {sessions.length === 0 ? (
           <div className="text-center py-16">
-            <div className="mx-auto w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mb-4">
-              <Activity className="h-6 w-6 text-gray-400" />
+            <div className="mx-auto w-12 h-12 bg-surface-3 rounded-full flex items-center justify-center mb-4">
+              <Activity className="h-6 w-6 text-ink-4" />
             </div>
-            <h3 className="text-base font-medium text-gray-900 mb-2">
+            <h3 className="text-base font-medium text-ink mb-2">
               No sessions yet
             </h3>
-            <p className="text-sm text-gray-500 max-w-sm mx-auto mb-4">
+            <p className="text-sm text-ink-3 max-w-sm mx-auto mb-4">
               Start your first coaching session with {clientName}.
             </p>
             <Button
               onClick={onUploadClick}
               size="sm"
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 text-ink-on-dark "
             >
               <Upload className="h-4 w-4 mr-2" />
               Upload First Recording
@@ -83,11 +83,11 @@ export default function SessionsList({
             ))}
 
             {sessions.length >= 10 && (
-              <div className="p-4 text-center border-t border-gray-100 bg-gray-50">
+              <div className="p-4 text-center border-t border-line bg-paper">
                 <Link href={`/sessions?client=${clientId}`}>
                   <Button
                     variant="outline"
-                    className="border-gray-300 hover:bg-white text-gray-700"
+                    className="border-line-strong hover:bg-surface-1 text-ink-2"
                   >
                     View All Sessions
                   </Button>

--- a/src/app/clients/[clientId]/components/sessions-tab.tsx
+++ b/src/app/clients/[clientId]/components/sessions-tab.tsx
@@ -24,11 +24,11 @@ export function SessionsTab({
   const router = useRouter()
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden h-full flex flex-col">
-      <CardHeader className="border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+    <Card className="border-line shadow-sm overflow-hidden h-full flex flex-col">
+      <CardHeader className="border-b border-line flex-shrink-0">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-            <MessageSquare className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+          <h2 className="text-lg font-semibold text-ink flex items-center gap-2">
+            <MessageSquare className="h-5 w-5 text-ink-3 " />
             Coaching Sessions
           </h2>
           {!isViewer && (
@@ -46,9 +46,8 @@ export function SessionsTab({
               <div
                 key={session.id}
                 className={cn(
-                  'p-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer',
-                  index !== 0 &&
-                    'border-t border-gray-100 dark:border-gray-700',
+                  'p-4 hover:bg-paper transition-colors cursor-pointer',
+                  index !== 0 && 'border-t border-line ',
                 )}
                 onClick={() => router.push(`/sessions/${session.id}`)}
               >
@@ -64,11 +63,9 @@ export function SessionsTab({
         ) : (
           <div className="flex items-center justify-center h-full">
             <div className="text-center p-8">
-              <MessageSquare className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-              <h3 className="text-gray-900 dark:text-white font-medium mb-2">
-                No sessions yet
-              </h3>
-              <p className="text-gray-500 dark:text-gray-400 text-sm mb-4">
+              <MessageSquare className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+              <h3 className="text-ink font-medium mb-2">No sessions yet</h3>
+              <p className="text-ink-3 text-sm mb-4">
                 {isViewer
                   ? `No sessions have been recorded for ${client.name} yet.`
                   : `Start recording your first coaching session with ${client.name}`}
@@ -76,7 +73,7 @@ export function SessionsTab({
               {!isViewer && (
                 <Button
                   onClick={onAddSession}
-                  className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+                  className="bg-ink hover:bg-ink-2 text-ink-on-dark "
                 >
                   <Upload className="h-4 w-4 mr-2" />
                   Upload Recording

--- a/src/app/clients/[clientId]/components/share-resource-dialog.tsx
+++ b/src/app/clients/[clientId]/components/share-resource-dialog.tsx
@@ -159,9 +159,9 @@ export function ShareResourceDialog({
         </DialogHeader>
 
         {/* Client Selector */}
-        <div className="space-y-2 pb-3 border-b border-gray-100 dark:border-gray-800">
-          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
-            <Users className="h-3.5 w-3.5 text-gray-500" />
+        <div className="space-y-2 pb-3 border-b border-line ">
+          <label className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
+            <Users className="h-3.5 w-3.5 text-ink-3" />
             Share with
           </label>
 
@@ -171,13 +171,13 @@ export function ShareResourceDialog({
               {selectedClients.map((client: any) => (
                 <span
                   key={client.id}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-900 dark:bg-white text-white dark:text-gray-900"
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-ink text-ink-on-dark "
                 >
                   {client.name}
                   <button
                     type="button"
                     onClick={() => toggleClient(client.id)}
-                    className="hover:bg-white/20 dark:hover:bg-black/20 rounded-full p-0.5"
+                    className="hover:bg-surface-1/20 rounded-full p-0.5"
                   >
                     <X className="h-3 w-3" />
                   </button>
@@ -188,7 +188,7 @@ export function ShareResourceDialog({
 
           {/* Client search + dropdown */}
           <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
             <Input
               value={clientSearch}
               onChange={e => setClientSearch(e.target.value)}
@@ -212,7 +212,7 @@ export function ShareResourceDialog({
                     }}
                     className={cn(
                       'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border',
-                      'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500 hover:text-gray-900 dark:hover:text-white',
+                      'bg-surface-1 text-ink-3 border-line hover:border-line-strong hover:text-ink ',
                     )}
                   >
                     <Plus className="h-3 w-3" />
@@ -222,7 +222,7 @@ export function ShareResourceDialog({
               {filteredClients.filter((c: any) => !selectedClientIds.has(c.id))
                 .length === 0 &&
                 clientSearch.trim() && (
-                  <p className="text-xs text-gray-400 py-1">No clients found</p>
+                  <p className="text-xs text-ink-4 py-1">No clients found</p>
                 )}
             </div>
           )}
@@ -253,14 +253,14 @@ export function ShareResourceDialog({
               </div>
             ) : personalResources.length === 0 ? (
               <div className="text-center py-8">
-                <BookOpen className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <BookOpen className="h-10 w-10 text-ink-2 mx-auto mb-3" />
+                <p className="text-sm text-ink-3 ">
                   No personal resources to share. Create one first.
                 </p>
               </div>
             ) : (
               <>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                <p className="text-xs text-ink-3 mb-2">
                   Select resources to share
                 </p>
                 {personalResources.map(resource => (
@@ -277,8 +277,8 @@ export function ShareResourceDialog({
 
           <TabsContent value="new" className="mt-4">
             <div className="flex flex-col items-center justify-center py-8">
-              <Plus className="h-10 w-10 text-gray-400 dark:text-gray-500 mb-3" />
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 text-center">
+              <Plus className="h-10 w-10 text-ink-4 mb-3" />
+              <p className="text-sm text-ink-3 mb-4 text-center">
                 Create a new resource to share
               </p>
               <Button onClick={onCreateNew}>
@@ -290,7 +290,7 @@ export function ShareResourceDialog({
         </Tabs>
 
         {selectedResourceIds.size > 0 && selectedClientIds.size > 0 && (
-          <DialogFooter className="pt-4 border-t border-gray-100 dark:border-gray-800">
+          <DialogFooter className="pt-4 border-t border-line ">
             <Button
               variant="outline"
               onClick={() => setSelectedResourceIds(new Set())}
@@ -300,7 +300,7 @@ export function ShareResourceDialog({
             <Button
               onClick={handleShare}
               disabled={shareResource.isPending}
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 "
             >
               {shareResource.isPending
                 ? 'Sharing...'
@@ -330,32 +330,26 @@ function ShareableResourceItem({
       onClick={onToggle}
       className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
         selected
-          ? 'border-gray-900 dark:border-white bg-gray-50 dark:bg-gray-800'
-          : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-500'
+          ? 'border-line bg-paper '
+          : 'border-line hover:border-line-strong '
       }`}
     >
       <div
         className={`w-5 h-5 rounded border-2 flex items-center justify-center shrink-0 ${
-          selected
-            ? 'border-gray-900 dark:border-white bg-gray-900 dark:bg-white'
-            : 'border-gray-300 dark:border-gray-500'
+          selected ? 'border-line bg-ink ' : 'border-line-strong '
         }`}
       >
-        {selected && (
-          <Check className="h-3 w-3 text-white dark:text-gray-900" />
-        )}
+        {selected && <Check className="h-3 w-3 text-ink-on-dark " />}
       </div>
       <div className={`p-1.5 rounded ${colors.bg} shrink-0`}>
         <Icon className={`h-3.5 w-3.5 ${colors.text}`} />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+        <p className="text-sm font-medium text-ink truncate">
           {resource.title}
         </p>
         {resource.description && (
-          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
-            {resource.description}
-          </p>
+          <p className="text-xs text-ink-3 truncate">{resource.description}</p>
         )}
       </div>
       <Badge

--- a/src/app/clients/[clientId]/components/sprint-kanban-section.tsx
+++ b/src/app/clients/[clientId]/components/sprint-kanban-section.tsx
@@ -81,27 +81,27 @@ function SprintAccordionItem({
   const getStatusBadge = () => {
     if (isUpcoming) {
       return (
-        <Badge variant="secondary" className="bg-blue-100 text-blue-700">
+        <Badge variant="secondary" className="bg-ds-accent-bg text-ds-accent">
           Upcoming
         </Badge>
       )
     }
     if (isEnded) {
       return (
-        <Badge variant="secondary" className="bg-gray-100 text-gray-700">
+        <Badge variant="secondary" className="bg-surface-3 text-ink-2">
           Ended
         </Badge>
       )
     }
     return (
-      <Badge variant="default" className="bg-green-100 text-green-700">
+      <Badge variant="default" className="bg-forest-bg text-forest">
         Active
       </Badge>
     )
   }
 
   return (
-    <Card className="border-gray-200 shadow-sm hover:shadow-md transition-shadow">
+    <Card className="border-line shadow-sm hover:shadow-md transition-shadow">
       {/* Sprint Header - Always Visible */}
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-4">
@@ -111,9 +111,9 @@ function SprintAccordionItem({
           >
             <div className="flex-shrink-0 mt-1">
               {isExpanded ? (
-                <ChevronDown className="h-5 w-5 text-gray-600" />
+                <ChevronDown className="h-5 w-5 text-ink-3" />
               ) : (
-                <ChevronRight className="h-5 w-5 text-gray-600" />
+                <ChevronRight className="h-5 w-5 text-ink-3" />
               )}
             </div>
 
@@ -129,7 +129,7 @@ function SprintAccordionItem({
                 {sprint.goal && (
                   <Badge
                     variant="outline"
-                    className="bg-gray-50 border-gray-200 text-gray-700 text-xs"
+                    className="bg-paper border-line text-ink-2 text-xs"
                   >
                     <Target className="h-3 w-3 mr-1" />
                     {sprint.goal.title}
@@ -138,7 +138,7 @@ function SprintAccordionItem({
               </div>
 
               {/* Date Range */}
-              <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">
+              <div className="flex items-center gap-2 text-sm text-ink-3 mb-2">
                 <Calendar className="h-3.5 w-3.5" />
                 <span>
                   {formatDate(sprint.start_date, 'MMM d')} -{' '}
@@ -161,9 +161,9 @@ function SprintAccordionItem({
 
               {/* Quick Stats (Collapsed View) */}
               {!isExpanded && (
-                <div className="flex items-center gap-4 text-xs text-gray-600">
+                <div className="flex items-center gap-4 text-xs text-ink-3">
                   <div className="flex items-center gap-1">
-                    <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+                    <CheckCircle2 className="h-3.5 w-3.5 text-forest" />
                     <span>
                       {completedCommitments}/{totalCommitments} Done
                     </span>
@@ -191,7 +191,7 @@ function SprintAccordionItem({
                   e.stopPropagation()
                   onEndSprint(sprint)
                 }}
-                className="border-orange-300 text-orange-700 hover:bg-orange-50"
+                className="border-amber-token text-amber-token hover:bg-amber-token-bg"
               >
                 End Sprint
               </Button>
@@ -205,16 +205,16 @@ function SprintAccordionItem({
         <CardContent className="pt-0 space-y-4">
           {/* Progress Bar */}
           <div className="space-y-2">
-            <div className="flex items-center justify-between text-xs text-gray-600">
+            <div className="flex items-center justify-between text-xs text-ink-3">
               <span>Commitment Progress</span>
               <span className="font-semibold">
                 {completedCommitments}/{totalCommitments} ({progressPercentage}
                 %)
               </span>
             </div>
-            <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+            <div className="h-2 bg-surface-3 rounded-full overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-primary to-primary/80 rounded-full transition-all duration-500"
+                className="h-full  rounded-full transition-all duration-500"
                 style={{ width: `${progressPercentage}%` }}
               />
             </div>
@@ -222,7 +222,7 @@ function SprintAccordionItem({
 
           {/* Description */}
           {sprint.description && (
-            <p className="text-sm text-gray-600 bg-gray-50 rounded-lg p-3">
+            <p className="text-sm text-ink-3 bg-paper rounded-lg p-3">
               {sprint.description}
             </p>
           )}
@@ -332,16 +332,16 @@ export function SprintKanbanSection({
   // No active sprints
   if (sprintsArray.length === 0) {
     return (
-      <Card className="border-gray-200">
+      <Card className="border-line">
         <CardContent className="p-12 text-center">
           <div className="max-w-md mx-auto">
             <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
               <Target className="h-8 w-8 text-primary" />
             </div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+            <h3 className="text-lg font-semibold text-ink mb-2">
               No Active Sprints
             </h3>
-            <p className="text-sm text-gray-600 mb-6">
+            <p className="text-sm text-ink-3 mb-6">
               Create a sprint to organize commitments and track progress over a
               6-8 week period. You can run multiple sprints concurrently.
             </p>
@@ -368,10 +368,10 @@ export function SprintKanbanSection({
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">
+          <h3 className="text-lg font-semibold text-ink">
             Active Sprints ({sprintsArray.length})
           </h3>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-ink-3">
             Organize commitments into time-boxed sprints
           </p>
         </div>

--- a/src/app/clients/[clientId]/components/sprints-tab.tsx
+++ b/src/app/clients/[clientId]/components/sprints-tab.tsx
@@ -46,15 +46,15 @@ export function SprintsTab({
 
         {/* Right: Commitments */}
         <div>
-          <Card className="border-gray-200 shadow-sm">
+          <Card className="border-line shadow-sm">
             <CardHeader>
               <div className="flex items-center justify-between">
                 <div>
                   <div className="flex items-center gap-2">
                     <Activity className="h-5 w-5" />
-                    <h3 className="font-semibold text-gray-900">Commitments</h3>
+                    <h3 className="font-semibold text-ink">Commitments</h3>
                   </div>
-                  <p className="text-sm text-gray-600 mt-1">
+                  <p className="text-sm text-ink-3 mt-1">
                     {selectedTargetId
                       ? 'Filtered by selected outcome'
                       : 'All active commitments'}

--- a/src/app/clients/[clientId]/components/unified-creation-modal.tsx
+++ b/src/app/clients/[clientId]/components/unified-creation-modal.tsx
@@ -70,44 +70,36 @@ export function UnifiedCreationModal({
       icon: Target,
       title: 'Vision',
       description: 'Long-term outcome',
-      color: 'text-gray-600 dark:text-gray-400',
-      bgColor:
-        'bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 border-gray-300 dark:border-gray-600',
-      selectedColor:
-        'bg-gray-100 dark:bg-gray-700 border-gray-400 dark:border-gray-500',
+      color: 'text-ink-3 ',
+      bgColor: 'bg-paper hover:bg-surface-3 border-line-strong ',
+      selectedColor: 'bg-surface-3 border-line-strong ',
     },
     {
       type: 'outcome' as const,
       icon: Zap,
       title: 'Coaching Outcome',
       description: 'Short-term win',
-      color: 'text-blue-600',
-      bgColor:
-        'bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 border-blue-300 dark:border-blue-700',
-      selectedColor:
-        'bg-blue-100 dark:bg-blue-900/40 border-blue-400 dark:border-blue-600',
+      color: 'text-ds-accent',
+      bgColor: 'bg-ds-accent-bg hover:bg-ds-accent-bg border-ds-accent ',
+      selectedColor: 'bg-ds-accent-bg border-ds-accent ',
     },
     {
       type: 'sprint' as const,
       icon: Calendar,
       title: 'Sprint',
       description: '6-8 week timeboxed period',
-      color: 'text-purple-600',
-      bgColor:
-        'bg-purple-50 dark:bg-purple-900/30 hover:bg-purple-100 dark:hover:bg-purple-900/50 border-purple-300 dark:border-purple-700',
-      selectedColor:
-        'bg-purple-100 dark:bg-purple-900/40 border-purple-400 dark:border-purple-600',
+      color: 'text-indigo',
+      bgColor: 'bg-indigo-bg hover:bg-indigo-bg border-indigo ',
+      selectedColor: 'bg-indigo-bg border-indigo ',
     },
     {
       type: 'commitment' as const,
       icon: CheckCircle2,
       title: 'Commitment',
       description: 'Actionable task or promise',
-      color: 'text-green-600',
-      bgColor:
-        'bg-green-50 dark:bg-green-900/30 hover:bg-green-100 dark:hover:bg-green-900/50 border-green-300 dark:border-green-700',
-      selectedColor:
-        'bg-green-100 dark:bg-green-900/40 border-green-400 dark:border-green-600',
+      color: 'text-forest',
+      bgColor: 'bg-forest-bg hover:bg-forest-bg border-forest ',
+      selectedColor: 'bg-forest-bg border-forest ',
     },
   ]
 
@@ -178,19 +170,17 @@ export function UnifiedCreationModal({
               >
                 <div
                   className={cn(
-                    'flex-shrink-0 p-3 rounded-lg bg-white dark:bg-gray-900',
+                    'flex-shrink-0 p-3 rounded-lg bg-surface-1 ',
                     option.selectedColor,
                   )}
                 >
                   <Icon className={cn('h-6 w-6', option.color)} />
                 </div>
                 <div className="flex-1">
-                  <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+                  <h4 className="text-base font-semibold text-ink mb-1">
                     {option.title}
                   </h4>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {option.description}
-                  </p>
+                  <p className="text-sm text-ink-3 ">{option.description}</p>
                 </div>
               </button>
             )

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -318,15 +318,15 @@ export default function ClientDetailPage({
   return (
     <ProtectedRoute loadingMessage="Loading client details...">
       <PageLayout>
-        <div className="min-h-screen bg-white dark:bg-gray-900">
+        <div className="min-h-screen bg-surface-1 ">
           {/* Simple Back Link */}
-          <div className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+          <div className="border-b border-line bg-surface-1 ">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => router.push('/clients')}
-                className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="text-ink-3 hover:text-ink hover:bg-surface-3 "
               >
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Clients
@@ -367,38 +367,38 @@ export default function ClientDetailPage({
                   className="space-y-6"
                 >
                   <div className="flex items-center justify-between">
-                    <TabsList className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-1 rounded-xl shadow-sm">
+                    <TabsList className="bg-surface-1 border border-line p-1 rounded-xl shadow-sm">
                       <TabsTrigger
                         value="overview"
-                        className="data-[state=active]:bg-black data-[state=active]:text-white dark:text-gray-400 dark:data-[state=active]:text-white rounded-lg"
+                        className="data-[state=active]:bg-ink data-[state=active]:text-ink-on-dark dark:data-[state=active]:text-ink-on-dark rounded-lg"
                       >
                         <LayoutDashboard className="h-4 w-4 mr-2" />
                         Overview
                       </TabsTrigger>
                       <TabsTrigger
                         value="sessions"
-                        className="data-[state=active]:bg-black data-[state=active]:text-white dark:text-gray-400 dark:data-[state=active]:text-white rounded-lg"
+                        className="data-[state=active]:bg-ink data-[state=active]:text-ink-on-dark dark:data-[state=active]:text-ink-on-dark rounded-lg"
                       >
                         <MessageSquare className="h-4 w-4 mr-2" />
                         Sessions & Chat
                       </TabsTrigger>
                       <TabsTrigger
                         value="goals"
-                        className="data-[state=active]:bg-black data-[state=active]:text-white dark:text-gray-400 dark:data-[state=active]:text-white rounded-lg"
+                        className="data-[state=active]:bg-ink data-[state=active]:text-ink-on-dark dark:data-[state=active]:text-ink-on-dark rounded-lg"
                       >
                         <Target className="h-4 w-4 mr-2" />
                         Vision & Progress
                       </TabsTrigger>
                       <TabsTrigger
                         value="wins"
-                        className="data-[state=active]:bg-black data-[state=active]:text-white dark:text-gray-400 dark:data-[state=active]:text-white rounded-lg"
+                        className="data-[state=active]:bg-ink data-[state=active]:text-ink-on-dark dark:data-[state=active]:text-ink-on-dark rounded-lg"
                       >
                         <Trophy className="h-4 w-4 mr-2" />
                         Wins
                       </TabsTrigger>
                       <TabsTrigger
                         value="resources"
-                        className="data-[state=active]:bg-black data-[state=active]:text-white dark:text-gray-400 dark:data-[state=active]:text-white rounded-lg"
+                        className="data-[state=active]:bg-ink data-[state=active]:text-ink-on-dark dark:data-[state=active]:text-ink-on-dark rounded-lg"
                       >
                         <BookOpen className="h-4 w-4 mr-2" />
                         Resources
@@ -421,7 +421,7 @@ export default function ClientDetailPage({
                             modalState.setIsScheduleSessionModalOpen(true)
                           }
                           variant="outline"
-                          className="border-gray-300 dark:border-gray-600"
+                          className="border-line-strong "
                         >
                           <CalendarClock className="h-4 w-4 mr-2" />
                           Schedule Session
@@ -585,8 +585,8 @@ export default function ClientDetailPage({
           <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                  <AlertTriangle className="h-5 w-5 text-red-600" />
+                <div className="p-2 bg-vermillion-bg rounded-full">
+                  <AlertTriangle className="h-5 w-5 text-vermillion" />
                 </div>
                 <AlertDialogTitle>Delete Client</AlertDialogTitle>
               </div>
@@ -595,10 +595,10 @@ export default function ClientDetailPage({
                   Are you sure you want to delete{' '}
                   <strong>{client?.name}</strong>?
                 </p>
-                <p className="text-sm text-red-600 font-medium">
+                <p className="text-sm text-vermillion font-medium">
                   This action cannot be undone. This will permanently delete:
                 </p>
-                <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1 ml-4">
+                <ul className="text-sm text-ink-2 space-y-1 ml-4">
                   <li>• All coaching sessions and transcripts</li>
                   <li>• Session insights and analysis</li>
                   <li>• Client persona and knowledge base</li>
@@ -614,7 +614,7 @@ export default function ClientDetailPage({
               <AlertDialogAction
                 onClick={handleDelete}
                 disabled={isDeleting}
-                className="bg-red-600 hover:bg-red-700 text-white"
+                className="bg-vermillion hover:bg-vermillion text-ink-on-dark"
               >
                 {isDeleting ? (
                   <>
@@ -644,8 +644,8 @@ export default function ClientDetailPage({
           <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                  <XCircle className="h-5 w-5 text-red-600" />
+                <div className="p-2 bg-vermillion-bg rounded-full">
+                  <XCircle className="h-5 w-5 text-vermillion" />
                 </div>
                 <AlertDialogTitle>Cancel Invitation</AlertDialogTitle>
               </div>
@@ -665,7 +665,7 @@ export default function ClientDetailPage({
                   handleCancelInvitation()
                 }}
                 disabled={isCancellingInvite}
-                className="bg-red-600 hover:bg-red-700 text-white"
+                className="bg-vermillion hover:bg-vermillion text-ink-on-dark"
               >
                 {isCancellingInvite ? (
                   <>
@@ -696,27 +696,27 @@ export default function ClientDetailPage({
           <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                  <AlertTriangle className="h-5 w-5 text-red-600" />
+                <div className="p-2 bg-vermillion-bg rounded-full">
+                  <AlertTriangle className="h-5 w-5 text-vermillion" />
                 </div>
                 <AlertDialogTitle>Delete Vision</AlertDialogTitle>
               </div>
               <AlertDialogDescription className="space-y-3">
                 <p>
                   Are you sure you want to delete the vision{' '}
-                  <span className="font-semibold text-gray-900 dark:text-white">
+                  <span className="font-semibold text-ink ">
                     &quot;{goalToDelete?.title}&quot;
                   </span>
                   ?
                 </p>
-                <div className="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-                  <p className="text-sm text-blue-800 dark:text-blue-300">
+                <div className="bg-ds-accent-bg border border-ds-accent rounded-lg p-3">
+                  <p className="text-sm text-ds-accent ">
                     <strong>Note:</strong> Deleting this vision will unlink it
                     from any associated outcomes. The outcomes themselves will
                     remain and stay linked to their sprints and commitments.
                   </p>
                 </div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-sm text-ink-3 ">
                   This action cannot be undone.
                 </p>
               </AlertDialogDescription>
@@ -731,7 +731,7 @@ export default function ClientDetailPage({
                   handleDeleteGoal()
                 }}
                 disabled={isDeletingGoal}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-vermillion hover:bg-vermillion"
               >
                 {isDeletingGoal ? (
                   <>
@@ -762,20 +762,20 @@ export default function ClientDetailPage({
           <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                  <AlertTriangle className="h-5 w-5 text-red-600" />
+                <div className="p-2 bg-vermillion-bg rounded-full">
+                  <AlertTriangle className="h-5 w-5 text-vermillion" />
                 </div>
                 <AlertDialogTitle>Delete Outcome</AlertDialogTitle>
               </div>
               <AlertDialogDescription className="space-y-3">
                 <p>
                   Are you sure you want to delete the outcome{' '}
-                  <span className="font-semibold text-gray-900 dark:text-white">
+                  <span className="font-semibold text-ink ">
                     &quot;{outcomeToDelete?.title}&quot;
                   </span>
                   ?
                 </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-sm text-ink-3 ">
                   This action cannot be undone. This will also delete all
                   associated commitments for this outcome.
                 </p>
@@ -791,7 +791,7 @@ export default function ClientDetailPage({
                   handleDeleteOutcome()
                 }}
                 disabled={isDeletingOutcome}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-vermillion hover:bg-vermillion"
               >
                 {isDeletingOutcome ? (
                   <>
@@ -822,27 +822,27 @@ export default function ClientDetailPage({
           <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                  <AlertTriangle className="h-5 w-5 text-red-600" />
+                <div className="p-2 bg-vermillion-bg rounded-full">
+                  <AlertTriangle className="h-5 w-5 text-vermillion" />
                 </div>
                 <AlertDialogTitle>Delete Sprint</AlertDialogTitle>
               </div>
               <AlertDialogDescription className="space-y-3">
                 <p>
                   Are you sure you want to delete the sprint{' '}
-                  <span className="font-semibold text-gray-900 dark:text-white">
+                  <span className="font-semibold text-ink ">
                     &quot;{sprintToDelete?.title}&quot;
                   </span>
                   ?
                 </p>
-                <div className="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-                  <p className="text-sm text-blue-800 dark:text-blue-300">
+                <div className="bg-ds-accent-bg border border-ds-accent rounded-lg p-3">
+                  <p className="text-sm text-ds-accent ">
                     <strong>Note:</strong> Deleting this sprint will unlink it
                     from any associated outcomes. The outcomes themselves will
                     remain.
                   </p>
                 </div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-sm text-ink-3 ">
                   This action cannot be undone.
                 </p>
               </AlertDialogDescription>
@@ -857,7 +857,7 @@ export default function ClientDetailPage({
                   handleDeleteSprint()
                 }}
                 disabled={isDeletingSprint}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-vermillion hover:bg-vermillion"
               >
                 {isDeletingSprint ? (
                   <>

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -40,6 +40,7 @@ import {
   Trophy,
   BookOpen,
   XCircle,
+  Eye,
 } from 'lucide-react'
 import {
   AlertDialog,
@@ -61,7 +62,7 @@ export default function ClientDetailPage({
 }: {
   params: Promise<{ clientId: string }>
 }) {
-  const { userId } = useAuth()
+  const { userId, hasClientAccess } = useAuth()
   const permissions = usePermissions()
   const isViewer = permissions.isViewer()
   const router = useRouter()
@@ -331,6 +332,20 @@ export default function ClientDetailPage({
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Clients
               </Button>
+              {client && hasClientAccess(client.id) && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    sessionStorage.setItem('view_as_client_id', client.id)
+                    sessionStorage.setItem('view_as_client_name', client.name)
+                    router.push('/client-portal/dashboard')
+                  }}
+                >
+                  <Eye className="h-4 w-4 mr-2" />
+                  View Client Portal
+                </Button>
+              )}
             </div>
           </div>
 

--- a/src/app/clients/components/client-card.tsx
+++ b/src/app/clients/components/client-card.tsx
@@ -84,7 +84,7 @@ export default function ClientCard({
 
   return (
     <Card
-      className="group border border-gray-200 bg-white rounded-xl hover:border-gray-300 hover:shadow-md transition-all duration-200 cursor-pointer"
+      className="group border border-line bg-surface-1 rounded-xl hover:border-line-strong hover:shadow-md transition-all duration-200 cursor-pointer"
       onClick={onView}
     >
       <CardContent className="p-5">
@@ -96,13 +96,13 @@ export default function ClientCard({
               <Avatar
                 className={`h-11 w-11 ${
                   isAssigned
-                    ? 'bg-blue-100 ring-2 ring-blue-200'
-                    : 'bg-gray-100 ring-2 ring-gray-200'
+                    ? 'bg-ds-accent-bg ring-2 ring-ds-accent'
+                    : 'bg-surface-3 ring-2 ring-line'
                 }`}
               >
                 <AvatarFallback
                   className={`text-sm font-semibold ${
-                    isAssigned ? 'text-blue-700' : 'text-gray-700'
+                    isAssigned ? 'text-ds-accent' : 'text-ink-2'
                   }`}
                 >
                   {getInitials(client.name)}
@@ -110,8 +110,8 @@ export default function ClientCard({
               </Avatar>
               {isActive && (
                 <div
-                  className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-white ${
-                    isAssigned ? 'bg-blue-500' : 'bg-green-500'
+                  className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-paper ${
+                    isAssigned ? 'bg-ds-accent' : 'bg-forest'
                   }`}
                 />
               )}
@@ -119,11 +119,11 @@ export default function ClientCard({
 
             {/* Name and Coach */}
             <div className="min-w-0">
-              <h3 className="font-semibold text-gray-900 truncate group-hover:text-gray-700 transition-colors">
+              <h3 className="font-semibold text-ink truncate group-hover:text-ink-2 transition-colors">
                 {client.name}
               </h3>
               {isAssigned && client.coach_name && (
-                <p className="text-xs text-blue-600 truncate">
+                <p className="text-xs text-ds-accent truncate">
                   Coach: {client.coach_name}
                 </p>
               )}
@@ -135,12 +135,12 @@ export default function ClientCard({
             {/* Status Badges */}
             <div className="flex items-center gap-1.5 mr-1">
               {client.invitation_status === 'invited' && (
-                <span className="px-2 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 rounded-full">
+                <span className="px-2 py-0.5 text-xs font-medium bg-indigo-bg text-indigo rounded-full">
                   Invited
                 </span>
               )}
               {client.invitation_status === 'accepted' && (
-                <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 rounded-full flex items-center gap-1">
+                <span className="px-2 py-0.5 text-xs font-medium bg-forest-bg text-forest rounded-full flex items-center gap-1">
                   <UserCheck className="h-3 w-3" />
                   Portal
                 </span>
@@ -156,7 +156,7 @@ export default function ClientCard({
                   className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={e => e.stopPropagation()}
                 >
-                  <MoreHorizontal className="h-4 w-4 text-gray-500" />
+                  <MoreHorizontal className="h-4 w-4 text-ink-3" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-40">
@@ -196,7 +196,7 @@ export default function ClientCard({
                             e.stopPropagation()
                             onCancelInvite()
                           }}
-                          className="text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/30"
+                          className="text-vermillion focus:text-vermillion focus:bg-vermillion-bg "
                         >
                           <XCircle className="h-4 w-4 mr-2" />
                           Cancel Invitation
@@ -208,7 +208,7 @@ export default function ClientCard({
                         e.stopPropagation()
                         onDelete()
                       }}
-                      className="text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/30"
+                      className="text-vermillion focus:text-vermillion focus:bg-vermillion-bg "
                     >
                       <Trash2 className="h-4 w-4 mr-2" />
                       Delete Client
@@ -222,18 +222,16 @@ export default function ClientCard({
 
         {/* Notes */}
         {client.notes && (
-          <p className="text-sm text-gray-500 mt-3 line-clamp-2">
-            {client.notes}
-          </p>
+          <p className="text-sm text-ink-3 mt-3 line-clamp-2">{client.notes}</p>
         )}
 
         {/* Stats Row */}
-        <div className="flex items-center gap-4 mt-4 pt-4 border-t border-gray-100">
+        <div className="flex items-center gap-4 mt-4 pt-4 border-t border-line">
           {/* Sessions */}
           <div className="flex items-center gap-2">
-            <Calendar className="h-4 w-4 text-gray-400" />
-            <span className="text-sm text-gray-600">
-              <span className="font-medium text-gray-900">
+            <Calendar className="h-4 w-4 text-ink-4" />
+            <span className="text-sm text-ink-3">
+              <span className="font-medium text-ink">
                 {stats?.total_sessions || 0}
               </span>{' '}
               sessions
@@ -241,12 +239,12 @@ export default function ClientCard({
           </div>
 
           {/* Divider */}
-          <div className="w-px h-4 bg-gray-200" />
+          <div className="w-px h-4 bg-surface-3" />
 
           {/* Last Activity */}
           <div className="flex items-center gap-2">
-            <Clock className="h-4 w-4 text-gray-400" />
-            <span className="text-sm text-gray-600">
+            <Clock className="h-4 w-4 text-ink-4" />
+            <span className="text-sm text-ink-3">
               {formatLastSession(stats?.last_session_date)}
             </span>
           </div>

--- a/src/app/clients/components/clients-filters.tsx
+++ b/src/app/clients/components/clients-filters.tsx
@@ -96,10 +96,8 @@ export default function ClientsFilters({
         {/* Status Filter */}
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <Filter className="h-4 w-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-              Status:
-            </span>
+            <Filter className="h-4 w-4 text-ink-3 " />
+            <span className="text-sm font-medium text-ink-2 ">Status:</span>
           </div>
 
           <Popover open={statusPopoverOpen} onOpenChange={setStatusPopoverOpen}>
@@ -125,16 +123,16 @@ export default function ClientsFilters({
                       onStatusFilter(option.value)
                       setStatusPopoverOpen(false)
                     }}
-                    className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                    className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
                       statusFilter === option.value
-                        ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                        ? 'bg-surface-3 font-medium'
                         : ''
                     }`}
                   >
                     {option.icon}
                     <span className="flex-1 text-left">{option.label}</span>
                     {statusFilter === option.value && (
-                      <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                      <Check className="h-3 w-3 text-ink-3 " />
                     )}
                   </button>
                 ))}
@@ -146,10 +144,8 @@ export default function ClientsFilters({
         {/* Coach Filter */}
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <Users className="h-4 w-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-              Coach:
-            </span>
+            <Users className="h-4 w-4 text-ink-3 " />
+            <span className="text-sm font-medium text-ink-2 ">Coach:</span>
           </div>
 
           <Popover open={coachPopoverOpen} onOpenChange={setCoachPopoverOpen}>
@@ -168,9 +164,9 @@ export default function ClientsFilters({
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-[280px] p-0" align="start">
-              <div className="p-2 border-b dark:border-slate-700">
+              <div className="p-2 border-b ">
                 <div className="relative">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-slate-400 dark:text-slate-500" />
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-ink-4 " />
                   <Input
                     placeholder="Search coaches..."
                     value={coachSearch}
@@ -188,16 +184,14 @@ export default function ClientsFilters({
                       setCoachPopoverOpen(false)
                       setCoachSearch('')
                     }}
-                    className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
-                      selectedCoachId === null
-                        ? 'bg-slate-100 dark:bg-slate-800 font-medium'
-                        : ''
+                    className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
+                      selectedCoachId === null ? 'bg-surface-3 font-medium' : ''
                     }`}
                   >
                     <Users className="h-3 w-3" />
                     <span className="flex-1 text-left">All Coaches</span>
                     {selectedCoachId === null && (
-                      <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                      <Check className="h-3 w-3 text-ink-3 " />
                     )}
                   </button>
 
@@ -210,29 +204,29 @@ export default function ClientsFilters({
                         setCoachPopoverOpen(false)
                         setCoachSearch('')
                       }}
-                      className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                      className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
                         selectedCoachId === coach.id
-                          ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                          ? 'bg-surface-3 font-medium'
                           : ''
                       }`}
                     >
                       <User className="h-3 w-3" />
                       <span className="flex-1 text-left">{coach.name}</span>
                       {selectedCoachId === coach.id && (
-                        <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                        <Check className="h-3 w-3 text-ink-3 " />
                       )}
                     </button>
                   ))}
 
                   {filteredCoaches.length === 0 && (
-                    <div className="px-2 py-4 text-xs text-slate-500 dark:text-slate-400 text-center">
+                    <div className="px-2 py-4 text-xs text-ink-3 text-center">
                       No coaches found
                     </div>
                   )}
                 </div>
               </ScrollArea>
               {coaches.length > 0 && (
-                <div className="p-2 border-t dark:border-slate-700 text-xs text-slate-500 dark:text-slate-400 text-center">
+                <div className="p-2 border-t text-xs text-ink-3 text-center">
                   {coaches.length} coaches total
                 </div>
               )}
@@ -246,7 +240,7 @@ export default function ClientsFilters({
             variant="ghost"
             size="sm"
             onClick={onClearFilters}
-            className="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 text-xs"
+            className="text-ink-3 hover:text-ink-2 text-xs"
           >
             <X className="h-3 w-3 mr-1" />
             Clear filters
@@ -256,19 +250,19 @@ export default function ClientsFilters({
 
       {/* Active Filters Display */}
       {hasActiveFilters && (
-        <div className="p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg space-y-2">
+        <div className="p-3 bg-ds-accent-bg border border-ds-accent rounded-lg space-y-2">
           {statusFilter !== 'all' && (
             <div className="flex items-center gap-2">
-              <UserCheck className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-              <span className="text-sm font-medium text-blue-900 dark:text-blue-200">
+              <UserCheck className="h-4 w-4 text-ds-accent " />
+              <span className="text-sm font-medium text-ds-accent ">
                 Status: {currentStatusLabel}
               </span>
             </div>
           )}
           {selectedCoach && (
             <div className="flex items-center gap-2">
-              <Users className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-              <span className="text-sm font-medium text-blue-900 dark:text-blue-200">
+              <Users className="h-4 w-4 text-ds-accent " />
+              <span className="text-sm font-medium text-ds-accent ">
                 Coach: {selectedCoach.name}
               </span>
             </div>

--- a/src/app/clients/components/clients-list.tsx
+++ b/src/app/clients/components/clients-list.tsx
@@ -42,22 +42,19 @@ export default function ClientsList({
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {[...Array(6)].map((_, i) => (
-          <Card
-            key={i}
-            className="border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 rounded-xl"
-          >
+          <Card key={i} className="border border-line bg-surface-1 rounded-xl">
             <CardContent className="p-5">
               <div className="flex items-center gap-3">
-                <div className="h-11 w-11 bg-gray-100 dark:bg-gray-800 rounded-full animate-pulse" />
+                <div className="h-11 w-11 bg-surface-3 rounded-full animate-pulse" />
                 <div className="flex-1">
-                  <div className="h-5 w-28 bg-gray-100 dark:bg-gray-800 rounded animate-pulse" />
-                  <div className="h-3 w-20 bg-gray-100 dark:bg-gray-800 rounded animate-pulse mt-2" />
+                  <div className="h-5 w-28 bg-surface-3 rounded animate-pulse" />
+                  <div className="h-3 w-20 bg-surface-3 rounded animate-pulse mt-2" />
                 </div>
               </div>
-              <div className="h-4 w-full bg-gray-50 dark:bg-gray-800 rounded animate-pulse mt-4" />
-              <div className="flex gap-4 mt-4 pt-4 border-t border-gray-100 dark:border-gray-700">
-                <div className="h-4 w-20 bg-gray-50 dark:bg-gray-800 rounded animate-pulse" />
-                <div className="h-4 w-24 bg-gray-50 dark:bg-gray-800 rounded animate-pulse" />
+              <div className="h-4 w-full bg-paper rounded animate-pulse mt-4" />
+              <div className="flex gap-4 mt-4 pt-4 border-t border-line ">
+                <div className="h-4 w-20 bg-paper rounded animate-pulse" />
+                <div className="h-4 w-24 bg-paper rounded animate-pulse" />
               </div>
             </CardContent>
           </Card>
@@ -69,15 +66,15 @@ export default function ClientsList({
   // Error state
   if (error) {
     return (
-      <Card className="border-0 bg-white dark:bg-gray-800 rounded-xl shadow-sm">
+      <Card className="border-0 bg-surface-1 rounded-xl shadow-sm">
         <CardContent className="p-12 text-center">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-red-100 rounded-full mb-4">
-            <AlertCircle className="h-8 w-8 text-red-600" />
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-vermillion-bg rounded-full mb-4">
+            <AlertCircle className="h-8 w-8 text-vermillion" />
           </div>
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          <h3 className="text-lg font-semibold text-ink mb-2">
             Failed to load clients
           </h3>
-          <p className="text-gray-500 dark:text-gray-400 mb-6">{error}</p>
+          <p className="text-ink-3 mb-6">{error}</p>
           <Button onClick={onRefetch} variant="outline">
             Try Again
           </Button>
@@ -89,15 +86,15 @@ export default function ClientsList({
   // Empty state
   if (myClients.length === 0 && assignedClients.length === 0) {
     return (
-      <Card className="border-0 bg-white dark:bg-gray-800 rounded-xl shadow-sm">
+      <Card className="border-0 bg-surface-1 rounded-xl shadow-sm">
         <CardContent className="p-12 text-center">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-full mb-4">
-            <Users className="h-8 w-8 text-gray-400" />
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-surface-3 rounded-full mb-4">
+            <Users className="h-8 w-8 text-ink-4" />
           </div>
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          <h3 className="text-lg font-semibold text-ink mb-2">
             {searchTerm ? 'No clients found' : 'No clients yet'}
           </h3>
-          <p className="text-gray-500 dark:text-gray-400 mb-6">
+          <p className="text-ink-3 mb-6">
             {searchTerm
               ? 'Try adjusting your search or filters'
               : 'Add your first client to start tracking coaching relationships'}
@@ -119,12 +116,8 @@ export default function ClientsList({
       {myClients.length > 0 && (
         <div className="space-y-4">
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              My Clients
-            </h2>
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              ({myClients.length})
-            </span>
+            <h2 className="text-lg font-semibold text-ink ">My Clients</h2>
+            <span className="text-sm text-ink-3 ">({myClients.length})</span>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {myClients.map(client => (
@@ -148,10 +141,10 @@ export default function ClientsList({
       {assignedClients.length > 0 && (
         <div className="space-y-4">
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            <h2 className="text-lg font-semibold text-ink ">
               Assigned Clients
             </h2>
-            <span className="text-sm text-blue-600">
+            <span className="text-sm text-ds-accent">
               ({assignedClients.length})
             </span>
           </div>

--- a/src/app/clients/components/clients-stats.tsx
+++ b/src/app/clients/components/clients-stats.tsx
@@ -18,48 +18,46 @@ export default function ClientsStats({
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
       {/* My Clients */}
-      <div className="flex items-center gap-3 bg-white p-4 rounded-xl border border-gray-100 shadow-sm">
-        <div className="w-12 h-12 bg-gray-900 rounded-xl flex items-center justify-center">
-          <Users className="h-5 w-5 text-white" />
+      <div className="flex items-center gap-3 bg-surface-1 p-4 rounded-xl border border-line shadow-sm">
+        <div className="w-12 h-12 bg-ink rounded-xl flex items-center justify-center">
+          <Users className="h-5 w-5 text-ink-on-dark" />
         </div>
         <div>
-          <p className="text-2xl font-bold text-gray-900">{myClientsCount}</p>
-          <p className="text-xs text-gray-500">My Clients</p>
+          <p className="text-2xl font-bold text-ink">{myClientsCount}</p>
+          <p className="text-xs text-ink-3">My Clients</p>
         </div>
       </div>
 
       {/* Assigned Clients */}
-      <div className="flex items-center gap-3 bg-white p-4 rounded-xl border border-gray-100 shadow-sm">
-        <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center">
-          <UserCheck className="h-5 w-5 text-white" />
+      <div className="flex items-center gap-3 bg-surface-1 p-4 rounded-xl border border-line shadow-sm">
+        <div className="w-12 h-12  rounded-xl flex items-center justify-center">
+          <UserCheck className="h-5 w-5 text-ink-on-dark" />
         </div>
         <div>
-          <p className="text-2xl font-bold text-gray-900">
-            {assignedClientsCount}
-          </p>
-          <p className="text-xs text-gray-500">Assigned</p>
+          <p className="text-2xl font-bold text-ink">{assignedClientsCount}</p>
+          <p className="text-xs text-ink-3">Assigned</p>
         </div>
       </div>
 
       {/* Total Sessions */}
-      <div className="flex items-center gap-3 bg-white p-4 rounded-xl border border-gray-100 shadow-sm">
-        <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center">
-          <Calendar className="h-5 w-5 text-gray-600" />
+      <div className="flex items-center gap-3 bg-surface-1 p-4 rounded-xl border border-line shadow-sm">
+        <div className="w-12 h-12 bg-surface-3 rounded-xl flex items-center justify-center">
+          <Calendar className="h-5 w-5 text-ink-3" />
         </div>
         <div>
-          <p className="text-2xl font-bold text-gray-900">{totalSessions}</p>
-          <p className="text-xs text-gray-500">Total Sessions</p>
+          <p className="text-2xl font-bold text-ink">{totalSessions}</p>
+          <p className="text-xs text-ink-3">Total Sessions</p>
         </div>
       </div>
 
       {/* Active This Week */}
-      <div className="flex items-center gap-3 bg-white p-4 rounded-xl border border-gray-100 shadow-sm">
-        <div className="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center">
-          <Clock className="h-5 w-5 text-green-600" />
+      <div className="flex items-center gap-3 bg-surface-1 p-4 rounded-xl border border-line shadow-sm">
+        <div className="w-12 h-12 bg-forest-bg rounded-xl flex items-center justify-center">
+          <Clock className="h-5 w-5 text-forest" />
         </div>
         <div>
-          <p className="text-2xl font-bold text-gray-900">{activeThisWeek}</p>
-          <p className="text-xs text-gray-500">Active This Week</p>
+          <p className="text-2xl font-bold text-ink">{activeThisWeek}</p>
+          <p className="text-xs text-ink-3">Active This Week</p>
         </div>
       </div>
     </div>

--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -165,20 +165,18 @@ export default function ClientsPage() {
   return (
     <ProtectedRoute loadingMessage="Loading clients...">
       <PageLayout>
-        <div className="min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900">
+        <div className="min-h-screen  ">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             {/* Page Header */}
-            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 mb-6">
+            <div className="bg-surface-1 rounded-2xl shadow-sm border border-line p-6 mb-6">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                 <div className="flex items-center gap-4">
-                  <div className="p-3 bg-gray-900 rounded-xl">
-                    <Users className="h-6 w-6 text-white" />
+                  <div className="p-3 bg-ink rounded-xl">
+                    <Users className="h-6 w-6 text-ink-on-dark" />
                   </div>
                   <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-                      Clients
-                    </h1>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                    <h1 className="text-2xl font-bold text-ink ">Clients</h1>
+                    <p className="text-sm text-ink-3 mt-0.5">
                       {isViewer
                         ? 'View assigned clients and their information'
                         : 'Manage and track your coaching relationships'}
@@ -190,7 +188,7 @@ export default function ClientsPage() {
                   {!isViewer && (
                     <Button
                       onClick={() => setIsCreateModalOpen(true)}
-                      className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+                      className="bg-ink hover:bg-ink-2 "
                     >
                       <Plus className="h-4 w-4 mr-2" />
                       Add Client
@@ -212,14 +210,14 @@ export default function ClientsPage() {
 
               {/* Viewer Notice */}
               {isViewer && (
-                <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg">
+                <div className="mt-4 p-4 bg-ds-accent-bg border border-ds-accent rounded-lg">
                   <div className="flex items-start gap-3">
-                    <Info className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
+                    <Info className="h-5 w-5 text-ds-accent mt-0.5" />
                     <div>
-                      <p className="text-sm font-medium text-blue-900 dark:text-blue-200">
+                      <p className="text-sm font-medium text-ds-accent ">
                         Viewer Access
                       </p>
-                      <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
+                      <p className="text-sm text-ds-accent mt-1">
                         You have read-only access to these assigned clients.
                         Contact your administrator to modify access levels.
                       </p>
@@ -233,19 +231,19 @@ export default function ClientsPage() {
             <div className="flex flex-col sm:flex-row gap-4 mb-6">
               {/* Search */}
               <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-4" />
                 <Input
                   placeholder="Search by name or notes..."
                   value={searchTerm}
                   onChange={e => setSearchTerm(e.target.value)}
-                  className="pl-10 pr-10 h-11 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
+                  className="pl-10 pr-10 h-11 bg-surface-1 border-line "
                 />
                 {searchTerm && (
                   <button
                     onClick={() => setSearchTerm('')}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:bg-surface-3 rounded-full"
                   >
-                    <X className="h-4 w-4 text-gray-400" />
+                    <X className="h-4 w-4 text-ink-4" />
                   </button>
                 )}
               </div>
@@ -255,8 +253,8 @@ export default function ClientsPage() {
                 value={sortBy}
                 onValueChange={(value: SortBy) => setSortBy(value)}
               >
-                <SelectTrigger className="w-[180px] h-11 bg-white dark:bg-gray-800">
-                  <ArrowUpDown className="h-4 w-4 mr-2 text-gray-400" />
+                <SelectTrigger className="w-[180px] h-11 bg-surface-1 ">
+                  <ArrowUpDown className="h-4 w-4 mr-2 text-ink-4" />
                   <SelectValue placeholder="Sort by" />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -97,28 +97,23 @@ const statusConfig: Record<
 > = {
   draft: {
     label: 'Draft',
-    className:
-      'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700',
+    className: 'bg-surface-3 text-ink-3 border-line ',
   },
   active: {
     label: 'Active',
-    className:
-      'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800',
+    className: 'bg-ds-accent-bg text-ds-accent border-ds-accent ',
   },
   in_progress: {
     label: 'In Progress',
-    className:
-      'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800',
+    className: 'bg-amber-token-bg text-amber-token border-amber-token ',
   },
   completed: {
     label: 'Completed',
-    className:
-      'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800',
+    className: 'bg-forest-bg text-forest border-forest ',
   },
   abandoned: {
     label: 'Abandoned',
-    className:
-      'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-200 dark:border-red-800',
+    className: 'bg-vermillion-bg text-vermillion border-vermillion ',
   },
 }
 
@@ -126,10 +121,10 @@ const priorityConfig: Record<
   CommitmentPriority,
   { label: string; className: string }
 > = {
-  low: { label: 'Low', className: 'text-gray-500' },
-  medium: { label: 'Medium', className: 'text-amber-600' },
-  high: { label: 'High', className: 'text-orange-600' },
-  urgent: { label: 'Urgent', className: 'text-red-600' },
+  low: { label: 'Low', className: 'text-ink-3' },
+  medium: { label: 'Medium', className: 'text-amber-token' },
+  high: { label: 'High', className: 'text-amber-token' },
+  urgent: { label: 'Urgent', className: 'text-vermillion' },
 }
 
 // --- Inline Commitment Row ---
@@ -191,8 +186,8 @@ function CommitmentRow({
   return (
     <div
       className={cn(
-        'flex items-start gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors',
-        isSelected && 'bg-blue-50/50 dark:bg-blue-900/10',
+        'flex items-start gap-3 px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper transition-colors',
+        isSelected && 'bg-ds-accent-bg/50 ',
       )}
     >
       {/* Checkbox for drafts */}
@@ -209,7 +204,7 @@ function CommitmentRow({
         {/* Title line */}
         <div className="flex items-center gap-2 flex-wrap">
           <span
-            className="text-sm font-medium text-gray-900 dark:text-white cursor-pointer hover:underline"
+            className="text-sm font-medium text-ink cursor-pointer hover:underline"
             onClick={() => onEdit(commitment)}
           >
             {commitment.title}
@@ -217,7 +212,7 @@ function CommitmentRow({
           {commitment.extracted_from_transcript && (
             <Badge
               variant="outline"
-              className="text-xs bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 border-purple-200 dark:border-purple-800"
+              className="text-xs bg-indigo-bg text-indigo border-indigo "
             >
               <Sparkles className="h-3 w-3 mr-1" />
               AI
@@ -233,14 +228,14 @@ function CommitmentRow({
 
         {/* Description */}
         {commitment.description && (
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate max-w-2xl">
+          <p className="text-xs text-ink-3 mt-0.5 truncate max-w-2xl">
             {commitment.description}
           </p>
         )}
 
         {/* Transcript context for drafts */}
         {isDraft && commitment.transcript_context && (
-          <p className="text-xs text-gray-400 italic mt-0.5 truncate max-w-xl">
+          <p className="text-xs text-ink-4 italic mt-0.5 truncate max-w-xl">
             &ldquo;{commitment.transcript_context}&rdquo;
           </p>
         )}
@@ -264,7 +259,7 @@ function CommitmentRow({
           <DropdownMenuContent align="end">
             {isDraft && (
               <DropdownMenuItem onClick={() => onConfirm(commitment.id)}>
-                <Check className="h-3.5 w-3.5 mr-2 text-green-500" />
+                <Check className="h-3.5 w-3.5 mr-2 text-forest" />
                 Approve
               </DropdownMenuItem>
             )}
@@ -272,7 +267,7 @@ function CommitmentRow({
               <DropdownMenuItem
                 onClick={() => onStatusChange(commitment.id, 'active')}
               >
-                <Target className="h-3.5 w-3.5 mr-2 text-blue-500" />
+                <Target className="h-3.5 w-3.5 mr-2 text-ds-accent" />
                 Active
               </DropdownMenuItem>
             )}
@@ -280,7 +275,7 @@ function CommitmentRow({
               <DropdownMenuItem
                 onClick={() => onStatusChange(commitment.id, 'completed')}
               >
-                <CheckCircle2 className="h-3.5 w-3.5 mr-2 text-green-500" />
+                <CheckCircle2 className="h-3.5 w-3.5 mr-2 text-forest" />
                 Completed
               </DropdownMenuItem>
             )}
@@ -288,7 +283,7 @@ function CommitmentRow({
               <DropdownMenuItem
                 onClick={() => onStatusChange(commitment.id, 'abandoned')}
               >
-                <XCircle className="h-3.5 w-3.5 mr-2 text-red-500" />
+                <XCircle className="h-3.5 w-3.5 mr-2 text-vermillion" />
                 Abandon
               </DropdownMenuItem>
             )}
@@ -300,12 +295,12 @@ function CommitmentRow({
           <PopoverTrigger asChild>
             <button
               className={cn(
-                'inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs border border-gray-200 dark:border-gray-700 cursor-pointer transition-colors hover:bg-gray-100 dark:hover:bg-gray-700',
+                'inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs border border-line cursor-pointer transition-colors hover:bg-surface-3 ',
                 isOverdue
-                  ? 'text-red-600 dark:text-red-400 font-medium border-red-200 dark:border-red-800'
+                  ? 'text-vermillion font-medium border-vermillion '
                   : daysUntil !== null && daysUntil <= 7
-                    ? 'text-amber-600 dark:text-amber-400'
-                    : 'text-gray-600 dark:text-gray-400',
+                    ? 'text-amber-token '
+                    : 'text-ink-3 ',
               )}
             >
               <Calendar className="h-3 w-3" />
@@ -342,7 +337,7 @@ function CommitmentRow({
             <Button
               variant="outline"
               size="sm"
-              className="h-7 px-2.5 text-xs text-green-600 border-green-200 dark:border-green-800 hover:bg-green-50 dark:hover:bg-green-900/20"
+              className="h-7 px-2.5 text-xs text-forest border-forest hover:bg-forest-bg "
               onClick={handleConfirm}
               disabled={actionLoading !== null}
             >
@@ -356,7 +351,7 @@ function CommitmentRow({
             <Button
               variant="outline"
               size="sm"
-              className="h-7 px-2.5 text-xs text-red-600 border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-900/20"
+              className="h-7 px-2.5 text-xs text-vermillion border-vermillion hover:bg-vermillion-bg "
               onClick={handleReject}
               disabled={actionLoading !== null}
             >
@@ -374,7 +369,7 @@ function CommitmentRow({
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 px-2 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+          className="h-7 px-2 text-xs text-ink-3 hover:text-ink-2 "
           onClick={() => onEdit(commitment)}
         >
           <Edit className="h-3 w-3 mr-1" />
@@ -385,7 +380,7 @@ function CommitmentRow({
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 px-2 text-xs text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+          className="h-7 px-2 text-xs text-vermillion hover:text-vermillion hover:bg-vermillion-bg "
           onClick={() => onDelete(commitment.id)}
         >
           <Trash2 className="h-3 w-3" />
@@ -620,7 +615,7 @@ export default function CommitmentsPage() {
     return (
       <PageLayout>
         <div className="flex items-center justify-center min-h-[60vh]">
-          <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+          <Loader2 className="h-8 w-8 animate-spin text-ink-4" />
         </div>
       </PageLayout>
     )
@@ -632,16 +627,14 @@ export default function CommitmentsPage() {
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-              Commitments
-            </h1>
-            <p className="text-gray-500 dark:text-gray-400 mt-1">
+            <h1 className="text-3xl font-bold text-ink ">Commitments</h1>
+            <p className="text-ink-3 mt-1">
               Track and manage commitments across all your clients
             </p>
           </div>
           <Button
             onClick={() => setCreatePanelOpen(true)}
-            className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+            className="bg-ink hover:bg-ink-2 text-ink-on-dark "
           >
             <Plus className="h-4 w-4 mr-2" />
             New Commitment
@@ -650,54 +643,50 @@ export default function CommitmentsPage() {
 
         {/* Stats Cards */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardContent className="p-4">
               <div className="flex items-center gap-2 mb-1">
-                <Target className="h-4 w-4 text-blue-500" />
-                <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
-                  Active
-                </span>
+                <Target className="h-4 w-4 text-ds-accent" />
+                <span className="text-xs text-ink-3 font-medium">Active</span>
               </div>
-              <p className="text-xl font-bold text-gray-900 dark:text-white">
+              <p className="text-xl font-bold text-ink ">
                 {stats?.total_active ?? activeCount}
               </p>
             </CardContent>
           </Card>
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardContent className="p-4">
               <div className="flex items-center gap-2 mb-1">
-                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+                <CheckCircle2 className="h-4 w-4 text-forest" />
+                <span className="text-xs text-ink-3 font-medium">
                   Completed
                 </span>
               </div>
-              <p className="text-xl font-bold text-gray-900 dark:text-white">
+              <p className="text-xl font-bold text-ink ">
                 {stats?.total_completed ?? completedCount}
               </p>
             </CardContent>
           </Card>
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardContent className="p-4">
               <div className="flex items-center gap-2 mb-1">
-                <AlertCircle className="h-4 w-4 text-red-500" />
-                <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
-                  At Risk
-                </span>
+                <AlertCircle className="h-4 w-4 text-vermillion" />
+                <span className="text-xs text-ink-3 font-medium">At Risk</span>
               </div>
-              <p className="text-xl font-bold text-gray-900 dark:text-white">
+              <p className="text-xl font-bold text-ink ">
                 {stats?.at_risk_count ?? 0}
               </p>
             </CardContent>
           </Card>
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardContent className="p-4">
               <div className="flex items-center gap-2 mb-1">
-                <TrendingUp className="h-4 w-4 text-emerald-500" />
-                <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+                <TrendingUp className="h-4 w-4 text-forest" />
+                <span className="text-xs text-ink-3 font-medium">
                   Completion Rate
                 </span>
               </div>
-              <p className="text-xl font-bold text-gray-900 dark:text-white">
+              <p className="text-xl font-bold text-ink ">
                 {stats?.completion_rate ?? 0}%
               </p>
             </CardContent>
@@ -707,7 +696,7 @@ export default function CommitmentsPage() {
         {/* Filters & Tabs Bar */}
         <div className="flex flex-wrap items-center gap-3 mb-6">
           {/* Tabs */}
-          <div className="flex items-center bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+          <div className="flex items-center bg-surface-3 rounded-lg p-1">
             {[
               {
                 key: 'all' as const,
@@ -728,8 +717,8 @@ export default function CommitmentsPage() {
                 className={cn(
                   'px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1.5',
                   activeTab === tab.key
-                    ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm'
-                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300',
+                    ? 'bg-surface-1 text-ink shadow-sm'
+                    : 'text-ink-3 hover:text-ink-2 ',
                 )}
               >
                 {tab.label}
@@ -738,8 +727,8 @@ export default function CommitmentsPage() {
                     className={cn(
                       'text-xs px-1.5 py-0.5 rounded-full',
                       activeTab === tab.key
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                        : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+                        ? 'bg-ink text-ink-on-dark '
+                        : 'bg-surface-3 text-ink-3 ',
                     )}
                   >
                     {tab.count}
@@ -753,7 +742,7 @@ export default function CommitmentsPage() {
 
           {/* Client filter */}
           <Select value={selectedClient} onValueChange={setSelectedClient}>
-            <SelectTrigger className="w-[180px] border-gray-200 dark:border-gray-700">
+            <SelectTrigger className="w-[180px] border-line ">
               <SelectValue placeholder="All Clients" />
             </SelectTrigger>
             <SelectContent>
@@ -773,7 +762,7 @@ export default function CommitmentsPage() {
             value={selectedType}
             onValueChange={v => setSelectedType(v as CommitmentType | 'all')}
           >
-            <SelectTrigger className="w-[160px] border-gray-200 dark:border-gray-700">
+            <SelectTrigger className="w-[160px] border-line ">
               <SelectValue placeholder="All Types" />
             </SelectTrigger>
             <SelectContent>
@@ -789,7 +778,7 @@ export default function CommitmentsPage() {
 
         {/* Bulk Draft Actions */}
         {activeTab === 'drafts' && draftCount > 0 && (
-          <Card className="border-amber-200 dark:border-amber-800/50 bg-amber-50/50 dark:bg-amber-950/20 mb-4">
+          <Card className="border-amber-token bg-amber-token-bg/50 mb-4">
             <CardContent className="py-3 px-4">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -797,7 +786,7 @@ export default function CommitmentsPage() {
                     checked={allDraftsSelected}
                     onCheckedChange={toggleAllDrafts}
                   />
-                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                  <span className="text-sm text-ink-2 ">
                     {selectedDraftIds.size > 0
                       ? `${selectedDraftIds.size} of ${allDraftIds.length} selected`
                       : `${allDraftIds.length} draft${allDraftIds.length !== 1 ? 's' : ''} pending review`}
@@ -811,7 +800,7 @@ export default function CommitmentsPage() {
                     disabled={
                       selectedDraftIds.size === 0 || bulkDiscard.isPending
                     }
-                    className="border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
+                    className="border-vermillion text-vermillion hover:bg-vermillion-bg "
                   >
                     {bulkDiscard.isPending ? (
                       <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
@@ -826,7 +815,7 @@ export default function CommitmentsPage() {
                     disabled={
                       selectedDraftIds.size === 0 || bulkConfirm.isPending
                     }
-                    className="bg-green-600 hover:bg-green-700 text-white"
+                    className="bg-forest hover:bg-forest text-ink-on-dark"
                   >
                     {bulkConfirm.isPending ? (
                       <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
@@ -843,15 +832,15 @@ export default function CommitmentsPage() {
 
         {/* Empty State */}
         {filteredCommitments.length === 0 && (
-          <Card className="border-gray-200 dark:border-gray-700">
+          <Card className="border-line ">
             <CardContent className="py-16 text-center">
-              <div className="inline-flex items-center justify-center w-14 h-14 bg-gray-100 dark:bg-gray-800 rounded-full mb-4">
-                <Target className="h-7 w-7 text-gray-400" />
+              <div className="inline-flex items-center justify-center w-14 h-14 bg-surface-3 rounded-full mb-4">
+                <Target className="h-7 w-7 text-ink-4" />
               </div>
-              <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+              <h3 className="text-base font-semibold text-ink mb-1">
                 No commitments found
               </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              <p className="text-sm text-ink-3 mb-4">
                 {activeTab === 'drafts'
                   ? 'No draft commitments to review. Drafts are created when AI extracts commitments from session transcripts.'
                   : 'Commitments are created during sessions or manually by coaches.'}
@@ -859,7 +848,7 @@ export default function CommitmentsPage() {
               <Button
                 variant="outline"
                 onClick={() => setCreatePanelOpen(true)}
-                className="border-gray-300 dark:border-gray-600"
+                className="border-line-strong "
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Create Commitment
@@ -876,39 +865,39 @@ export default function CommitmentsPage() {
               open={expandedClients.has(clientGroup.clientId)}
               onOpenChange={() => toggleClient(clientGroup.clientId)}
             >
-              <Card className="border-gray-200 dark:border-gray-700 overflow-hidden">
+              <Card className="border-line overflow-hidden">
                 {/* Client Header */}
                 <CollapsibleTrigger asChild>
-                  <button className="w-full flex items-center gap-3 px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors text-left">
+                  <button className="w-full flex items-center gap-3 px-5 py-4 hover:bg-paper transition-colors text-left">
                     <ChevronRight
                       className={cn(
-                        'h-4 w-4 text-gray-400 transition-transform flex-shrink-0',
+                        'h-4 w-4 text-ink-4 transition-transform flex-shrink-0',
                         expandedClients.has(clientGroup.clientId) &&
                           'rotate-90',
                       )}
                     />
-                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-900 dark:bg-white flex-shrink-0">
-                      <UserCircle className="h-4 w-4 text-white dark:text-gray-900" />
+                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-ink flex-shrink-0">
+                      <UserCircle className="h-4 w-4 text-ink-on-dark " />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+                      <h3 className="text-sm font-semibold text-ink ">
                         {clientGroup.clientName}
                       </h3>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
                       {clientGroup.draftCount > 0 && (
-                        <Badge className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs">
+                        <Badge className="bg-surface-3 text-ink-3 text-xs">
                           {clientGroup.draftCount} draft
                           {clientGroup.draftCount !== 1 && 's'}
                         </Badge>
                       )}
                       {clientGroup.activeCount > 0 && (
-                        <Badge className="bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs">
+                        <Badge className="bg-ds-accent-bg text-ds-accent text-xs">
                           {clientGroup.activeCount} active
                         </Badge>
                       )}
                       {clientGroup.completedCount > 0 && (
-                        <Badge className="bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 text-xs">
+                        <Badge className="bg-forest-bg text-forest text-xs">
                           {clientGroup.completedCount} done
                         </Badge>
                       )}
@@ -917,17 +906,17 @@ export default function CommitmentsPage() {
                 </CollapsibleTrigger>
 
                 <CollapsibleContent>
-                  <div className="border-t border-gray-100 dark:border-gray-800">
+                  <div className="border-t border-line ">
                     {clientGroup.sessions.map((session, idx) => (
                       <div key={session.sessionId || `manual-${idx}`}>
                         {/* Session Header */}
-                        <div className="flex items-center gap-2 px-5 py-2.5 bg-gray-50 dark:bg-gray-800/30 border-b border-gray-100 dark:border-gray-800">
+                        <div className="flex items-center gap-2 px-5 py-2.5 bg-paper border-b border-line ">
                           {session.sessionId ? (
-                            <Calendar className="h-3.5 w-3.5 text-gray-400" />
+                            <Calendar className="h-3.5 w-3.5 text-ink-4" />
                           ) : (
-                            <FileText className="h-3.5 w-3.5 text-gray-400" />
+                            <FileText className="h-3.5 w-3.5 text-ink-4" />
                           )}
-                          <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                          <span className="text-xs font-medium text-ink-3 ">
                             {session.sessionId
                               ? `Session - ${session.sessionDate ? formatDate(session.sessionDate, 'MMM d, yyyy') : 'Unknown date'}`
                               : 'Manually Created'}

--- a/src/app/components/attention-needed.tsx
+++ b/src/app/components/attention-needed.tsx
@@ -60,8 +60,8 @@ export function AttentionNeeded({ clients }: AttentionNeededProps) {
           icon: Clock,
           href: '/commitments',
           color:
-            'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border-red-200 dark:border-red-800 hover:bg-red-100 dark:hover:bg-red-900/30',
-          iconColor: 'text-red-500',
+            'bg-vermillion-bg text-vermillion border-vermillion hover:bg-vermillion-bg ',
+          iconColor: 'text-vermillion',
         }
       : null,
     staleClientCount > 0
@@ -70,8 +70,8 @@ export function AttentionNeeded({ clients }: AttentionNeededProps) {
           icon: UserX,
           href: '/clients',
           color:
-            'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800 hover:bg-amber-100 dark:hover:bg-amber-900/30',
-          iconColor: 'text-amber-500',
+            'bg-amber-token-bg text-amber-token border-amber-token hover:bg-amber-token-bg ',
+          iconColor: 'text-amber-token',
         }
       : null,
     draftCount > 0
@@ -80,8 +80,8 @@ export function AttentionNeeded({ clients }: AttentionNeededProps) {
           icon: FileEdit,
           href: '/commitments?tab=drafts',
           color:
-            'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/30',
-          iconColor: 'text-blue-500',
+            'bg-ds-accent-bg text-ds-accent border-ds-accent hover:bg-ds-accent-bg ',
+          iconColor: 'text-ds-accent',
         }
       : null,
   ].filter((item): item is AttentionItem => item !== null)

--- a/src/app/components/commitment-stats.tsx
+++ b/src/app/components/commitment-stats.tsx
@@ -12,7 +12,7 @@ export function CommitmentStatsRow() {
     return (
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
         {[1, 2, 3, 4].map(i => (
-          <Card key={i} className="border-gray-200 dark:border-gray-700">
+          <Card key={i} className="border-line ">
             <CardContent className="p-4">
               <Skeleton className="h-4 w-20 mb-2" />
               <Skeleton className="h-7 w-12" />
@@ -30,25 +30,25 @@ export function CommitmentStatsRow() {
       label: 'Active',
       value: stats.total_active,
       icon: Activity,
-      iconColor: 'text-blue-500',
+      iconColor: 'text-ds-accent',
     },
     {
       label: 'Completed',
       value: stats.total_completed,
       icon: CheckCircle2,
-      iconColor: 'text-green-500',
+      iconColor: 'text-forest',
     },
     {
       label: 'At Risk',
       value: stats.at_risk_count,
       icon: AlertCircle,
-      iconColor: stats.at_risk_count > 0 ? 'text-red-500' : 'text-gray-400',
+      iconColor: stats.at_risk_count > 0 ? 'text-vermillion' : 'text-ink-4',
     },
     {
       label: 'Completion Rate',
       value: `${stats.completion_rate}%`,
       icon: TrendingUp,
-      iconColor: 'text-emerald-500',
+      iconColor: 'text-forest',
     },
   ]
 
@@ -57,20 +57,15 @@ export function CommitmentStatsRow() {
       {items.map(item => {
         const Icon = item.icon
         return (
-          <Card
-            key={item.label}
-            className="border-gray-200 dark:border-gray-700"
-          >
+          <Card key={item.label} className="border-line ">
             <CardContent className="p-4">
               <div className="flex items-center gap-2 mb-1">
                 <Icon className={`h-4 w-4 ${item.iconColor}`} />
-                <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+                <span className="text-xs text-ink-3 font-medium">
                   {item.label}
                 </span>
               </div>
-              <p className="text-xl font-bold text-gray-900 dark:text-white">
-                {item.value}
-              </p>
+              <p className="text-xl font-bold text-ink ">{item.value}</p>
             </CardContent>
           </Card>
         )

--- a/src/app/components/live-session-banner.tsx
+++ b/src/app/components/live-session-banner.tsx
@@ -72,26 +72,24 @@ export default function LiveSessionBanner({
         return (
           <div
             key={session.id}
-            className="relative overflow-hidden rounded-xl border border-emerald-200 bg-gradient-to-r from-emerald-50 to-white dark:from-emerald-950/30 dark:to-gray-800 dark:border-emerald-800"
+            className="relative overflow-hidden rounded-xl border border-forest  "
           >
             <div className="flex items-center justify-between px-5 py-4">
               <div className="flex items-center gap-4">
                 {/* Pulsing live indicator */}
-                <div className="relative flex items-center justify-center w-10 h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/50">
-                  <Radio className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                  <span className="absolute inset-0 rounded-full bg-emerald-400/30 animate-ping" />
+                <div className="relative flex items-center justify-center w-10 h-10 rounded-full bg-forest-bg ">
+                  <Radio className="h-5 w-5 text-forest " />
+                  <span className="absolute inset-0 rounded-full bg-forest/30 animate-ping" />
                 </div>
 
                 <div>
                   <div className="flex items-center gap-2">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-                      {title}
-                    </h3>
+                    <h3 className="text-sm font-semibold text-ink ">{title}</h3>
                     {session.is_group_session && (
-                      <Users className="h-3.5 w-3.5 text-gray-500" />
+                      <Users className="h-3.5 w-3.5 text-ink-3" />
                     )}
                   </div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  <p className="text-xs text-ink-3 mt-0.5">
                     Started {formatRelativeTime(session.created_at)}
                   </p>
                 </div>
@@ -106,7 +104,7 @@ export default function LiveSessionBanner({
                   )
                 }
                 size="sm"
-                className="bg-emerald-600 hover:bg-emerald-700 text-white"
+                className="bg-forest hover:bg-forest text-ink-on-dark"
               >
                 {session.bot_id ? 'Rejoin Session' : 'View Session'}
                 <ArrowRight className="h-4 w-4 ml-1.5" />

--- a/src/app/components/my-commitments.tsx
+++ b/src/app/components/my-commitments.tsx
@@ -30,10 +30,10 @@ export function MyCommitments() {
 
   if (isLoading) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700 mb-6">
-        <CardHeader className="pb-3 border-b border-gray-200 dark:border-gray-700">
+      <Card className="border-line mb-6">
+        <CardHeader className="pb-3 border-b border-line ">
           <div className="flex items-center gap-2">
-            <CheckSquare className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <CheckSquare className="h-5 w-5 text-ink-3 " />
             <CardTitle className="text-base font-semibold">
               My Commitments
             </CardTitle>
@@ -56,18 +56,16 @@ export function MyCommitments() {
   // Show empty state if no coach commitments
   if (activeCommitments.length === 0) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700 mb-6">
-        <CardHeader className="pb-3 border-b border-gray-200 dark:border-gray-700">
+      <Card className="border-line mb-6">
+        <CardHeader className="pb-3 border-b border-line ">
           <CardTitle className="text-base font-semibold flex items-center gap-2">
-            <CheckSquare className="h-5 w-5 text-amber-600" />
+            <CheckSquare className="h-5 w-5 text-amber-token" />
             My Tasks
           </CardTitle>
         </CardHeader>
         <CardContent className="p-6 text-center">
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            No tasks assigned to you yet.
-          </p>
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          <p className="text-sm text-ink-3 ">No tasks assigned to you yet.</p>
+          <p className="text-xs text-ink-4 mt-1">
             Create a commitment and assign it to yourself from any client page.
           </p>
         </CardContent>
@@ -76,45 +74,43 @@ export function MyCommitments() {
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 mb-6">
-      <CardHeader className="pb-3 border-b border-gray-200 dark:border-gray-700">
+    <Card className="border-line mb-6">
+      <CardHeader className="pb-3 border-b border-line ">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-semibold flex items-center gap-2">
-            <CheckSquare className="h-5 w-5 text-amber-600" />
+            <CheckSquare className="h-5 w-5 text-amber-token" />
             My Tasks
           </CardTitle>
           <Badge
             variant="outline"
-            className="bg-amber-50 dark:bg-amber-900/30 border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-300"
+            className="bg-amber-token-bg border-amber-token text-amber-token "
           >
             {activeCommitments.length}
           </Badge>
         </div>
       </CardHeader>
       <CardContent className="p-0">
-        <div className="divide-y divide-gray-100 dark:divide-gray-800">
+        <div className="divide-y divide-line ">
           {activeCommitments.map(commitment => (
             <Link
               key={commitment.id}
               href={`/clients/${commitment.client_id}?tab=overview`}
-              className="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors group"
+              className="block px-4 py-3 hover:bg-paper transition-colors group"
             >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
-                  <h4 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                  <h4 className="text-sm font-medium text-ink truncate">
                     {commitment.title}
                   </h4>
-                  <div className="flex items-center gap-2 mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  <div className="flex items-center gap-2 mt-1 text-xs text-ink-3 ">
                     <User className="h-3 w-3" />
                     <span>{commitment.client_name || 'Client'}</span>
                     {commitment.target_date && (
                       <>
-                        <span className="text-gray-300 dark:text-gray-600">
-                          |
-                        </span>
+                        <span className="text-ink-2 ">|</span>
                         <Calendar className="h-3 w-3" />
                         {new Date(commitment.target_date) < now ? (
-                          <span className="text-red-500 font-medium">
+                          <span className="text-vermillion font-medium">
                             Overdue -{' '}
                             {formatDate(commitment.target_date, 'MMM d')}
                           </span>
@@ -127,7 +123,7 @@ export function MyCommitments() {
                     )}
                   </div>
                 </div>
-                <ArrowRight className="h-4 w-4 text-gray-400 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+                <ArrowRight className="h-4 w-4 text-ink-4 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             </Link>
           ))}

--- a/src/app/components/recent-clients.tsx
+++ b/src/app/components/recent-clients.tsx
@@ -25,16 +25,16 @@ export default function RecentClients({
 
   if (clientsLoading) {
     return (
-      <Card className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 h-full w-full">
-        <CardHeader className="pb-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="h-6 w-32 bg-gray-100 dark:bg-gray-800 rounded animate-pulse" />
+      <Card className="bg-surface-1 border border-line h-full w-full">
+        <CardHeader className="pb-4 border-b border-line ">
+          <div className="h-6 w-32 bg-surface-3 rounded animate-pulse" />
         </CardHeader>
         <CardContent className="p-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {[1, 2, 3, 4, 5, 6].map(i => (
               <div
                 key={i}
-                className="h-20 bg-gray-100 dark:bg-gray-800 rounded-lg animate-pulse w-full"
+                className="h-20 bg-surface-3 rounded-lg animate-pulse w-full"
               />
             ))}
           </div>
@@ -49,26 +49,24 @@ export default function RecentClients({
   // scoped to clients they own.
   if (myClients.length === 0) {
     return (
-      <Card className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
-        <CardHeader className="border-b border-gray-200 dark:border-gray-700 pb-4">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-            My Clients
-          </h2>
+      <Card className="bg-surface-1 border border-line ">
+        <CardHeader className="border-b border-line pb-4">
+          <h2 className="text-lg font-semibold text-ink ">My Clients</h2>
         </CardHeader>
         <CardContent className="p-6">
           <div className="text-center py-12">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-full mb-4">
-              <Users className="h-8 w-8 text-gray-400" />
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-surface-3 rounded-full mb-4">
+              <Users className="h-8 w-8 text-ink-4" />
             </div>
-            <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+            <h3 className="text-base font-semibold text-ink mb-2">
               No clients yet
             </h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+            <p className="text-sm text-ink-3 mb-6">
               Start building meaningful coaching relationships
             </p>
             <Button
               onClick={() => router.push('/clients')}
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 text-ink-on-dark "
             >
               Add Your First Client
               <Plus className="h-4 w-4 ml-2" />
@@ -83,21 +81,21 @@ export default function RecentClients({
     <div className="h-full flex flex-col w-full">
       {/* My Clients Section */}
       {myClients.length > 0 && (
-        <Card className="border border-gray-200 dark:border-gray-700 flex flex-col h-full w-full">
+        <Card className="border border-line flex flex-col h-full w-full">
           <CardHeader className="pb-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-900 dark:bg-white rounded-lg">
-                  <UserCircle className="h-5 w-5 text-white dark:text-gray-900" />
+                <div className="p-2 bg-ink rounded-lg">
+                  <UserCircle className="h-5 w-5 text-ink-on-dark " />
                 </div>
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                  <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
                     My Clients
-                    <Badge className="bg-gray-900 dark:bg-white text-white dark:text-gray-900">
+                    <Badge className="bg-ink text-ink-on-dark ">
                       {myClients.length}
                     </Badge>
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-ink-3 ">
                     Clients you created and manage
                   </p>
                 </div>
@@ -106,7 +104,7 @@ export default function RecentClients({
                 variant="ghost"
                 size="sm"
                 onClick={() => router.push('/clients')}
-                className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                className="text-ink-3 hover:text-ink "
               >
                 View All
                 <ChevronRight className="h-4 w-4 ml-1" />
@@ -133,7 +131,7 @@ export default function RecentClients({
                   variant="outline"
                   size="sm"
                   onClick={() => router.push('/clients')}
-                  className="border-gray-300 dark:border-gray-600 hover:border-gray-900 dark:hover:border-gray-400"
+                  className="border-line-strong hover:border-line "
                 >
                   View {myClients.length - 6} More Clients
                 </Button>

--- a/src/app/components/recent-sessions-to-review.tsx
+++ b/src/app/components/recent-sessions-to-review.tsx
@@ -30,14 +30,14 @@ export function RecentSessionsToReview() {
     <section className="mb-6">
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Users className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          <Users className="h-4 w-4 text-ink-3 " />
+          <h2 className="text-base font-semibold text-ink ">
             Recent sessions to review
           </h2>
         </div>
         <Link
           href="/sessions/shared"
-          className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700"
+          className="inline-flex items-center gap-1 text-sm font-medium text-indigo hover:text-indigo"
         >
           View all
           <ArrowRight className="h-3.5 w-3.5" />

--- a/src/app/components/recent-sessions.tsx
+++ b/src/app/components/recent-sessions.tsx
@@ -53,59 +53,57 @@ export default function RecentSessions({
     const isError = session.status === 'error'
 
     const statusDot = isLive
-      ? 'bg-emerald-500'
+      ? 'bg-forest'
       : isCompleted
-        ? 'bg-gray-900 dark:bg-white'
+        ? 'bg-ink '
         : isError
-          ? 'bg-red-500'
-          : 'bg-amber-500'
+          ? 'bg-vermillion'
+          : 'bg-amber-token'
 
     return (
       <div
-        className="flex items-start gap-4 px-5 py-4 border-b border-gray-100 dark:border-gray-800 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer group"
+        className="flex items-start gap-4 px-5 py-4 border-b border-line last:border-b-0 hover:bg-paper transition-colors cursor-pointer group"
         onClick={() => onViewDetails(session.id)}
       >
         {/* Client avatar */}
         <div className="relative flex-shrink-0">
-          <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-            <User className="h-5 w-5 text-gray-400" />
+          <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center">
+            <User className="h-5 w-5 text-ink-4" />
           </div>
           {/* Status dot */}
           <span
             className={cn(
-              'absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-white dark:border-gray-900',
+              'absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-paper ',
               statusDot,
             )}
           />
           {/* Live ping */}
           {isLive && (
-            <span className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-emerald-500 animate-ping" />
+            <span className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-forest animate-ping" />
           )}
         </div>
 
         {/* Content */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-0.5">
-            <h4 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+            <h4 className="text-sm font-semibold text-ink truncate">
               {clientName || 'Coaching Session'}
             </h4>
             {isLive && (
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium bg-forest-bg text-forest ">
                 Live
               </span>
             )}
           </div>
 
           {/* Meta line */}
-          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+          <div className="flex items-center gap-2 text-xs text-ink-3 ">
             <span>{formatDate(session.created_at, 'MMM d')}</span>
-            <span className="text-gray-300 dark:text-gray-600">&middot;</span>
+            <span className="text-ink-2 ">&middot;</span>
             <span>{formatRelativeTime(session.created_at)}</span>
             {durationMinutes && (
               <>
-                <span className="text-gray-300 dark:text-gray-600">
-                  &middot;
-                </span>
+                <span className="text-ink-2 ">&middot;</span>
                 <span className="inline-flex items-center gap-0.5">
                   <Clock className="h-3 w-3" />
                   {durationMinutes}m
@@ -116,49 +114,47 @@ export default function RecentSessions({
 
           {/* Summary — single line */}
           {!isViewer && meetingSummary && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate">
-              {meetingSummary}
-            </p>
+            <p className="text-xs text-ink-3 mt-1 truncate">{meetingSummary}</p>
           )}
           {isViewer && (
-            <p className="text-xs text-gray-400 mt-1 flex items-center gap-1">
+            <p className="text-xs text-ink-4 mt-1 flex items-center gap-1">
               <Lock className="h-3 w-3" />
               Content restricted
             </p>
           )}
           {!isViewer && !meetingSummary && isCompleted && (
-            <p className="text-xs text-gray-400 italic mt-1">
+            <p className="text-xs text-ink-4 italic mt-1">
               Processing summary...
             </p>
           )}
           {isLive && !meetingSummary && (
-            <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium mt-1">
+            <p className="text-xs text-forest font-medium mt-1">
               Recording in progress
             </p>
           )}
         </div>
 
         {/* Arrow */}
-        <ArrowRight className="h-4 w-4 text-gray-300 dark:text-gray-600 flex-shrink-0 mt-1 opacity-0 group-hover:opacity-100 transition-opacity" />
+        <ArrowRight className="h-4 w-4 text-ink-2 flex-shrink-0 mt-1 opacity-0 group-hover:opacity-100 transition-opacity" />
       </div>
     )
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 overflow-hidden">
+    <Card className="border-line overflow-hidden">
       {/* Header */}
       <CardHeader className="pb-0 pt-5 px-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-900 dark:bg-white rounded-lg">
-              <Video className="h-4 w-4 text-white dark:text-gray-900" />
+            <div className="p-2 bg-ink rounded-lg">
+              <Video className="h-4 w-4 text-ink-on-dark " />
             </div>
             <div>
-              <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+              <h3 className="text-base font-semibold text-ink ">
                 Recent Sessions
               </h3>
               {totalSessions > 0 && (
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-3 ">
                   {totalSessions} total session{totalSessions !== 1 && 's'}
                 </p>
               )}
@@ -168,7 +164,7 @@ export default function RecentSessions({
             variant="ghost"
             size="sm"
             onClick={() => router.push('/sessions')}
-            className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            className="text-ink-3 hover:text-ink "
           >
             View All
             <ArrowRight className="h-4 w-4 ml-1" />
@@ -180,10 +176,8 @@ export default function RecentSessions({
       <CardContent className="p-0 mt-4">
         {historyError && (
           <div className="text-center py-10 px-5">
-            <AlertCircle className="h-8 w-8 text-red-400 mx-auto mb-2" />
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
-              Failed to load sessions
-            </p>
+            <AlertCircle className="h-8 w-8 text-vermillion mx-auto mb-2" />
+            <p className="text-sm text-ink-3 mb-3">Failed to load sessions</p>
             <Button variant="outline" size="sm" onClick={onRefetch}>
               Try Again
             </Button>
@@ -191,13 +185,13 @@ export default function RecentSessions({
         )}
 
         {historyLoading && !meetingHistory && (
-          <div className="divide-y divide-gray-100 dark:divide-gray-800">
+          <div className="divide-y divide-line ">
             {[1, 2, 3].map(i => (
               <div key={i} className="flex items-start gap-4 px-5 py-4">
-                <div className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+                <div className="w-10 h-10 rounded-full bg-surface-3 animate-pulse flex-shrink-0" />
                 <div className="flex-1 space-y-2">
-                  <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3 animate-pulse" />
-                  <div className="h-3 bg-gray-100 dark:bg-gray-800 rounded w-1/2 animate-pulse" />
+                  <div className="h-4 bg-surface-3 rounded w-1/3 animate-pulse" />
+                  <div className="h-3 bg-surface-3 rounded w-1/2 animate-pulse" />
                 </div>
               </div>
             ))}
@@ -208,13 +202,13 @@ export default function RecentSessions({
           !historyError &&
           meetingHistory?.meetings.length === 0 && (
             <div className="text-center py-12 px-5">
-              <div className="inline-flex items-center justify-center w-12 h-12 bg-gray-100 dark:bg-gray-800 rounded-full mb-3">
-                <MessageSquare className="h-6 w-6 text-gray-400" />
+              <div className="inline-flex items-center justify-center w-12 h-12 bg-surface-3 rounded-full mb-3">
+                <MessageSquare className="h-6 w-6 text-ink-4" />
               </div>
-              <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+              <h3 className="text-sm font-semibold text-ink mb-1">
                 No sessions yet
               </h3>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-ink-3 ">
                 Start your first coaching session to see it here
               </p>
             </div>

--- a/src/app/components/start-recording.tsx
+++ b/src/app/components/start-recording.tsx
@@ -16,8 +16,8 @@ export default function StartRecording({
     <div>
       <MeetingFormSimple onSubmit={onSubmit} loading={loading} />
       {error && (
-        <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-sm text-red-700 flex items-center gap-2">
+        <div className="mt-4 p-3 bg-vermillion-bg border border-vermillion rounded-lg">
+          <p className="text-sm text-vermillion flex items-center gap-2">
             <AlertCircle className="h-4 w-4" />
             {error}
           </p>

--- a/src/app/components/system-status.tsx
+++ b/src/app/components/system-status.tsx
@@ -1,16 +1,16 @@
 export default function SystemStatus() {
   return (
-    <div className="mt-8 flex items-center justify-center gap-6 text-xs text-neutral-500 dark:text-neutral-400">
+    <div className="mt-8 flex items-center justify-center gap-6 text-xs text-ink-3 ">
       <div className="flex items-center gap-2">
-        <div className="w-1.5 h-1.5 bg-neutral-900 dark:bg-neutral-100 rounded-full"></div>
+        <div className="w-1.5 h-1.5 bg-ink rounded-full"></div>
         <span>System Online</span>
       </div>
       <div className="flex items-center gap-2">
-        <div className="w-1.5 h-1.5 bg-neutral-900 dark:bg-neutral-100 rounded-full"></div>
+        <div className="w-1.5 h-1.5 bg-ink rounded-full"></div>
         <span>AI Ready</span>
       </div>
       <div className="flex items-center gap-2">
-        <div className="w-1.5 h-1.5 bg-neutral-900 dark:bg-neutral-100 rounded-full"></div>
+        <div className="w-1.5 h-1.5 bg-ink rounded-full"></div>
         <span>Transcription Active</span>
       </div>
     </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -18,8 +18,8 @@ export default function Error({
   return (
     <div className="flex items-center justify-center min-h-[60vh] px-4">
       <div className="text-center max-w-md">
-        <div className="w-12 h-12 mx-auto mb-4 rounded-xl bg-red-50 dark:bg-red-900/20 flex items-center justify-center">
-          <AlertCircle className="h-6 w-6 text-red-500" />
+        <div className="w-12 h-12 mx-auto mb-4 rounded-xl bg-vermillion-bg flex items-center justify-center">
+          <AlertCircle className="h-6 w-6 text-vermillion" />
         </div>
         <h2 className="text-lg font-semibold text-app-primary mb-2">
           Something went wrong

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -13,7 +13,7 @@ export default function GlobalError({
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased bg-background text-foreground flex items-center justify-center min-h-screen">
         <div className="text-center px-8 max-w-md">
-          <div className="w-12 h-12 mx-auto mb-4 rounded-xl bg-red-50 dark:bg-red-900/20 flex items-center justify-center">
+          <div className="w-12 h-12 mx-auto mb-4 rounded-xl bg-vermillion-bg flex items-center justify-center">
             <svg
               width="24"
               height="24"
@@ -23,7 +23,7 @@ export default function GlobalError({
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
-              className="text-red-500"
+              className="text-vermillion"
             >
               <circle cx="12" cy="12" r="10" />
               <line x1="12" y1="8" x2="12" y2="12" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@ body {
   pointer-events: auto !important;
 }
 
-/* Custom Scrollbar Styles */
+/* Custom Scrollbar Styles — token-driven */
 .scrollbar-thin {
   scrollbar-width: thin;
 }
@@ -20,29 +20,17 @@ body {
 }
 
 .scrollbar-thin::-webkit-scrollbar-track {
-  background: #f3f4f6;
+  background: var(--surface-3);
   border-radius: 3px;
-}
-
-.dark .scrollbar-thin::-webkit-scrollbar-track {
-  background: #1f2937;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: #9ca3af;
+  background: var(--ink-4);
   border-radius: 3px;
 }
 
-.dark .scrollbar-thin::-webkit-scrollbar-thumb {
-  background: #4b5563;
-}
-
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: #6b7280;
-}
-
-.dark .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: #6b7280;
+  background: var(--ink-3);
 }
 
 @theme inline {
@@ -84,94 +72,167 @@ body {
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 
-  /* App Theme Colors (reference CSS vars for dark mode support) */
+  /* App Theme Colors (legacy aliases, retained so existing bg-app-* utilities keep working) */
   --color-app-primary: var(--app-primary);
   --color-app-secondary: var(--app-secondary);
   --color-app-accent: var(--app-accent);
   --color-app-background: var(--app-background);
   --color-app-surface: var(--app-surface);
   --color-app-border: var(--app-border);
+
+  /* ============================================================
+     Coach Sidekick Design System — Tailwind utility registration
+     Exposes ink/paper/surface/line + status tokens as utilities:
+       bg-paper, bg-surface-1/2/3, bg-ink, text-ink-2/3/4, text-ink-on-dark,
+       border-line / border-line-2 / border-line-strong,
+       bg-forest / text-forest / bg-forest-bg,
+       bg-vermillion / text-vermillion / bg-vermillion-bg,
+       bg-amber-token / text-amber-token / bg-amber-token-bg,
+       bg-indigo / text-indigo / bg-indigo-bg,
+       bg-ds-accent / text-ds-accent / bg-ds-accent-bg,
+       bg-brand-tile / text-brand-tile-fg, bg-overlay
+     ============================================================ */
+  --color-paper: var(--paper);
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-ink: var(--ink);
+  --color-ink-2: var(--ink-2);
+  --color-ink-3: var(--ink-3);
+  --color-ink-4: var(--ink-4);
+  --color-ink-on-dark: var(--ink-on-dark);
+  --color-line: var(--line);
+  --color-line-2: var(--line-2);
+  --color-line-strong: var(--line-strong);
+  --color-ds-accent: var(--ds-accent);
+  --color-ds-accent-bg: var(--ds-accent-bg);
+  --color-forest: var(--forest);
+  --color-forest-bg: var(--forest-bg);
+  --color-vermillion: var(--vermillion);
+  --color-vermillion-bg: var(--vermillion-bg);
+  --color-amber-token: var(--amber-token);
+  --color-amber-token-bg: var(--amber-token-bg);
+  --color-indigo: var(--indigo);
+  --color-indigo-bg: var(--indigo-bg);
+  --color-brand-tile: var(--brand-tile-bg);
+  --color-brand-tile-fg: var(--brand-tile-fg);
+  --color-overlay: var(--overlay);
 }
 
 :root {
   --radius: 0.625rem;
-  --app-primary: #111111;
-  --app-secondary: #6B7280;
-  --app-accent: #2563EB;
-  --app-background: #FFFFFF;
-  --app-surface: #F9FAFB;
-  --app-border: #E5E7EB;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  /* ---------- Coach Sidekick DS — Ink / paper / surface (light) ---------- */
+  --paper: #FFFFFF;
+  --surface-1: #FFFFFF;
+  --surface-2: #F9FAFB;
+  --surface-3: #F3F4F6;
+
+  --ink: #0A0A0A;
+  --ink-2: #404040;
+  --ink-3: #737373;
+  --ink-4: #A3A3A3;
+  --ink-on-dark: #FAFAFA;
+
+  --line: #E5E7EB;
+  --line-2: #F3F4F6;
+  --line-strong: #D4D4D4;
+
+  /* DS chromatic accent (links, focus ring). Distinct from shadcn --accent
+     which is a *neutral* hover surface. */
+  --ds-accent: #2563EB;
+  --ds-accent-bg: #EFF6FF;
+
+  /* DS status colors — saturated chip + tinted bg pairs */
+  --forest: #15803D;
+  --forest-bg: #ECFDF5;
+  --vermillion: #B91C1C;
+  --vermillion-bg: #FEF2F2;
+  --amber-token: #B45309;
+  --amber-token-bg: #FFFBEB;
+  --indigo: #4338CA;
+  --indigo-bg: #EEF2FF;
+
+  /* Tokens that intentionally do NOT flip in dark mode */
+  --brand-tile-bg: #0A0A0A;
+  --brand-tile-fg: #FAFAFA;
+  --overlay: rgba(0, 0, 0, 0.5);
+
+  --shadow-focus: 0 0 0 3px rgba(37,99,235,0.18);
+
+  /* ---------- Legacy --app-* aliases (point at DS tokens, no value drift) ---------- */
+  --app-primary: var(--ink);
+  --app-secondary: var(--ink-3);
+  --app-accent: var(--ds-accent);
+  --app-background: var(--paper);
+  --app-surface: var(--surface-2);
+  --app-border: var(--line);
+
+  /* ---------- shadcn semantic tokens — remapped to DS scale ---------- */
+  --background: var(--paper);
+  --foreground: var(--ink);
+  --card: var(--surface-1);
+  --card-foreground: var(--ink);
+  --popover: var(--surface-1);
+  --popover-foreground: var(--ink);
+  --primary: var(--ink);
+  --primary-foreground: var(--ink-on-dark);
+  --secondary: var(--surface-2);
+  --secondary-foreground: var(--ink);
+  --muted: var(--surface-2);
+  --muted-foreground: var(--ink-3);
+  --accent: var(--surface-2);
+  --accent-foreground: var(--ink);
+  --destructive: var(--vermillion);
+  --border: var(--line);
+  --input: var(--line);
+  --ring: var(--ds-accent);
+
+  /* ---------- Chart tokens — DS-mapped ---------- */
+  --chart-1: var(--ds-accent);
+  --chart-2: var(--forest);
+  --chart-3: var(--amber-token);
+  --chart-4: var(--indigo);
+  --chart-5: var(--vermillion);
+
+  /* ---------- Sidebar tokens — DS-mapped ---------- */
+  --sidebar: var(--surface-2);
+  --sidebar-foreground: var(--ink);
+  --sidebar-primary: var(--ink);
+  --sidebar-primary-foreground: var(--ink-on-dark);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: var(--ink);
+  --sidebar-border: var(--line);
+  --sidebar-ring: var(--ds-accent);
 }
 
 .dark {
-  --app-primary: #F9FAFB;
-  --app-secondary: #9CA3AF;
-  --app-accent: #3B82F6;
-  --app-background: #111827;
-  --app-surface: #1F2937;
-  --app-border: #374151;
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* ---------- Coach Sidekick DS — Ink / paper / surface (dark) ---------- */
+  --paper: #0A0A0A;
+  --surface-1: #171717;
+  --surface-2: #1F1F1F;
+  --surface-3: #262626;
+
+  --ink: #FAFAFA;
+  --ink-2: #D4D4D4;
+  --ink-3: #A3A3A3;
+  --ink-4: #737373;
+  --ink-on-dark: #0A0A0A;
+
+  --line: #2A2A2A;
+  --line-2: #1F1F1F;
+  --line-strong: #404040;
+
+  --ds-accent: #3B82F6;
+  --ds-accent-bg: rgba(59,130,246,0.12);
+
+  /* Saturated chips stay the same hue in dark; only -bg flips translucent. */
+  --forest-bg: rgba(21,128,61,0.14);
+  --vermillion-bg: rgba(185,28,28,0.14);
+  --amber-token-bg: rgba(180,83,9,0.14);
+  --indigo-bg: rgba(67,56,202,0.18);
+
+  /* --brand-tile-bg, --brand-tile-fg, --overlay intentionally NOT overridden. */
 }
 
 @layer base {

--- a/src/app/invitations/client-access/[token]/page.tsx
+++ b/src/app/invitations/client-access/[token]/page.tsx
@@ -239,12 +239,10 @@ export default function ClientAccessInvitationPage() {
 
   if (loading || authLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+      <div className="min-h-screen flex items-center justify-center bg-paper ">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-white mx-auto mb-4"></div>
-          <p className="text-gray-600 dark:text-gray-400">
-            Loading invitation...
-          </p>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-line mx-auto mb-4"></div>
+          <p className="text-ink-3 ">Loading invitation...</p>
         </div>
       </div>
     )
@@ -252,19 +250,19 @@ export default function ClientAccessInvitationPage() {
 
   if (error && !invitation) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950 p-4">
-        <Card className="max-w-md w-full border-gray-200 dark:border-gray-800">
+      <div className="min-h-screen flex items-center justify-center bg-paper p-4">
+        <Card className="max-w-md w-full border-line ">
           <CardContent className="pt-6 text-center">
-            <div className="h-12 w-12 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mx-auto mb-4">
-              <AlertCircle className="h-6 w-6 text-gray-600 dark:text-gray-400" />
+            <div className="h-12 w-12 rounded-full bg-surface-3 flex items-center justify-center mx-auto mb-4">
+              <AlertCircle className="h-6 w-6 text-ink-3 " />
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            <h2 className="text-xl font-semibold text-ink mb-2">
               Invalid Invitation
             </h2>
-            <p className="text-gray-600 dark:text-gray-400">{error}</p>
+            <p className="text-ink-3 ">{error}</p>
             <Button
               onClick={() => router.push('/')}
-              className="mt-6 bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100"
+              className="mt-6 bg-ink text-ink-on-dark hover:bg-ink-2 "
             >
               Go to Home
             </Button>
@@ -276,23 +274,20 @@ export default function ClientAccessInvitationPage() {
 
   if (success) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950 p-4">
-        <Card className="max-w-md w-full border-gray-200 dark:border-gray-800">
+      <div className="min-h-screen flex items-center justify-center bg-paper p-4">
+        <Card className="max-w-md w-full border-line ">
           <CardContent className="pt-6 text-center">
-            <div className="h-12 w-12 rounded-full bg-gray-900 dark:bg-white flex items-center justify-center mx-auto mb-4">
-              <CheckCircle className="h-6 w-6 text-white dark:text-gray-900" />
+            <div className="h-12 w-12 rounded-full bg-ink flex items-center justify-center mx-auto mb-4">
+              <CheckCircle className="h-6 w-6 text-ink-on-dark " />
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            <h2 className="text-xl font-semibold text-ink mb-2">
               Invitation Accepted!
             </h2>
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-ink-3 ">
               You now have access to coaching with{' '}
-              <strong className="text-gray-900 dark:text-white">
-                {invitation?.coach_name}
-              </strong>
-              .
+              <strong className="text-ink ">{invitation?.coach_name}</strong>.
             </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-4">
+            <p className="text-sm text-ink-3 mt-4">
               Redirecting to your dashboard...
             </p>
           </CardContent>
@@ -302,30 +297,28 @@ export default function ClientAccessInvitationPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950 p-4">
-      <Card className="max-w-lg w-full border-gray-200 dark:border-gray-800">
-        <CardHeader className="text-center border-b border-gray-100 dark:border-gray-800">
-          <div className="mx-auto w-16 h-16 bg-gray-900 dark:bg-white rounded-full flex items-center justify-center mb-4">
-            <Users className="h-8 w-8 text-white dark:text-gray-900" />
+    <div className="min-h-screen flex items-center justify-center bg-paper p-4">
+      <Card className="max-w-lg w-full border-line ">
+        <CardHeader className="text-center border-b border-line ">
+          <div className="mx-auto w-16 h-16 bg-ink rounded-full flex items-center justify-center mb-4">
+            <Users className="h-8 w-8 text-ink-on-dark " />
           </div>
-          <CardTitle className="text-2xl text-gray-900 dark:text-white">
+          <CardTitle className="text-2xl text-ink ">
             Coaching Invitation
           </CardTitle>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+          <p className="text-sm text-ink-3 mt-2">
             You&apos;ve been invited to join a coaching program
           </p>
         </CardHeader>
 
         <CardContent className="space-y-4 pt-6">
           {/* Coach Info */}
-          <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-4 rounded-lg">
-            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-              <strong className="text-gray-900 dark:text-white">
-                {invitation?.coach_name}
-              </strong>{' '}
+          <div className="bg-paper border border-line p-4 rounded-lg">
+            <p className="text-sm text-ink-2 mb-2">
+              <strong className="text-ink ">{invitation?.coach_name}</strong>{' '}
               has invited you to join their coaching program
             </p>
-            <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-2 text-xs text-ink-3 ">
               <Mail className="h-3 w-3" />
               <span>{invitation?.coach_email}</span>
             </div>
@@ -333,11 +326,11 @@ export default function ClientAccessInvitationPage() {
 
           {/* Personal Message */}
           {invitation?.message && (
-            <div className="bg-gray-50 dark:bg-gray-800 border-l-4 border-gray-900 dark:border-white p-4">
-              <p className="text-sm text-gray-700 dark:text-gray-300 font-medium mb-1">
+            <div className="bg-paper border-l-4 border-line p-4">
+              <p className="text-sm text-ink-2 font-medium mb-1">
                 Personal message:
               </p>
-              <p className="text-sm text-gray-600 dark:text-gray-400 italic">
+              <p className="text-sm text-ink-3 italic">
                 &quot;{invitation.message}&quot;
               </p>
             </div>
@@ -345,24 +338,22 @@ export default function ClientAccessInvitationPage() {
 
           {/* Benefits */}
           <div className="space-y-2">
-            <h3 className="font-medium text-gray-900 dark:text-white">
-              What you&apos;ll get:
-            </h3>
-            <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-2">
+            <h3 className="font-medium text-ink ">What you&apos;ll get:</h3>
+            <ul className="text-sm text-ink-3 space-y-2">
               <li className="flex items-start">
-                <CheckCircle className="h-4 w-4 text-gray-700 dark:text-gray-300 mr-2 mt-0.5 flex-shrink-0" />
+                <CheckCircle className="h-4 w-4 text-ink-2 mr-2 mt-0.5 flex-shrink-0" />
                 <span>Access to your personalized coaching dashboard</span>
               </li>
               <li className="flex items-start">
-                <CheckCircle className="h-4 w-4 text-gray-700 dark:text-gray-300 mr-2 mt-0.5 flex-shrink-0" />
+                <CheckCircle className="h-4 w-4 text-ink-2 mr-2 mt-0.5 flex-shrink-0" />
                 <span>Track progress and insights from your sessions</span>
               </li>
               <li className="flex items-start">
-                <CheckCircle className="h-4 w-4 text-gray-700 dark:text-gray-300 mr-2 mt-0.5 flex-shrink-0" />
+                <CheckCircle className="h-4 w-4 text-ink-2 mr-2 mt-0.5 flex-shrink-0" />
                 <span>View session commitments and next steps</span>
               </li>
               <li className="flex items-start">
-                <CheckCircle className="h-4 w-4 text-gray-700 dark:text-gray-300 mr-2 mt-0.5 flex-shrink-0" />
+                <CheckCircle className="h-4 w-4 text-ink-2 mr-2 mt-0.5 flex-shrink-0" />
                 <span>Manage multiple coaches from one account</span>
               </li>
             </ul>
@@ -370,7 +361,7 @@ export default function ClientAccessInvitationPage() {
 
           {/* Already Has Access */}
           {invitation?.already_has_access && (
-            <Alert className="border-gray-200 dark:border-gray-700">
+            <Alert className="border-line ">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
                 You already have access to this coaching program.
@@ -380,8 +371,8 @@ export default function ClientAccessInvitationPage() {
 
           {/* Inline Signup/Login Form */}
           {!isAuthenticated && !authLoading && (
-            <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-4 rounded-lg space-y-4">
-              <h3 className="font-medium text-gray-900 dark:text-white">
+            <div className="bg-paper border border-line p-4 rounded-lg space-y-4">
+              <h3 className="font-medium text-ink ">
                 {invitation?.existing_user
                   ? 'Log in to accept'
                   : 'Create your account'}
@@ -389,10 +380,7 @@ export default function ClientAccessInvitationPage() {
 
               {/* Email (readonly) */}
               <div className="space-y-1.5">
-                <Label
-                  htmlFor="email"
-                  className="text-sm text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="email" className="text-sm text-ink-2 ">
                   Email
                 </Label>
                 <Input
@@ -400,17 +388,14 @@ export default function ClientAccessInvitationPage() {
                   type="email"
                   value={invitation?.invitee_email || ''}
                   readOnly
-                  className="bg-gray-100 dark:bg-gray-700 cursor-not-allowed"
+                  className="bg-surface-3 cursor-not-allowed"
                 />
               </div>
 
               {/* Full Name (new users only) */}
               {!invitation?.existing_user && (
                 <div className="space-y-1.5">
-                  <Label
-                    htmlFor="fullName"
-                    className="text-sm text-gray-700 dark:text-gray-300"
-                  >
+                  <Label htmlFor="fullName" className="text-sm text-ink-2 ">
                     Full Name
                   </Label>
                   <Input
@@ -425,10 +410,7 @@ export default function ClientAccessInvitationPage() {
 
               {/* Password */}
               <div className="space-y-1.5">
-                <Label
-                  htmlFor="password"
-                  className="text-sm text-gray-700 dark:text-gray-300"
-                >
+                <Label htmlFor="password" className="text-sm text-ink-2 ">
                   Password
                 </Label>
                 <Input
@@ -450,7 +432,7 @@ export default function ClientAccessInvitationPage() {
                   <div className="space-y-1.5">
                     <Label
                       htmlFor="confirmPassword"
-                      className="text-sm text-gray-700 dark:text-gray-300"
+                      className="text-sm text-ink-2 "
                     >
                       Confirm Password
                     </Label>
@@ -462,7 +444,7 @@ export default function ClientAccessInvitationPage() {
                       onChange={e => setConfirmPassword(e.target.value)}
                     />
                     {confirmPassword && password !== confirmPassword && (
-                      <p className="text-xs text-red-600">
+                      <p className="text-xs text-vermillion">
                         Passwords do not match
                       </p>
                     )}
@@ -481,12 +463,10 @@ export default function ClientAccessInvitationPage() {
 
           {/* Current User */}
           {isAuthenticated && user && (
-            <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-3 rounded-lg">
-              <p className="text-sm text-gray-700 dark:text-gray-300">
+            <div className="bg-paper border border-line p-3 rounded-lg">
+              <p className="text-sm text-ink-2 ">
                 Logged in as:{' '}
-                <strong className="text-gray-900 dark:text-white">
-                  {user.email}
-                </strong>
+                <strong className="text-ink ">{user.email}</strong>
               </p>
             </div>
           )}
@@ -503,7 +483,7 @@ export default function ClientAccessInvitationPage() {
         <CardFooter className="flex gap-3 pt-6">
           <Button
             variant="outline"
-            className="flex-1 border-gray-300 dark:border-gray-600"
+            className="flex-1 border-line-strong "
             onClick={handleDecline}
             disabled={
               accepting ||
@@ -516,7 +496,7 @@ export default function ClientAccessInvitationPage() {
             Decline
           </Button>
           <Button
-            className="flex-1 bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100"
+            className="flex-1 bg-ink text-ink-on-dark hover:bg-ink-2 "
             onClick={isAuthenticated ? handleAccept : handleAcceptSignup}
             disabled={accepting || submitting || invitation?.already_has_access}
           >
@@ -532,8 +512,8 @@ export default function ClientAccessInvitationPage() {
         </CardFooter>
 
         {/* Expiration */}
-        <div className="px-6 pb-4 border-t border-gray-100 dark:border-gray-800 pt-4">
-          <p className="text-xs text-center text-gray-500 dark:text-gray-400">
+        <div className="px-6 pb-4 border-t border-line pt-4">
+          <p className="text-xs text-center text-ink-3 ">
             This invitation expires on{' '}
             {invitation?.expires_at
               ? formatDate(invitation.expires_at, 'EEEE, MMMM d, yyyy')

--- a/src/app/meeting/[botId]/components/meeting-header.tsx
+++ b/src/app/meeting/[botId]/components/meeting-header.tsx
@@ -44,7 +44,7 @@ export default function MeetingHeader({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="bg-surface-1 border-b border-line shadow-sm">
       <div className="w-full px-4 py-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
@@ -52,7 +52,7 @@ export default function MeetingHeader({
               variant="ghost"
               size="sm"
               onClick={onNavigateBack}
-              className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+              className="text-ink-3 hover:text-ink "
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
               Dashboard
@@ -60,19 +60,16 @@ export default function MeetingHeader({
 
             {bot && (
               <div className="flex items-center gap-3">
-                <div className="h-8 w-px bg-gray-300 dark:bg-gray-600" />
-                <Badge
-                  variant="outline"
-                  className="font-mono text-xs dark:border-gray-600 dark:text-gray-300"
-                >
+                <div className="h-8 w-px bg-line " />
+                <Badge variant="outline" className="font-mono text-xs ">
                   {bot.id}
                 </Badge>
                 <BotStatus bot={bot} onStop={onStopBot} compact />
-                <div className="h-8 w-px bg-gray-300 dark:bg-gray-600" />
+                <div className="h-8 w-px bg-line " />
                 <WebSocketStatus />
                 {isGroupSession && (
                   <>
-                    <div className="h-8 w-px bg-gray-300 dark:bg-gray-600" />
+                    <div className="h-8 w-px bg-line " />
                     <GroupSessionBadge />
                   </>
                 )}
@@ -85,7 +82,7 @@ export default function MeetingHeader({
               {/* Client Meeting Link - inline with actions */}
               {sessionId && (
                 <>
-                  <div className="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+                  <div className="h-6 w-px bg-line " />
                   <ClientMeetingLink
                     sessionId={sessionId}
                     clientId={clientId ?? null}
@@ -94,7 +91,7 @@ export default function MeetingHeader({
                 </>
               )}
 
-              <div className="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+              <div className="h-6 w-px bg-line " />
 
               {/* Theme Toggle */}
               {mounted && (
@@ -102,7 +99,7 @@ export default function MeetingHeader({
                   variant="ghost"
                   size="sm"
                   onClick={toggleTheme}
-                  className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                  className="text-ink-3 hover:text-ink "
                   title={
                     theme === 'dark'
                       ? 'Switch to light mode'

--- a/src/app/meeting/[botId]/components/meeting-panels.tsx
+++ b/src/app/meeting/[botId]/components/meeting-panels.tsx
@@ -219,17 +219,17 @@ export default function MeetingPanels({
               size="sm"
               onClick={() => setAiSuggestionsOpen(!aiSuggestionsOpen)}
               className={cn(
-                'h-auto py-3 px-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-r-lg rounded-l-none border-l-0',
-                aiSuggestionsOpen && 'bg-gray-100 dark:bg-gray-700',
+                'h-auto py-3 px-2 border-line bg-surface-1 hover:bg-paper rounded-r-lg rounded-l-none border-l-0',
+                aiSuggestionsOpen && 'bg-surface-3 ',
               )}
             >
               <div className="flex flex-col items-center gap-2">
                 {aiSuggestionsOpen ? (
-                  <PanelLeftClose className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                  <PanelLeftClose className="h-4 w-4 text-ink-3 " />
                 ) : (
-                  <PanelLeftOpen className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                  <PanelLeftOpen className="h-4 w-4 text-ink-3 " />
                 )}
-                <Sparkles className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+                <Sparkles className="h-3.5 w-3.5 text-ink-3 " />
               </div>
             </Button>
           </div>
@@ -237,7 +237,7 @@ export default function MeetingPanels({
           {/* Collapsible AI Suggestions Panel + Resources */}
           <div
             className={cn(
-              'flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ease-in-out overflow-hidden',
+              'flex-shrink-0 border-r border-line bg-surface-1 transition-all duration-300 ease-in-out overflow-hidden',
               aiSuggestionsOpen ? 'w-72 xl:w-80 2xl:w-96' : 'w-0',
             )}
           >
@@ -252,14 +252,14 @@ export default function MeetingPanels({
 
               {/* Resources section below AI suggestions */}
               {allResources.length > 0 && (
-                <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 overflow-hidden">
+                <div className="flex-shrink-0 border-t border-line overflow-hidden">
                   <button
                     onClick={() => setResourcesOpen(!resourcesOpen)}
-                    className="w-full flex items-center justify-between px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                    className="w-full flex items-center justify-between px-4 py-2 hover:bg-paper transition-colors"
                   >
                     <div className="flex items-center gap-2">
-                      <BookOpen className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
-                      <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                      <BookOpen className="h-3.5 w-3.5 text-ds-accent " />
+                      <span className="text-xs font-semibold text-ink ">
                         Resources
                       </span>
                       <Badge
@@ -270,9 +270,9 @@ export default function MeetingPanels({
                       </Badge>
                     </div>
                     {resourcesOpen ? (
-                      <ChevronUp className="h-3 w-3 text-gray-400" />
+                      <ChevronUp className="h-3 w-3 text-ink-4" />
                     ) : (
-                      <ChevronDown className="h-3 w-3 text-gray-400" />
+                      <ChevronDown className="h-3 w-3 text-ink-4" />
                     )}
                   </button>
 
@@ -293,19 +293,19 @@ export default function MeetingPanels({
                         return (
                           <div
                             key={resource.id}
-                            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-paper "
                           >
                             <div
                               className={`p-1 rounded ${colors.bg} shrink-0`}
                             >
                               <Icon className={`h-3 w-3 ${colors.text}`} />
                             </div>
-                            <p className="flex-1 min-w-0 text-[11px] font-medium text-gray-900 dark:text-white truncate">
+                            <p className="flex-1 min-w-0 text-[11px] font-medium text-ink truncate">
                               {resource.title}
                             </p>
                             {targetClientId &&
                               (alreadyShared ? (
-                                <div className="shrink-0 flex items-center gap-0.5 text-green-600 dark:text-green-400">
+                                <div className="shrink-0 flex items-center gap-0.5 text-forest ">
                                   <Check className="h-2.5 w-2.5" />
                                   <span className="text-[9px] font-medium">
                                     Shared
@@ -367,17 +367,17 @@ export default function MeetingPanels({
                   isMeetingEnded={isMeetingEnded}
                 />
               ) : (
-                <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 h-full">
+                <Card className="bg-surface-1 rounded-xl shadow-sm border border-line h-full">
                   <CardContent className="p-4">
                     <div className="flex items-start gap-3">
-                      <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                        <FileText className="h-4 w-4 text-gray-400" />
+                      <div className="p-2 bg-surface-3 rounded-lg">
+                        <FileText className="h-4 w-4 text-ink-4" />
                       </div>
                       <div>
-                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <h4 className="text-sm font-medium text-ink-2 ">
                           Notes
                         </h4>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <p className="text-xs text-ink-3 mt-1">
                           Session loading...
                         </p>
                       </div>
@@ -399,18 +399,18 @@ export default function MeetingPanels({
           >
             <button
               onClick={() => setCommitmentsOpen(!commitmentsOpen)}
-              className="flex items-center justify-between px-3 py-2 bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-t-xl flex-shrink-0 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors lg:hidden"
+              className="flex items-center justify-between px-3 py-2 bg-surface-1 border border-line rounded-t-xl flex-shrink-0 hover:bg-paper transition-colors lg:hidden"
             >
               <div className="flex items-center gap-2">
-                <Target className="h-3.5 w-3.5 text-gray-500" />
-                <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                <Target className="h-3.5 w-3.5 text-ink-3" />
+                <span className="text-xs font-semibold text-ink ">
                   Commitments
                 </span>
               </div>
               {commitmentsOpen ? (
-                <ChevronUp className="h-3 w-3 text-gray-400" />
+                <ChevronUp className="h-3 w-3 text-ink-4" />
               ) : (
-                <ChevronDown className="h-3 w-3 text-gray-400" />
+                <ChevronDown className="h-3 w-3 text-ink-4" />
               )}
             </button>
             <div
@@ -425,17 +425,17 @@ export default function MeetingPanels({
                   clientId={commitmentClientId}
                 />
               ) : sessionId && !commitmentClientId ? (
-                <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-amber-100 dark:border-amber-900/50 h-full">
+                <Card className="bg-surface-1 rounded-xl shadow-sm border border-amber-token h-full">
                   <CardContent className="p-4">
                     <div className="flex items-start gap-3">
-                      <div className="p-2 bg-amber-50 dark:bg-amber-900/30 rounded-lg">
-                        <Target className="h-4 w-4 text-amber-500 dark:text-amber-400" />
+                      <div className="p-2 bg-amber-token-bg rounded-lg">
+                        <Target className="h-4 w-4 text-amber-token " />
                       </div>
                       <div>
-                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <h4 className="text-sm font-medium text-ink-2 ">
                           Commitments
                         </h4>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <p className="text-xs text-ink-3 mt-1">
                           No client selected
                         </p>
                       </div>
@@ -443,17 +443,17 @@ export default function MeetingPanels({
                   </CardContent>
                 </Card>
               ) : (
-                <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 h-full">
+                <Card className="bg-surface-1 rounded-xl shadow-sm border border-line h-full">
                   <CardContent className="p-4">
                     <div className="flex items-start gap-3">
-                      <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                        <Target className="h-4 w-4 text-gray-400" />
+                      <div className="p-2 bg-surface-3 rounded-lg">
+                        <Target className="h-4 w-4 text-ink-4" />
                       </div>
                       <div>
-                        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <h4 className="text-sm font-medium text-ink-2 ">
                           Commitments
                         </h4>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <p className="text-xs text-ink-3 mt-1">
                           Session loading...
                         </p>
                       </div>
@@ -473,20 +473,20 @@ export default function MeetingPanels({
           size="sm"
           onClick={() => setSidebarOpen(!sidebarOpen)}
           className={cn(
-            'h-auto py-3 px-2 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-l-lg rounded-r-none border-r-0',
-            sidebarOpen && 'bg-gray-100 dark:bg-gray-700',
+            'h-auto py-3 px-2 border-line bg-surface-1 hover:bg-paper rounded-l-lg rounded-r-none border-r-0',
+            sidebarOpen && 'bg-surface-3 ',
           )}
         >
           <div className="flex flex-col items-center gap-2">
             {sidebarOpen ? (
-              <PanelRightClose className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <PanelRightClose className="h-4 w-4 text-ink-3 " />
             ) : (
-              <PanelRightOpen className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <PanelRightOpen className="h-4 w-4 text-ink-3 " />
             )}
             <div className="flex flex-col items-center gap-1">
-              <MessageSquare className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-              <Info className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-              <BookOpen className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+              <MessageSquare className="h-3.5 w-3.5 text-ink-3 " />
+              <Info className="h-3.5 w-3.5 text-ink-3 " />
+              <BookOpen className="h-3.5 w-3.5 text-ink-3 " />
             </div>
           </div>
         </Button>
@@ -495,27 +495,27 @@ export default function MeetingPanels({
       {/* Collapsible Sidebar */}
       <div
         className={cn(
-          'flex-shrink-0 border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ease-in-out overflow-hidden',
+          'flex-shrink-0 border-l border-line bg-surface-1 transition-all duration-300 ease-in-out overflow-hidden',
           sidebarOpen ? 'w-72 xl:w-80' : 'w-0',
         )}
       >
         <div className="w-72 xl:w-80 h-full flex flex-col">
           {/* Sidebar Tabs */}
-          <div className="flex-shrink-0 border-b border-gray-100 dark:border-gray-700">
+          <div className="flex-shrink-0 border-b border-line ">
             <div className="flex">
               <button
                 onClick={() => setSidebarTab('transcript')}
                 className={cn(
                   'flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 flex items-center justify-center gap-1.5',
                   sidebarTab === 'transcript'
-                    ? 'text-gray-900 dark:text-white border-gray-900 dark:border-white'
-                    : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300',
+                    ? 'text-ink border-line '
+                    : 'text-ink-3 border-transparent hover:text-ink-2 ',
                 )}
               >
                 <MessageSquare className="h-3.5 w-3.5" />
                 Transcript
                 {transcript.length > 0 && (
-                  <span className="text-xs bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded text-gray-500 dark:text-gray-400">
+                  <span className="text-xs bg-surface-3 px-1.5 py-0.5 rounded text-ink-3 ">
                     {transcript.length}
                   </span>
                 )}
@@ -525,8 +525,8 @@ export default function MeetingPanels({
                 className={cn(
                   'flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 flex items-center justify-center gap-1.5',
                   sidebarTab === 'context'
-                    ? 'text-gray-900 dark:text-white border-gray-900 dark:border-white'
-                    : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300',
+                    ? 'text-ink border-line '
+                    : 'text-ink-3 border-transparent hover:text-ink-2 ',
                 )}
               >
                 <Info className="h-3.5 w-3.5" />
@@ -537,8 +537,8 @@ export default function MeetingPanels({
                 className={cn(
                   'flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 flex items-center justify-center gap-1.5',
                   sidebarTab === 'resources'
-                    ? 'text-gray-900 dark:text-white border-gray-900 dark:border-white'
-                    : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300',
+                    ? 'text-ink border-line '
+                    : 'text-ink-3 border-transparent hover:text-ink-2 ',
                 )}
               >
                 <BookOpen className="h-3.5 w-3.5" />
@@ -549,8 +549,8 @@ export default function MeetingPanels({
                 className={cn(
                   'flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 flex items-center justify-center gap-1.5',
                   sidebarTab === 'questionnaire'
-                    ? 'text-gray-900 dark:text-white border-gray-900 dark:border-white'
-                    : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300',
+                    ? 'text-ink border-line '
+                    : 'text-ink-3 border-transparent hover:text-ink-2 ',
                 )}
               >
                 <ClipboardList className="h-3.5 w-3.5" />
@@ -582,14 +582,14 @@ export default function MeetingPanels({
                 <Accordion
                   type="multiple"
                   defaultValue={['profile']}
-                  className="divide-y divide-gray-100 dark:divide-gray-700"
+                  className="divide-y divide-line "
                 >
                   {/* Client Profile */}
                   <AccordionItem value="profile" className="border-none">
-                    <AccordionTrigger className="px-4 py-2.5 hover:no-underline hover:bg-gray-50 dark:hover:bg-gray-700 text-xs">
+                    <AccordionTrigger className="px-4 py-2.5 hover:no-underline hover:bg-paper text-xs">
                       <div className="flex items-center gap-2">
-                        <User className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                        <User className="h-3.5 w-3.5 text-ink-3 " />
+                        <span className="font-medium text-ink-2 ">
                           Client Profile
                         </span>
                       </div>
@@ -597,8 +597,8 @@ export default function MeetingPanels({
                     <AccordionContent className="px-4 pb-3">
                       {contextLoading ? (
                         <div className="animate-pulse space-y-2">
-                          <div className="h-3 bg-gray-200 dark:bg-gray-600 rounded w-full"></div>
-                          <div className="h-3 bg-gray-200 dark:bg-gray-600 rounded w-3/4"></div>
+                          <div className="h-3 bg-surface-3 rounded w-full"></div>
+                          <div className="h-3 bg-surface-3 rounded w-3/4"></div>
                         </div>
                       ) : (
                         <ClientProfileCard
@@ -612,14 +612,14 @@ export default function MeetingPanels({
 
                   {/* Similar Sessions */}
                   <AccordionItem value="similar" className="border-none">
-                    <AccordionTrigger className="px-4 py-2.5 hover:no-underline hover:bg-gray-50 dark:hover:bg-gray-700 text-xs">
+                    <AccordionTrigger className="px-4 py-2.5 hover:no-underline hover:bg-paper text-xs">
                       <div className="flex items-center gap-2">
-                        <History className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                        <History className="h-3.5 w-3.5 text-ink-3 " />
+                        <span className="font-medium text-ink-2 ">
                           Similar Sessions
                         </span>
                         {(fullContext?.similar_sessions?.length || 0) > 0 && (
-                          <span className="text-xs bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded text-gray-500 dark:text-gray-400">
+                          <span className="text-xs bg-surface-3 px-1.5 py-0.5 rounded text-ink-3 ">
                             {fullContext?.similar_sessions?.length}
                           </span>
                         )}
@@ -628,8 +628,8 @@ export default function MeetingPanels({
                     <AccordionContent className="px-4 pb-3">
                       {contextLoading ? (
                         <div className="animate-pulse space-y-2">
-                          <div className="h-3 bg-gray-200 dark:bg-gray-600 rounded w-full"></div>
-                          <div className="h-3 bg-gray-200 dark:bg-gray-600 rounded w-5/6"></div>
+                          <div className="h-3 bg-surface-3 rounded w-full"></div>
+                          <div className="h-3 bg-surface-3 rounded w-5/6"></div>
                         </div>
                       ) : (
                         <SimilarSessionsCard
@@ -643,14 +643,14 @@ export default function MeetingPanels({
 
                   {/* Pattern Insights */}
                   <AccordionItem value="patterns" className="border-none">
-                    <AccordionTrigger className="px-4 py-2.5 hover:no-underline hover:bg-gray-50 dark:hover:bg-gray-700 text-xs">
+                    <AccordionTrigger className="px-4 py-2.5 hover:no-underline hover:bg-paper text-xs">
                       <div className="flex items-center gap-2">
-                        <TrendingUp className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                        <TrendingUp className="h-3.5 w-3.5 text-ink-3 " />
+                        <span className="font-medium text-ink-2 ">
                           Pattern Insights
                         </span>
                         {patterns.length > 0 && (
-                          <span className="text-xs bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded text-gray-500 dark:text-gray-400">
+                          <span className="text-xs bg-surface-3 px-1.5 py-0.5 rounded text-ink-3 ">
                             {patterns.length}
                           </span>
                         )}
@@ -659,8 +659,8 @@ export default function MeetingPanels({
                     <AccordionContent className="px-4 pb-3">
                       {contextLoading ? (
                         <div className="animate-pulse space-y-2">
-                          <div className="h-3 bg-gray-200 dark:bg-gray-600 rounded w-full"></div>
-                          <div className="h-3 bg-gray-200 dark:bg-gray-600 rounded w-4/5"></div>
+                          <div className="h-3 bg-surface-3 rounded w-full"></div>
+                          <div className="h-3 bg-surface-3 rounded w-4/5"></div>
                         </div>
                       ) : (
                         <PatternInsightsCard

--- a/src/app/meeting/[botId]/components/meeting-resources-panel.tsx
+++ b/src/app/meeting/[botId]/components/meeting-resources-panel.tsx
@@ -82,14 +82,14 @@ export function MeetingResourcesPanel({
   return (
     <div className="h-full flex flex-col">
       {/* Search */}
-      <div className="p-3 border-b border-gray-100 dark:border-gray-700">
+      <div className="p-3 border-b border-line ">
         <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
           <Input
             placeholder="Search resources..."
             value={search}
             onChange={e => setSearch(e.target.value)}
-            className="h-8 text-xs pl-8 border-gray-200 dark:border-gray-600"
+            className="h-8 text-xs pl-8 border-line "
           />
         </div>
       </div>
@@ -97,19 +97,19 @@ export function MeetingResourcesPanel({
       {/* List */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
-          <div className="p-4 flex items-center justify-center gap-2 text-gray-400">
+          <div className="p-4 flex items-center justify-center gap-2 text-ink-4">
             <Loader2 className="h-4 w-4 animate-spin" />
             <span className="text-xs">Loading resources...</span>
           </div>
         ) : filtered.length === 0 ? (
           <div className="p-6 text-center">
-            <BookOpen className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <BookOpen className="h-8 w-8 text-ink-2 mx-auto mb-2" />
+            <p className="text-xs text-ink-3 ">
               {search ? 'No matching resources' : 'No resources yet'}
             </p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-100 dark:divide-gray-700">
+          <div className="divide-y divide-line ">
             {filtered.map(resource => {
               const Icon = CATEGORY_ICONS[resource.category] || FileText
               const colors =
@@ -120,14 +120,14 @@ export function MeetingResourcesPanel({
               return (
                 <div
                   key={resource.id}
-                  className="flex items-center gap-2.5 px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                  className="flex items-center gap-2.5 px-3 py-2.5 hover:bg-paper "
                 >
                   <div className={`p-1.5 rounded ${colors.bg} shrink-0`}>
                     <Icon className={`h-3.5 w-3.5 ${colors.text}`} />
                   </div>
 
                   <div className="flex-1 min-w-0">
-                    <p className="text-xs font-medium text-gray-900 dark:text-white truncate">
+                    <p className="text-xs font-medium text-ink truncate">
                       {resource.title}
                     </p>
                     <Badge
@@ -139,7 +139,7 @@ export function MeetingResourcesPanel({
                   </div>
 
                   {alreadyShared ? (
-                    <div className="shrink-0 flex items-center gap-1 text-green-600 dark:text-green-400">
+                    <div className="shrink-0 flex items-center gap-1 text-forest ">
                       <Check className="h-3.5 w-3.5" />
                       <span className="text-[10px] font-medium">Shared</span>
                     </div>

--- a/src/app/meeting/[botId]/page.tsx
+++ b/src/app/meeting/[botId]/page.tsx
@@ -136,7 +136,7 @@ export default function MeetingPage() {
   }
 
   return (
-    <div className="h-screen bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 flex flex-col overflow-hidden">
+    <div className="h-screen  flex flex-col overflow-hidden">
       {toast && (
         <Toast message={toast.message} type={toast.type} onClose={closeToast} />
       )}
@@ -167,7 +167,7 @@ export default function MeetingPage() {
           </div>
         </div>
       </div>
-      <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
+      <div className="flex-shrink-0 border-t border-line bg-surface-1/80 backdrop-blur-sm z-10">
         <BatchSaveStatus botId={botId} sessionId={sessionId} minimal={true} />
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -144,25 +144,22 @@ export default function CoachDashboard() {
 
             {/* Personalized Welcome Header */}
             <div className="mb-8 text-center">
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+              <h1 className="text-3xl font-bold text-ink mb-2">
                 Welcome, {firstName}!
               </h1>
-              <p className="text-gray-600 dark:text-gray-400 text-lg">
+              <p className="text-ink-3 text-lg">
                 Let&apos;s set up your coaching workspace in just 2 steps.
               </p>
             </div>
 
             {/* Getting Started Card */}
-            <Card className="border-gray-200 dark:border-gray-700 mb-6">
-              <CardHeader className="border-b border-gray-200 dark:border-gray-700">
+            <Card className="border-line mb-6">
+              <CardHeader className="border-b border-line ">
                 <div className="flex items-center justify-between">
-                  <CardTitle className="text-xl text-gray-900 dark:text-white">
+                  <CardTitle className="text-xl text-ink ">
                     Getting Started
                   </CardTitle>
-                  <Badge
-                    variant="outline"
-                    className="text-gray-600 dark:text-gray-400"
-                  >
+                  <Badge variant="outline" className="text-ink-3 ">
                     2 steps
                   </Badge>
                 </div>
@@ -171,20 +168,20 @@ export default function CoachDashboard() {
                 <div className="space-y-6">
                   {/* Step 1: Create Client */}
                   <div className="flex items-start gap-4">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-sm font-semibold flex-shrink-0">
+                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-ink text-ink-on-dark text-sm font-semibold flex-shrink-0">
                       1
                     </div>
                     <div className="flex-1">
-                      <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+                      <h3 className="text-base font-semibold text-ink mb-1">
                         Create Your First Client
                       </h3>
-                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                      <p className="text-sm text-ink-3 mb-3">
                         Add a client to organize their coaching journey, track
                         sessions, and monitor progress.
                       </p>
                       <Button
                         onClick={() => setIsClientModalOpen(true)}
-                        className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+                        className="bg-ink hover:bg-ink-2 text-ink-on-dark "
                       >
                         <Plus className="h-4 w-4 mr-2" />
                         Add Client
@@ -192,18 +189,18 @@ export default function CoachDashboard() {
                     </div>
                   </div>
 
-                  <div className="border-t border-gray-200 dark:border-gray-700" />
+                  <div className="border-t border-line " />
 
                   {/* Step 2: Start Session (Disabled until client is created) */}
                   <div className="flex items-start gap-4 opacity-50">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-400 text-sm font-semibold flex-shrink-0">
+                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-surface-3 text-ink-4 text-sm font-semibold flex-shrink-0">
                       2
                     </div>
                     <div className="flex-1">
-                      <h3 className="text-base font-semibold text-gray-500 mb-1">
+                      <h3 className="text-base font-semibold text-ink-3 mb-1">
                         Record a Session
                       </h3>
-                      <p className="text-sm text-gray-400 mb-3">
+                      <p className="text-sm text-ink-4 mb-3">
                         Join a live meeting or upload a past session to get
                         AI-powered insights.
                       </p>
@@ -211,7 +208,7 @@ export default function CoachDashboard() {
                         <Button
                           variant="outline"
                           disabled
-                          className="text-gray-400 border-gray-200 dark:border-gray-700"
+                          className="text-ink-4 border-line "
                         >
                           <PlayCircle className="h-4 w-4 mr-2" />
                           Start Live Session
@@ -219,14 +216,14 @@ export default function CoachDashboard() {
                         <Button
                           variant="outline"
                           disabled
-                          className="text-gray-400 border-gray-200 dark:border-gray-700"
+                          className="text-ink-4 border-line "
                         >
                           <FileText className="h-4 w-4 mr-2" />
                           Add Past Session
                         </Button>
                       </div>
                       {/* Explanation for disabled step */}
-                      <p className="text-xs text-gray-400 mt-2">
+                      <p className="text-xs text-ink-4 mt-2">
                         Complete Step 1 first to unlock this step
                       </p>
                     </div>
@@ -257,10 +254,10 @@ export default function CoachDashboard() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Page Header */}
           <div className="mb-8">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+            <h1 className="text-3xl font-bold text-ink mb-2">
               {greeting}, {firstName}
             </h1>
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-ink-3 ">
               {overdueCount > 0 || staleClientCount > 0 ? (
                 <>
                   {overdueCount > 0 && (
@@ -285,24 +282,22 @@ export default function CoachDashboard() {
 
           {/* Viewer Mode Message */}
           {!canCreateMeeting && (
-            <Card className="border-gray-200 dark:border-gray-700 mb-8">
+            <Card className="border-line mb-8">
               <CardContent className="p-6">
                 <div className="flex items-center gap-4">
-                  <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-full">
-                    <Eye className="h-6 w-6 text-gray-600 dark:text-gray-400" />
+                  <div className="p-3 bg-surface-3 rounded-full">
+                    <Eye className="h-6 w-6 text-ink-3 " />
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
-                      Viewer Mode
-                    </h3>
-                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                    <h3 className="font-semibold text-ink mb-1">Viewer Mode</h3>
+                    <p className="text-sm text-ink-3 ">
                       You have read-only access to view assigned clients and
                       their sessions.
                     </p>
                   </div>
                   <Badge
                     variant="outline"
-                    className="bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 ml-auto"
+                    className="bg-surface-3 border-line-strong text-ink-2 ml-auto"
                   >
                     View Only Access
                   </Badge>
@@ -330,8 +325,8 @@ export default function CoachDashboard() {
             {/* Right: Start Session (1/3 width) */}
             {canCreateMeeting && (
               <div className="lg:col-span-1 flex">
-                <Card className="border-gray-200 dark:border-gray-700 flex flex-col w-full">
-                  <CardHeader className="border-b border-gray-200 dark:border-gray-700 pb-3">
+                <Card className="border-line flex flex-col w-full">
+                  <CardHeader className="border-b border-line pb-3">
                     <CardTitle className="text-base font-semibold">
                       Start Session
                     </CardTitle>
@@ -342,12 +337,12 @@ export default function CoachDashboard() {
                       error={error}
                       onSubmit={handleCreateBot}
                     />
-                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 space-y-2">
+                    <div className="mt-4 pt-4 border-t border-line space-y-2">
                       <Button
                         onClick={() => setIsGroupSessionModalOpen(true)}
                         variant="outline"
                         size="sm"
-                        className="w-full border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+                        className="w-full border-line-strong hover:bg-paper "
                       >
                         <Users className="h-4 w-4 mr-2" />
                         Start Group Session
@@ -356,7 +351,7 @@ export default function CoachDashboard() {
                         onClick={() => setIsScheduleSessionModalOpen(true)}
                         variant="outline"
                         size="sm"
-                        className="w-full border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+                        className="w-full border-line-strong hover:bg-paper "
                       >
                         <CalendarClock className="h-4 w-4 mr-2" />
                         Schedule Session
@@ -365,7 +360,7 @@ export default function CoachDashboard() {
                         onClick={() => setIsManualSessionModalOpen(true)}
                         variant="outline"
                         size="sm"
-                        className="w-full border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+                        className="w-full border-line-strong hover:bg-paper "
                       >
                         <FileText className="h-4 w-4 mr-2" />
                         Add Past Session

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -24,7 +24,7 @@ export default function ProgramsPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-ink flex items-center gap-2">
             <FolderKanban className="h-6 w-6" />
             Programs
           </h1>
@@ -55,7 +55,7 @@ export default function ProgramsPage() {
       ) : programs.length === 0 ? (
         <div className="text-center py-16">
           <FolderKanban className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-1">
+          <h3 className="text-lg font-medium text-ink mb-1">
             No programs found
           </h3>
           <p className="text-sm text-muted-foreground">

--- a/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
@@ -37,7 +37,7 @@ export function QuestionnaireComplete({
   const isThrillForm = kind === 'post_session'
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 via-white to-gray-100">
+    <div className="min-h-screen flex flex-col  ">
       {/* Logo */}
       <div className="pt-8 px-6 flex justify-center">
         <Image
@@ -59,8 +59,8 @@ export function QuestionnaireComplete({
               showCheck ? 'opacity-100 scale-100' : 'opacity-0 scale-75'
             }`}
           >
-            <div className="w-20 h-20 bg-gray-900 rounded-full flex items-center justify-center mx-auto mb-8">
-              <CheckCircle2 className="h-10 w-10 text-white" />
+            <div className="w-20 h-20 bg-ink rounded-full flex items-center justify-center mx-auto mb-8">
+              <CheckCircle2 className="h-10 w-10 text-ink-on-dark" />
             </div>
           </div>
 
@@ -70,28 +70,28 @@ export function QuestionnaireComplete({
               showText ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
             }`}
           >
-            <h1 className="text-3xl font-light text-gray-900 mb-4">
+            <h1 className="text-3xl font-light text-ink mb-4">
               Thank you, {clientName}!
             </h1>
-            <p className="text-gray-500 text-lg leading-relaxed mb-6">
+            <p className="text-ink-3 text-lg leading-relaxed mb-6">
               {isThrillForm
                 ? `Your Thrill Form has been shared with ${coachName}.`
                 : `Your responses have been shared with ${coachName}.`}
               {dateInfo && (
                 <>
                   <br />
-                  <span className="text-gray-400">See you on {dateInfo}.</span>
+                  <span className="text-ink-4">See you on {dateInfo}.</span>
                 </>
               )}
             </p>
-            <p className="text-sm text-gray-300">You can close this tab now.</p>
+            <p className="text-sm text-ink-2">You can close this tab now.</p>
           </div>
         </div>
       </div>
 
       {/* Footer */}
       <div className="pb-6 text-center">
-        <p className="text-xs text-gray-300">Powered by Novus Global</p>
+        <p className="text-xs text-ink-2">Powered by Novus Global</p>
       </div>
     </div>
   )

--- a/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
@@ -234,12 +234,12 @@ export function QuestionnaireFlow({
     kind === 'post_session' ? 'Thrill Form' : 'Pre-Session Questionnaire'
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 via-white to-gray-100">
+    <div className="min-h-screen flex flex-col  ">
       {/* Progress Bar */}
       <div className="fixed top-0 left-0 right-0 z-50">
-        <div className="h-1 bg-gray-100">
+        <div className="h-1 bg-surface-3">
           <div
-            className="h-full bg-gray-900 transition-all duration-500 ease-out"
+            className="h-full bg-ink transition-all duration-500 ease-out"
             style={{ width: `${progress}%` }}
           />
         </div>
@@ -255,7 +255,7 @@ export function QuestionnaireFlow({
           className="opacity-80"
           priority
         />
-        <p className="text-xs uppercase tracking-widest text-gray-400 font-medium">
+        <p className="text-xs uppercase tracking-widest text-ink-4 font-medium">
           {headerCaption}
         </p>
       </div>
@@ -274,15 +274,13 @@ export function QuestionnaireFlow({
           >
             {/* Question Counter */}
             <div className="mb-8">
-              <span className="text-sm text-gray-400 font-medium">
+              <span className="text-sm text-ink-4 font-medium">
                 {position + 1}{' '}
-                <span className="text-gray-300">
-                  / {visibleQuestions.length}
-                </span>
+                <span className="text-ink-2">/ {visibleQuestions.length}</span>
               </span>
             </div>
 
-            <h2 className="text-2xl sm:text-3xl font-light text-gray-900 leading-relaxed mb-8">
+            <h2 className="text-2xl sm:text-3xl font-light text-ink leading-relaxed mb-8">
               {currentQuestion?.text}
             </h2>
 
@@ -312,7 +310,7 @@ export function QuestionnaireFlow({
                     ? 'Optional — leave blank if you have nothing to add'
                     : 'Type your answer here...'
                 }
-                className="w-full bg-transparent border-0 border-b-2 border-gray-200 focus:border-gray-900 text-lg text-gray-800 placeholder-gray-300 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full bg-transparent border-0 border-b-2 border-line focus:border-line text-lg text-ink-2 placeholder-ink-2 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
                 rows={3}
               />
             )}
@@ -325,8 +323,8 @@ export function QuestionnaireFlow({
               disabled={isFirst || isAnimating}
               className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-all ${
                 isFirst
-                  ? 'text-gray-300 cursor-not-allowed'
-                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  ? 'text-ink-2 cursor-not-allowed'
+                  : 'text-ink-3 hover:text-ink hover:bg-surface-3'
               }`}
             >
               <ArrowLeft className="h-4 w-4" />
@@ -338,8 +336,8 @@ export function QuestionnaireFlow({
               disabled={!canAdvance || isAnimating || isSubmitting}
               className={`flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded-lg transition-all ${
                 canAdvance
-                  ? 'bg-gray-900 text-white hover:bg-gray-800 shadow-sm'
-                  : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                  ? 'bg-ink text-ink-on-dark hover:bg-ink-2 shadow-sm'
+                  : 'bg-surface-3 text-ink-4 cursor-not-allowed'
               }`}
             >
               <span
@@ -374,13 +372,13 @@ export function QuestionnaireFlow({
           {/* Keyboard hint — only useful for text inputs */}
           {currentQuestion?.type !== 'scale' &&
             currentQuestion?.type !== 'yes_no' && (
-              <p className="text-center text-xs text-gray-300 mt-8">
+              <p className="text-center text-xs text-ink-2 mt-8">
                 Press{' '}
-                <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
+                <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
                   ⌘
                 </kbd>{' '}
                 +{' '}
-                <kbd className="px-1.5 py-0.5 bg-gray-100 rounded text-gray-400 font-mono">
+                <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
                   Enter
                 </kbd>{' '}
                 to continue
@@ -391,7 +389,7 @@ export function QuestionnaireFlow({
 
       {/* Footer */}
       <div className="pb-6 text-center">
-        <p className="text-xs text-gray-300">Powered by Novus Global</p>
+        <p className="text-xs text-ink-2">Powered by Novus Global</p>
       </div>
     </div>
   )
@@ -425,8 +423,8 @@ function ScaleInput({ question, value, onChange, disabled }: ScaleInputProps) {
               onClick={() => onChange(String(n))}
               className={`aspect-square min-h-[44px] flex items-center justify-center rounded-lg border-2 text-base sm:text-lg font-semibold transition-all ${
                 isSelected
-                  ? 'bg-gray-900 text-white border-gray-900 shadow-sm scale-105'
-                  : 'bg-white text-gray-700 border-gray-200 hover:border-gray-400 hover:text-gray-900'
+                  ? 'bg-ink text-ink-on-dark border-line shadow-sm scale-105'
+                  : 'bg-surface-1 text-ink-2 border-line hover:border-line-strong hover:text-ink'
               } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
               aria-label={`Rate ${n}`}
               aria-pressed={isSelected}
@@ -437,7 +435,7 @@ function ScaleInput({ question, value, onChange, disabled }: ScaleInputProps) {
         })}
       </div>
       {(question.scale_min_label || question.scale_max_label) && (
-        <div className="flex justify-between mt-3 text-xs text-gray-400">
+        <div className="flex justify-between mt-3 text-xs text-ink-4">
           <span>
             {min}
             {question.scale_min_label ? ` — ${question.scale_min_label}` : ''}
@@ -472,8 +470,8 @@ function YesNoInput({ value, onChange, disabled }: YesNoInputProps) {
             onClick={() => onChange(opt)}
             className={`flex-1 py-4 sm:py-5 rounded-lg border-2 text-base sm:text-lg font-semibold transition-all capitalize ${
               isSelected
-                ? 'bg-gray-900 text-white border-gray-900 shadow-sm'
-                : 'bg-white text-gray-700 border-gray-200 hover:border-gray-400 hover:text-gray-900'
+                ? 'bg-ink text-ink-on-dark border-line shadow-sm'
+                : 'bg-surface-1 text-ink-2 border-line hover:border-line-strong hover:text-ink'
             } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
             aria-pressed={isSelected}
           >

--- a/src/app/questionnaire/[token]/layout.tsx
+++ b/src/app/questionnaire/[token]/layout.tsx
@@ -18,7 +18,7 @@ export default function QuestionnaireLayout({
       enableSystem={false}
       storageKey="questionnaire-theme"
     >
-      <div className="min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-100">
+      <div className="min-h-screen  ">
         {children}
         <Toaster position="top-center" richColors />
       </div>

--- a/src/app/questionnaire/[token]/page.tsx
+++ b/src/app/questionnaire/[token]/page.tsx
@@ -38,8 +38,8 @@ export default function QuestionnairePage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <Loader2 className="h-8 w-8 animate-spin text-gray-400 mx-auto mb-4" />
-          <p className="text-gray-500 text-sm">Loading questionnaire...</p>
+          <Loader2 className="h-8 w-8 animate-spin text-ink-4 mx-auto mb-4" />
+          <p className="text-ink-3 text-sm">Loading questionnaire...</p>
         </div>
       </div>
     )
@@ -49,13 +49,13 @@ export default function QuestionnairePage() {
     return (
       <div className="min-h-screen flex items-center justify-center px-4">
         <div className="text-center max-w-md">
-          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-6">
-            <AlertCircle className="h-8 w-8 text-gray-400" />
+          <div className="w-16 h-16 bg-surface-3 rounded-full flex items-center justify-center mx-auto mb-6">
+            <AlertCircle className="h-8 w-8 text-ink-4" />
           </div>
-          <h1 className="text-xl font-semibold text-gray-900 mb-3">
+          <h1 className="text-xl font-semibold text-ink mb-3">
             Questionnaire Unavailable
           </h1>
-          <p className="text-gray-500 leading-relaxed">{errorMessage}</p>
+          <p className="text-ink-3 leading-relaxed">{errorMessage}</p>
         </div>
       </div>
     )

--- a/src/app/resources/components/create-resource-dialog.tsx
+++ b/src/app/resources/components/create-resource-dialog.tsx
@@ -203,7 +203,7 @@ export function CreateResourceDialog({
           {/* Title */}
           <div className="space-y-2">
             <Label htmlFor="resource-title">
-              Title <span className="text-red-500">*</span>
+              Title <span className="text-vermillion">*</span>
             </Label>
             <Input
               id="resource-title"
@@ -222,17 +222,15 @@ export function CreateResourceDialog({
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
               className={`relative rounded-lg border-2 transition-colors ${
-                isDragging
-                  ? 'border-gray-900 dark:border-white bg-gray-50 dark:bg-gray-800'
-                  : 'border-gray-200 dark:border-gray-700'
+                isDragging ? 'border-line bg-paper ' : 'border-line '
               }`}
             >
               {/* Drag overlay */}
               {isDragging && (
-                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-gray-50/90 dark:bg-gray-800/90 border-2 border-dashed border-gray-400 dark:border-gray-500">
+                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-paper/90 border-2 border-dashed border-line-strong ">
                   <div className="text-center">
-                    <Upload className="h-8 w-8 text-gray-500 dark:text-gray-400 mx-auto mb-2" />
-                    <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                    <Upload className="h-8 w-8 text-ink-3 mx-auto mb-2" />
+                    <p className="text-sm font-medium text-ink-3 ">
                       Drop your file here
                     </p>
                   </div>
@@ -243,13 +241,13 @@ export function CreateResourceDialog({
                 /* File selected view */
                 <div className="flex items-center gap-3 p-4">
                   <div className="flex-shrink-0">
-                    <File className="h-8 w-8 text-gray-500 dark:text-gray-400" />
+                    <File className="h-8 w-8 text-ink-3 " />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    <p className="text-sm font-medium text-ink truncate">
                       {form.selectedFile.name}
                     </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-ink-3 ">
                       {formatFileSize(form.selectedFile.size)}
                     </p>
                   </div>
@@ -259,7 +257,7 @@ export function CreateResourceDialog({
                       variant="ghost"
                       size="sm"
                       onClick={() => fileInputRef.current?.click()}
-                      className="h-8 w-8 p-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      className="h-8 w-8 p-0 text-ink-4 hover:text-ink-3 "
                       title="Replace file"
                     >
                       <RefreshCw className="h-4 w-4" />
@@ -269,7 +267,7 @@ export function CreateResourceDialog({
                       variant="ghost"
                       size="sm"
                       onClick={removeFile}
-                      className="h-8 w-8 p-0 text-gray-400 hover:text-red-500"
+                      className="h-8 w-8 p-0 text-ink-4 hover:text-vermillion"
                       title="Remove file"
                     >
                       <X className="h-4 w-4" />
@@ -292,7 +290,7 @@ export function CreateResourceDialog({
                       variant="ghost"
                       size="sm"
                       onClick={() => fileInputRef.current?.click()}
-                      className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 gap-1.5"
+                      className="text-xs text-ink-4 hover:text-ink-3 gap-1.5"
                     >
                       <Upload className="h-3.5 w-3.5" />
                       Browse files
@@ -314,7 +312,7 @@ export function CreateResourceDialog({
 
             {/* Type indicator */}
             {hasContent && (
-              <div className="flex items-center justify-end gap-1.5 text-xs text-gray-400">
+              <div className="flex items-center justify-end gap-1.5 text-xs text-ink-4">
                 {detectedType === 'file' && <File className="h-3 w-3" />}
                 {detectedType === 'link' && <Link2 className="h-3 w-3" />}
                 {detectedType === 'text' && <FileText className="h-3 w-3" />}
@@ -327,13 +325,13 @@ export function CreateResourceDialog({
         {/* Upload progress bar */}
         {uploadProgress !== null && uploadProgress !== undefined && (
           <div className="space-y-1.5 pt-2">
-            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center justify-between text-xs text-ink-3 ">
               <span>Uploading file...</span>
               <span>{uploadProgress}%</span>
             </div>
-            <div className="h-2 w-full rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden">
+            <div className="h-2 w-full rounded-full bg-surface-3 overflow-hidden">
               <div
-                className="h-full rounded-full bg-gray-900 dark:bg-white transition-all duration-300 ease-out"
+                className="h-full rounded-full bg-ink transition-all duration-300 ease-out"
                 style={{ width: `${uploadProgress}%` }}
               />
             </div>
@@ -345,14 +343,14 @@ export function CreateResourceDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
             disabled={isPending}
-            className="border-gray-300 dark:border-gray-600"
+            className="border-line-strong "
           >
             Cancel
           </Button>
           <Button
             onClick={onSubmit}
             disabled={!canSubmit}
-            className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+            className="bg-ink hover:bg-ink-2 "
           >
             {uploadProgress !== null && uploadProgress !== undefined
               ? `Uploading ${uploadProgress}%`

--- a/src/app/resources/components/edit-resource-dialog.tsx
+++ b/src/app/resources/components/edit-resource-dialog.tsx
@@ -73,7 +73,7 @@ export function EditResourceDialog({
               onChange={e =>
                 setField('category', e.target.value as ResourceCategory)
               }
-              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-400 focus:border-transparent"
+              className="w-full rounded-md border border-line-strong bg-surface-1 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-line focus:border-transparent"
             >
               <option value="general">General</option>
               <option value="worksheet">Worksheet</option>
@@ -100,14 +100,14 @@ export function EditResourceDialog({
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
-            className="border-gray-300 dark:border-gray-600"
+            className="border-line-strong "
           >
             Cancel
           </Button>
           <Button
             onClick={onSubmit}
             disabled={!form.title.trim() || isPending}
-            className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+            className="bg-ink hover:bg-ink-2 "
           >
             {isPending ? 'Saving...' : 'Save Changes'}
           </Button>

--- a/src/app/resources/components/resource-card.tsx
+++ b/src/app/resources/components/resource-card.tsx
@@ -82,7 +82,7 @@ export function ResourceCard({
 
   return (
     <div
-      className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer transition-colors"
+      className="flex items-center gap-3 px-4 py-3 border-b border-line hover:bg-paper cursor-pointer transition-colors"
       onClick={() => onView(resource)}
     >
       {/* Category Icon */}
@@ -93,12 +93,12 @@ export function ResourceCard({
       {/* Title + Description */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+          <h3 className="text-sm font-medium text-ink truncate">
             {resource.title}
           </h3>
         </div>
         {resource.description && (
-          <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+          <p className="text-xs text-ink-3 truncate mt-0.5">
             {resource.description}
           </p>
         )}
@@ -122,7 +122,7 @@ export function ResourceCard({
             <PopoverTrigger asChild>
               <Badge
                 variant="outline"
-                className="text-xs gap-1 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="text-xs gap-1 cursor-pointer hover:bg-surface-3 "
                 onClick={e => e.stopPropagation()}
               >
                 <Share2 className="h-3 w-3" />
@@ -134,20 +134,18 @@ export function ResourceCard({
               className="w-auto max-w-64 p-3"
               onClick={e => e.stopPropagation()}
             >
-              <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
-                Shared with
-              </p>
+              <p className="text-xs font-medium text-ink-3 mb-2">Shared with</p>
               <div className="flex flex-wrap gap-1.5">
                 {resource.shares?.slice(0, 3).map(share => (
                   <span
                     key={share.id}
-                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800"
+                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border border-line text-ink-2 bg-paper "
                   >
                     {share.shared_with_name || 'Unknown'}
                   </span>
                 ))}
                 {shareCount > 3 && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700">
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-ink-3 bg-surface-3 ">
                     +{shareCount - 3} more
                   </span>
                 )}
@@ -156,7 +154,7 @@ export function ResourceCard({
           </Popover>
         )}
 
-        <span className="text-xs text-gray-400 hidden lg:inline">
+        <span className="text-xs text-ink-4 hidden lg:inline">
           {formatDate(resource.created_at)}
         </span>
 
@@ -192,7 +190,7 @@ export function ResourceCard({
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => onDelete(resource)}
-                  className="text-red-600"
+                  className="text-vermillion"
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Delete

--- a/src/app/resources/components/resource-detail-dialog.tsx
+++ b/src/app/resources/components/resource-detail-dialog.tsx
@@ -109,7 +109,7 @@ export function ResourceDetailDialog({
                 {resource.title}
               </SheetTitle>
               {resource.description && (
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                <p className="text-sm text-ink-3 mt-1">
                   {resource.description}
                 </p>
               )}
@@ -138,7 +138,7 @@ export function ResourceDetailDialog({
           </div>
 
           {/* Stats row */}
-          <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400 py-3 border-y border-gray-100 dark:border-gray-700">
+          <div className="flex items-center gap-4 text-sm text-ink-3 py-3 border-y border-line ">
             <span className="flex items-center gap-1.5">
               <Eye className="h-4 w-4" />
               {resource.view_count} views
@@ -156,36 +156,30 @@ export function ResourceDetailDialog({
           {/* Content preview */}
           {resource.content ? (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Content
-              </h4>
-              <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap leading-relaxed">
+              <h4 className="text-sm font-medium text-ink-2 ">Content</h4>
+              <div className="p-4 bg-paper rounded-lg text-sm text-ink-2 whitespace-pre-wrap leading-relaxed">
                 {resource.content}
               </div>
             </div>
           ) : !resource.file_url && !resource.content_url ? (
-            <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg text-center">
-              <FileText className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
-              <p className="text-sm text-gray-400 dark:text-gray-500">
-                No content added yet
-              </p>
+            <div className="p-4 bg-paper rounded-lg text-center">
+              <FileText className="h-8 w-8 text-ink-2 mx-auto mb-2" />
+              <p className="text-sm text-ink-4 ">No content added yet</p>
             </div>
           ) : null}
 
           {/* File details */}
           {resource.file_url && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                File
-              </h4>
-              <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <FileText className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+              <h4 className="text-sm font-medium text-ink-2 ">File</h4>
+              <div className="flex items-center gap-3 p-3 bg-paper rounded-lg">
+                <FileText className="h-5 w-5 text-ink-3 " />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                  <p className="text-sm font-medium text-ink truncate">
                     {resource.file_type || 'File'}
                   </p>
                   {resource.file_size && (
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-ink-3 ">
                       {formatFileSize(resource.file_size)}
                     </p>
                   )}
@@ -205,12 +199,10 @@ export function ResourceDetailDialog({
           {/* Link details */}
           {resource.content_url && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Link
-              </h4>
-              <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <Link2 className="h-5 w-5 text-gray-500 dark:text-gray-400" />
-                <p className="flex-1 text-sm text-blue-600 truncate">
+              <h4 className="text-sm font-medium text-ink-2 ">Link</h4>
+              <div className="flex items-center gap-3 p-3 bg-paper rounded-lg">
+                <Link2 className="h-5 w-5 text-ink-3 " />
+                <p className="flex-1 text-sm text-ds-accent truncate">
                   {resource.content_url}
                 </p>
                 <Button
@@ -234,7 +226,7 @@ export function ResourceDetailDialog({
           {/* Tags */}
           {resource.tags && resource.tags.length > 0 && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+              <h4 className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
                 <Tag className="h-4 w-4" />
                 Tags
               </h4>
@@ -251,7 +243,7 @@ export function ResourceDetailDialog({
           {/* Shares */}
           {resource.shares && resource.shares.length > 0 && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+              <h4 className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
                 <Share2 className="h-4 w-4" />
                 Shared with ({resource.shares.length})
               </h4>
@@ -259,16 +251,16 @@ export function ResourceDetailDialog({
                 {resource.shares.map(share => (
                   <div
                     key={share.id}
-                    className="flex items-center justify-between p-2 bg-gray-50 dark:bg-gray-800 rounded-lg text-sm"
+                    className="flex items-center justify-between p-2 bg-paper rounded-lg text-sm"
                   >
-                    <span className="text-gray-700 dark:text-gray-300">
+                    <span className="text-ink-2 ">
                       {share.shared_with_name || 'Client'}
                     </span>
                     {isOwner && (
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="h-6 w-6 p-0 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30"
+                        className="h-6 w-6 p-0 text-ink-4 hover:text-vermillion hover:bg-vermillion-bg "
                         onClick={() =>
                           unshareResource.mutate({
                             resourceId: resource.id,
@@ -292,7 +284,7 @@ export function ResourceDetailDialog({
 
           {/* Scope details */}
           {(resource.client_id || resource.session_id) && (
-            <div className="space-y-1 text-sm text-gray-500 dark:text-gray-400">
+            <div className="space-y-1 text-sm text-ink-3 ">
               {resource.client_id && <p>Client ID: {resource.client_id}</p>}
               {resource.session_id && <p>Session ID: {resource.session_id}</p>}
             </div>
@@ -300,7 +292,7 @@ export function ResourceDetailDialog({
 
           {/* Action buttons */}
           {(canShare || canEdit) && (
-            <div className="flex gap-2 pt-4 border-t border-gray-100 dark:border-gray-700">
+            <div className="flex gap-2 pt-4 border-t border-line ">
               {canShare && onShare && (
                 <Button
                   variant="outline"
@@ -330,7 +322,7 @@ export function ResourceDetailDialog({
                   <Button
                     variant="outline"
                     size="sm"
-                    className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30"
+                    className="text-vermillion hover:text-vermillion hover:bg-vermillion-bg "
                     onClick={() => {
                       onOpenChange(false)
                       onDelete(resource)

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -286,28 +286,25 @@ export default function CoachResourcesPage() {
       label: 'Total Resources',
       value: totalResources,
       icon: FolderOpen,
-      color: 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400',
+      color: 'bg-ds-accent-bg text-ds-accent ',
     },
     {
       label: 'Personal',
       value: personalCount,
       icon: User,
-      color:
-        'bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400',
+      color: 'bg-forest-bg text-forest ',
     },
     {
       label: 'Shared',
       value: sharedCount,
       icon: Share2,
-      color:
-        'bg-purple-50 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400',
+      color: 'bg-indigo-bg text-indigo ',
     },
     {
       label: 'Total Downloads',
       value: totalDownloads,
       icon: Download,
-      color:
-        'bg-orange-50 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400',
+      color: 'bg-amber-token-bg text-amber-token ',
     },
   ]
 
@@ -328,10 +325,8 @@ export default function CoachResourcesPage() {
       <PageLayout>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="text-center py-12">
-            <AlertCircle className="size-12 mx-auto mb-4 text-red-600" />
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
-              Failed to load resources
-            </p>
+            <AlertCircle className="size-12 mx-auto mb-4 text-vermillion" />
+            <p className="text-ink-3 mb-4">Failed to load resources</p>
             <Button onClick={() => refetch()} variant="outline">
               <RefreshCw className="h-4 w-4 mr-2" />
               Retry
@@ -348,10 +343,8 @@ export default function CoachResourcesPage() {
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-              Resources
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400 mt-2">
+            <h1 className="text-3xl font-bold text-ink ">Resources</h1>
+            <p className="text-ink-3 mt-2">
               Manage and share resources with your clients
             </p>
           </div>
@@ -360,7 +353,7 @@ export default function CoachResourcesPage() {
               variant="outline"
               size="sm"
               onClick={() => refetch()}
-              className="border-gray-300 dark:border-gray-600"
+              className="border-line-strong "
             >
               <RefreshCw className="h-4 w-4" />
             </Button>
@@ -381,22 +374,17 @@ export default function CoachResourcesPage() {
           {statCards.map(stat => {
             const StatIcon = stat.icon
             return (
-              <Card
-                key={stat.label}
-                className="border-gray-200 dark:border-gray-700"
-              >
+              <Card key={stat.label} className="border-line ">
                 <CardContent className="pt-6">
                   <div className="flex items-center gap-3">
                     <div className={`p-2 rounded-lg ${stat.color}`}>
                       <StatIcon className="h-5 w-5" />
                     </div>
                     <div>
-                      <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                      <p className="text-2xl font-bold text-ink ">
                         {stat.value}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
-                        {stat.label}
-                      </p>
+                      <p className="text-xs text-ink-3 ">{stat.label}</p>
                     </div>
                   </div>
                 </CardContent>
@@ -407,7 +395,7 @@ export default function CoachResourcesPage() {
 
         {/* Search Bar */}
         <div className="relative mb-6">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-4" />
           <Input
             placeholder="Search resources..."
             value={searchQuery}
@@ -426,8 +414,8 @@ export default function CoachResourcesPage() {
                 onClick={() => setScopeFilter(filter.value)}
                 className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors whitespace-nowrap ${
                   scopeFilter === filter.value
-                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                    : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
+                    ? 'bg-ink text-ink-on-dark '
+                    : 'bg-surface-3 text-ink-3 hover:bg-surface-3 '
                 }`}
               >
                 <FilterIcon className="h-3.5 w-3.5" />
@@ -439,20 +427,20 @@ export default function CoachResourcesPage() {
 
         {/* Resource count */}
         {total > 0 && (
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          <p className="text-sm text-ink-3 mb-4">
             {total} resource{total !== 1 ? 's' : ''}
           </p>
         )}
 
         {/* Resources List */}
         {resources.length === 0 ? (
-          <Card className="border-2 border-dashed border-gray-300 dark:border-gray-600">
+          <Card className="border-2 border-dashed border-line-strong ">
             <CardContent className="flex flex-col items-center justify-center py-16">
-              <BookOpen className="h-16 w-16 text-gray-400 mb-4" />
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              <BookOpen className="h-16 w-16 text-ink-4 mb-4" />
+              <h3 className="text-lg font-semibold text-ink mb-2">
                 No Resources Yet
               </h3>
-              <p className="text-gray-600 dark:text-gray-400 text-center max-w-md mb-6">
+              <p className="text-ink-3 text-center max-w-md mb-6">
                 Start sharing resources with your clients. Upload documents,
                 share links, or write articles.
               </p>
@@ -468,7 +456,7 @@ export default function CoachResourcesPage() {
             </CardContent>
           </Card>
         ) : (
-          <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-gray-800">
+          <div className="border border-line rounded-lg overflow-hidden bg-surface-1 ">
             {resources.map(resource => (
               <ResourceCard
                 key={resource.id}
@@ -560,13 +548,13 @@ export default function CoachResourcesPage() {
                   {selectedClients.map((client: any) => (
                     <span
                       key={client.id}
-                      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-900 dark:bg-white text-white dark:text-gray-900"
+                      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-ink text-ink-on-dark "
                     >
                       {client.name}
                       <button
                         type="button"
                         onClick={() => toggleClient(client.id)}
-                        className="hover:bg-white/20 dark:hover:bg-black/20 rounded-full p-0.5"
+                        className="hover:bg-surface-1/20 rounded-full p-0.5"
                       >
                         <X className="h-3 w-3" />
                       </button>
@@ -578,7 +566,7 @@ export default function CoachResourcesPage() {
               {/* Search + Select All */}
               <div className="flex items-center gap-2">
                 <div className="relative flex-1">
-                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4" />
                   <Input
                     value={clientSearch}
                     onChange={e => setClientSearch(e.target.value)}
@@ -610,22 +598,20 @@ export default function CoachResourcesPage() {
                       onClick={() => toggleClient(client.id)}
                       className={cn(
                         'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors',
-                        isSelected
-                          ? 'bg-gray-100 dark:bg-gray-800'
-                          : 'hover:bg-gray-50 dark:hover:bg-gray-800/50',
+                        isSelected ? 'bg-surface-3 ' : 'hover:bg-paper ',
                       )}
                     >
                       <div
                         className={cn(
                           'w-4 h-4 rounded border-2 flex items-center justify-center shrink-0',
                           isSelected
-                            ? 'border-gray-900 dark:border-white bg-gray-900 dark:bg-white'
-                            : 'border-gray-300 dark:border-gray-500',
+                            ? 'border-line bg-ink '
+                            : 'border-line-strong ',
                         )}
                       >
                         {isSelected && (
                           <svg
-                            className="h-2.5 w-2.5 text-white dark:text-gray-900"
+                            className="h-2.5 w-2.5 text-ink-on-dark "
                             fill="none"
                             viewBox="0 0 24 24"
                             stroke="currentColor"
@@ -640,11 +626,11 @@ export default function CoachResourcesPage() {
                         )}
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <p className="text-sm font-medium text-ink truncate">
                           {client.name}
                         </p>
                         {client.email && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                          <p className="text-xs text-ink-3 truncate">
                             {client.email}
                           </p>
                         )}
@@ -653,7 +639,7 @@ export default function CoachResourcesPage() {
                   )
                 })}
                 {filteredShareClients.length === 0 && clientSearch.trim() && (
-                  <p className="text-sm text-gray-400 text-center py-4">
+                  <p className="text-sm text-ink-4 text-center py-4">
                     No clients found
                   </p>
                 )}
@@ -661,7 +647,7 @@ export default function CoachResourcesPage() {
             </div>
 
             {selectedClientIds.size > 0 && (
-              <DialogFooter className="pt-3 border-t border-gray-100 dark:border-gray-800">
+              <DialogFooter className="pt-3 border-t border-line ">
                 <Button
                   variant="outline"
                   onClick={() => setSelectedClientIds(new Set())}
@@ -699,8 +685,8 @@ export default function CoachResourcesPage() {
           <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-full">
-                  <AlertTriangle className="h-5 w-5 text-red-600" />
+                <div className="p-2 bg-vermillion-bg rounded-full">
+                  <AlertTriangle className="h-5 w-5 text-vermillion" />
                 </div>
                 <AlertDialogTitle>Delete Resource</AlertDialogTitle>
               </div>
@@ -720,7 +706,7 @@ export default function CoachResourcesPage() {
                   handleDeleteConfirm()
                 }}
                 disabled={deleteResourceMutation.isPending}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-vermillion hover:bg-vermillion"
               >
                 {deleteResourceMutation.isPending ? (
                   <>

--- a/src/app/sessions/[sessionId]/components/analysis-print-view.tsx
+++ b/src/app/sessions/[sessionId]/components/analysis-print-view.tsx
@@ -1,5 +1,14 @@
 'use client'
 
+/**
+ * Print-only view. Hex literals here mirror DS tokens:
+ *   #0A0A0A=ink · #404040=ink-2 · #737373=ink-3 · #A3A3A3=ink-4
+ *   #E5E7EB=line · #F3F4F6=surface-3 · #F9FAFB=surface-2
+ *   #15803D=forest · #B91C1C=vermillion · #B45309=amber-token · #4338CA=indigo · #2563EB=ds-accent
+ * The print medium drops CSS variables in some renderers, so hex stays here
+ * intentionally. Do not migrate to Tailwind utilities.
+ */
+
 import React, { useRef, useCallback } from 'react'
 import { formatDate } from '@/lib/date-utils'
 import type {
@@ -32,13 +41,13 @@ function getScoreLevelLabel(level: ScoreLevel): string {
 function getLevelColor(level: ScoreLevel): string {
   switch (level) {
     case 'sophisticated':
-      return '#059669'
+      return '#15803D'
     case 'effective':
-      return '#2563eb'
+      return '#2563EB'
     case 'developing':
-      return '#d97706'
+      return '#B45309'
     case 'ineffective':
-      return '#dc2626'
+      return '#B91C1C'
   }
 }
 
@@ -217,7 +226,7 @@ export function AnalysisPrintView({
           * { margin: 0; padding: 0; box-sizing: border-box; }
           body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            color: #1a1a1a;
+            color: #0A0A0A;
             font-size: 11px;
             line-height: 1.5;
             -webkit-print-color-adjust: exact;
@@ -280,28 +289,28 @@ export function AnalysisPrintView({
         <div ref={printRef}>
           <style>{`
             .print-header { text-align: center; margin-bottom: 24px; padding-bottom: 16px; border-bottom: 2px solid #e5e7eb; }
-            .print-header h1 { font-size: 20px; font-weight: 700; color: #111; margin-bottom: 4px; }
-            .print-header .subtitle { font-size: 13px; color: #6b7280; }
-            .print-header .meta { display: flex; justify-content: center; gap: 24px; margin-top: 8px; font-size: 11px; color: #6b7280; }
+            .print-header h1 { font-size: 20px; font-weight: 700; color: #0A0A0A; margin-bottom: 4px; }
+            .print-header .subtitle { font-size: 13px; color: #737373; }
+            .print-header .meta { display: flex; justify-content: center; gap: 24px; margin-top: 8px; font-size: 11px; color: #737373; }
             .print-header .meta span { display: flex; align-items: center; gap: 4px; }
 
             .section { margin-bottom: 20px; }
-            .section-title { font-size: 14px; font-weight: 700; color: #111; margin-bottom: 10px; padding-bottom: 6px; border-bottom: 1px solid #e5e7eb; text-transform: uppercase; letter-spacing: 0.5px; }
+            .section-title { font-size: 14px; font-weight: 700; color: #0A0A0A; margin-bottom: 10px; padding-bottom: 6px; border-bottom: 1px solid #e5e7eb; text-transform: uppercase; letter-spacing: 0.5px; }
 
             .score-hero { display: flex; align-items: flex-start; gap: 24px; padding: 16px; border: 1px solid #e5e7eb; border-radius: 8px; margin-bottom: 20px; }
             .score-circle { text-align: center; min-width: 100px; }
-            .score-circle .big-score { font-size: 36px; font-weight: 800; color: #111; line-height: 1; }
-            .score-circle .big-score span { font-size: 18px; color: #9ca3af; font-weight: 400; }
+            .score-circle .big-score { font-size: 36px; font-weight: 800; color: #0A0A0A; line-height: 1; }
+            .score-circle .big-score span { font-size: 18px; color: #A3A3A3; font-weight: 400; }
             .score-circle .level-badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 11px; font-weight: 600; margin-top: 6px; }
-            .score-circle .label { font-size: 10px; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 4px; }
+            .score-circle .label { font-size: 10px; color: #A3A3A3; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 4px; }
 
             .score-details { flex: 1; }
             .score-details .quick-stats { display: flex; gap: 16px; margin-bottom: 12px; }
             .score-details .stat-box { padding: 6px 12px; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; text-align: center; }
-            .score-details .stat-box .val { font-size: 12px; font-weight: 600; color: #111; }
-            .score-details .stat-box .lbl { font-size: 9px; color: #9ca3af; text-transform: uppercase; }
+            .score-details .stat-box .val { font-size: 12px; font-weight: 600; color: #0A0A0A; }
+            .score-details .stat-box .lbl { font-size: 9px; color: #A3A3A3; text-transform: uppercase; }
 
-            .assessment-text { font-size: 11.5px; line-height: 1.6; color: #374151; }
+            .assessment-text { font-size: 11.5px; line-height: 1.6; color: #404040; }
 
             .two-col { display: flex; gap: 16px; }
             .two-col > div { flex: 1; }
@@ -309,43 +318,43 @@ export function AnalysisPrintView({
             .list-card { padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 6px; margin-bottom: 8px; }
             .list-card .card-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
             .list-card ul { padding-left: 16px; }
-            .list-card li { font-size: 11px; color: #374151; margin-bottom: 4px; line-height: 1.5; }
+            .list-card li { font-size: 11px; color: #404040; margin-bottom: 4px; line-height: 1.5; }
 
-            .strengths-title { color: #059669; }
+            .strengths-title { color: #15803D; }
             .strengths-card { border-color: #d1fae5; background: #f0fdf4; }
-            .growth-title { color: #d97706; }
+            .growth-title { color: #B45309; }
             .growth-card { border-color: #fef3c7; background: #fffbeb; }
-            .breakthrough-title { color: #7c3aed; }
-            .breakthrough-card { border-color: #ede9fe; background: #f5f3ff; }
+            .breakthrough-title { color: #4338CA; }
+            .breakthrough-card { border-color: #E0E7FF; background: #EEF2FF; }
 
             .emotions-row { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
-            .emotion-tag { display: inline-block; padding: 2px 8px; background: #f3f4f6; border-radius: 10px; font-size: 10px; color: #4b5563; }
+            .emotion-tag { display: inline-block; padding: 2px 8px; background: #f3f4f6; border-radius: 10px; font-size: 10px; color: #404040; }
 
             .metric-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
             .metric-card { border: 1px solid #e5e7eb; border-radius: 8px; padding: 10px 12px; page-break-inside: avoid; }
             .metric-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 6px; }
-            .metric-name { font-size: 12px; font-weight: 700; color: #111; }
-            .metric-score { font-size: 16px; font-weight: 800; color: #111; }
-            .metric-desc { font-size: 10px; color: #6b7280; margin-bottom: 6px; }
+            .metric-name { font-size: 12px; font-weight: 700; color: #0A0A0A; }
+            .metric-score { font-size: 16px; font-weight: 800; color: #0A0A0A; }
+            .metric-desc { font-size: 10px; color: #737373; margin-bottom: 6px; }
             .metric-badge { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 9px; font-weight: 600; margin-left: 6px; }
             .metric-bar { height: 4px; background: #e5e7eb; border-radius: 2px; margin-bottom: 8px; }
             .metric-bar-fill { height: 100%; border-radius: 2px; }
             .metric-justification { padding: 8px 10px; border-radius: 6px; margin-bottom: 6px; border: 1px solid #e5e7eb; background: #f9fafb; }
-            .metric-justification .j-title { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: #6b7280; margin-bottom: 3px; }
-            .metric-justification .j-text { font-size: 10.5px; color: #374151; line-height: 1.5; }
-            .metric-level { font-size: 10px; color: #6b7280; line-height: 1.4; }
-            .metric-level strong { color: #374151; }
+            .metric-justification .j-title { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: #737373; margin-bottom: 3px; }
+            .metric-justification .j-text { font-size: 10.5px; color: #404040; line-height: 1.5; }
+            .metric-level { font-size: 10px; color: #737373; line-height: 1.4; }
+            .metric-level strong { color: #404040; }
 
             .golive-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px; }
             .golive-card { text-align: center; padding: 10px 6px; border: 1px solid #e5e7eb; border-radius: 8px; }
-            .golive-label { font-size: 10px; color: #6b7280; font-weight: 500; margin-bottom: 4px; }
-            .golive-score { font-size: 18px; font-weight: 800; color: #111; }
+            .golive-label { font-size: 10px; color: #737373; font-weight: 500; margin-bottom: 4px; }
+            .golive-score { font-size: 18px; font-weight: 800; color: #0A0A0A; }
             .golive-badge { display: inline-block; padding: 1px 6px; border-radius: 10px; font-size: 8px; font-weight: 600; margin-top: 2px; }
 
             .suggestions-list { padding-left: 16px; }
-            .suggestions-list li { font-size: 11px; color: #374151; margin-bottom: 6px; line-height: 1.5; }
+            .suggestions-list li { font-size: 11px; color: #404040; margin-bottom: 6px; line-height: 1.5; }
 
-            .footer { margin-top: 24px; padding-top: 12px; border-top: 1px solid #e5e7eb; text-align: center; font-size: 9px; color: #9ca3af; }
+            .footer { margin-top: 24px; padding-top: 12px; border-top: 1px solid #e5e7eb; text-align: center; font-size: 9px; color: #A3A3A3; }
           `}</style>
 
           {/* Header */}
@@ -425,7 +434,7 @@ export function AnalysisPrintView({
                         fontWeight: 700,
                         textTransform: 'uppercase' as const,
                         letterSpacing: '0.5px',
-                        color: '#6b7280',
+                        color: '#737373',
                         marginBottom: '4px',
                       }}
                     >
@@ -506,7 +515,7 @@ export function AnalysisPrintView({
                     fontWeight: 700,
                     textTransform: 'uppercase' as const,
                     letterSpacing: '0.5px',
-                    color: '#6b7280',
+                    color: '#737373',
                     marginBottom: '4px',
                   }}
                 >

--- a/src/app/sessions/[sessionId]/components/group-aggregated-commitments.tsx
+++ b/src/app/sessions/[sessionId]/components/group-aggregated-commitments.tsx
@@ -32,13 +32,13 @@ interface ClientGroup {
 function getStatusColor(status: string) {
   switch (status) {
     case 'completed':
-      return 'bg-green-50 text-green-700 border-green-200'
+      return 'bg-forest-bg text-forest border-forest'
     case 'in_progress':
-      return 'bg-blue-50 text-blue-700 border-blue-200'
+      return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
     case 'draft':
-      return 'bg-amber-50 text-amber-700 border-amber-200'
+      return 'bg-amber-token-bg text-amber-token border-amber-token'
     default:
-      return 'bg-gray-50 text-gray-700 border-gray-200'
+      return 'bg-paper text-ink-2 border-line'
   }
 }
 

--- a/src/app/sessions/[sessionId]/components/pre-session-responses.tsx
+++ b/src/app/sessions/[sessionId]/components/pre-session-responses.tsx
@@ -38,7 +38,7 @@ export function PreSessionResponses({
           {isCompleted ? (
             <Badge
               variant="secondary"
-              className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-xs"
+              className="bg-forest-bg text-forest border-forest text-xs"
             >
               <CheckCircle2 className="h-3 w-3 mr-1" />
               Completed
@@ -48,7 +48,7 @@ export function PreSessionResponses({
           ) : (
             <Badge
               variant="secondary"
-              className="bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800 text-xs"
+              className="bg-amber-token-bg text-amber-token border-amber-token text-xs"
             >
               <Clock className="h-3 w-3 mr-1" />
               In Progress

--- a/src/app/sessions/[sessionId]/components/session-analysis-merged.tsx
+++ b/src/app/sessions/[sessionId]/components/session-analysis-merged.tsx
@@ -193,38 +193,35 @@ function getScoreLevelColor(level: ScoreLevel) {
   switch (level) {
     case 'sophisticated':
       return {
-        badge:
-          'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400',
-        progress: 'bg-emerald-500',
-        border: 'border-emerald-200 dark:border-emerald-800',
-        bg: 'bg-emerald-50 dark:bg-emerald-950/20',
-        dot: 'bg-emerald-500',
+        badge: 'bg-forest-bg text-forest ',
+        progress: 'bg-forest',
+        border: 'border-forest ',
+        bg: 'bg-forest-bg ',
+        dot: 'bg-forest',
       }
     case 'effective':
       return {
-        badge:
-          'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-        progress: 'bg-blue-500',
-        border: 'border-blue-200 dark:border-blue-800',
-        bg: 'bg-blue-50 dark:bg-blue-950/20',
-        dot: 'bg-blue-500',
+        badge: 'bg-ds-accent-bg text-ds-accent ',
+        progress: 'bg-ds-accent',
+        border: 'border-ds-accent ',
+        bg: 'bg-ds-accent-bg ',
+        dot: 'bg-ds-accent',
       }
     case 'developing':
       return {
-        badge:
-          'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-        progress: 'bg-amber-500',
-        border: 'border-amber-200 dark:border-amber-800',
-        bg: 'bg-amber-50 dark:bg-amber-950/20',
-        dot: 'bg-amber-500',
+        badge: 'bg-amber-token-bg text-amber-token ',
+        progress: 'bg-amber-token',
+        border: 'border-amber-token ',
+        bg: 'bg-amber-token-bg ',
+        dot: 'bg-amber-token',
       }
     case 'ineffective':
       return {
-        badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-        progress: 'bg-red-400',
-        border: 'border-red-200 dark:border-red-800',
-        bg: 'bg-red-50 dark:bg-red-950/20',
-        dot: 'bg-red-400',
+        badge: 'bg-vermillion-bg text-vermillion ',
+        progress: 'bg-vermillion',
+        border: 'border-vermillion ',
+        bg: 'bg-vermillion-bg ',
+        dot: 'bg-vermillion',
       }
   }
 }
@@ -254,7 +251,7 @@ function MetricCard({
       >
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-start gap-3 flex-1 min-w-0">
-            <div className="p-1.5 bg-white dark:bg-gray-800 rounded-lg border border-app-border mt-0.5">
+            <div className="p-1.5 bg-surface-1 rounded-lg border border-app-border mt-0.5">
               <Icon className="h-4 w-4 text-app-secondary" />
             </div>
             <div className="flex-1 min-w-0">
@@ -293,7 +290,7 @@ function MetricCard({
         <div className="px-4 pb-4 pt-0">
           {/* Justification - why this score was given */}
           {justification && (
-            <div className="bg-white dark:bg-gray-800 rounded-lg border border-app-border p-3 mt-1 mb-2">
+            <div className="bg-surface-1 rounded-lg border border-app-border p-3 mt-1 mb-2">
               <p className="text-xs font-medium text-app-secondary uppercase tracking-wider mb-1.5">
                 Why this score
               </p>
@@ -329,7 +326,7 @@ function MetricCard({
                   key={l}
                   className={`flex items-start gap-2 px-2 py-1.5 rounded text-xs ${
                     isActive
-                      ? 'bg-white dark:bg-gray-800 font-medium text-app-primary'
+                      ? 'bg-surface-1 font-medium text-app-primary'
                       : 'text-app-secondary/70'
                   }`}
                 >
@@ -641,7 +638,7 @@ export function SessionAnalysisMerged({
 
                         {/* Quick stats */}
                         <div className="grid grid-cols-2 gap-2 mt-4">
-                          <div className="text-center p-2 bg-white dark:bg-gray-800 rounded-lg border border-app-border">
+                          <div className="text-center p-2 bg-surface-1 rounded-lg border border-app-border">
                             <p className="text-sm font-semibold text-app-primary">
                               {coaching.sentiment.overall}
                             </p>
@@ -649,7 +646,7 @@ export function SessionAnalysisMerged({
                               Sentiment
                             </p>
                           </div>
-                          <div className="text-center p-2 bg-white dark:bg-gray-800 rounded-lg border border-app-border">
+                          <div className="text-center p-2 bg-surface-1 rounded-lg border border-app-border">
                             <p className="text-sm font-semibold text-app-primary">
                               {coaching.sentiment.engagement}
                             </p>
@@ -681,8 +678,8 @@ export function SessionAnalysisMerged({
                         coaching.key_strengths.length > 0 && (
                           <div>
                             <div className="flex items-center gap-1.5 mb-2">
-                              <Award className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-                              <h4 className="text-xs text-emerald-700 dark:text-emerald-400 uppercase tracking-wider font-medium">
+                              <Award className="h-3.5 w-3.5 text-forest " />
+                              <h4 className="text-xs text-forest uppercase tracking-wider font-medium">
                                 Key Strengths
                               </h4>
                             </div>
@@ -690,10 +687,10 @@ export function SessionAnalysisMerged({
                               {coaching.key_strengths.map((s, i) => (
                                 <div
                                   key={i}
-                                  className="flex items-start gap-2 p-2 bg-emerald-50 dark:bg-emerald-950/20 rounded-lg border border-emerald-100 dark:border-emerald-900/30"
+                                  className="flex items-start gap-2 p-2 bg-forest-bg rounded-lg border border-forest "
                                 >
-                                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400 mt-0.5 flex-shrink-0" />
-                                  <span className="text-xs text-emerald-800 dark:text-emerald-300 leading-relaxed">
+                                  <CheckCircle2 className="h-3.5 w-3.5 text-forest mt-0.5 flex-shrink-0" />
+                                  <span className="text-xs text-forest leading-relaxed">
                                     {s}
                                   </span>
                                 </div>
@@ -706,8 +703,8 @@ export function SessionAnalysisMerged({
                         coaching.areas_for_growth.length > 0 && (
                           <div>
                             <div className="flex items-center gap-1.5 mb-2">
-                              <TrendingUp className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
-                              <h4 className="text-xs text-amber-700 dark:text-amber-400 uppercase tracking-wider font-medium">
+                              <TrendingUp className="h-3.5 w-3.5 text-amber-token " />
+                              <h4 className="text-xs text-amber-token uppercase tracking-wider font-medium">
                                 Areas for Growth
                               </h4>
                             </div>
@@ -715,10 +712,10 @@ export function SessionAnalysisMerged({
                               {coaching.areas_for_growth.map((a, i) => (
                                 <div
                                   key={i}
-                                  className="flex items-start gap-2 p-2 bg-amber-50 dark:bg-amber-950/20 rounded-lg border border-amber-100 dark:border-amber-900/30"
+                                  className="flex items-start gap-2 p-2 bg-amber-token-bg rounded-lg border border-amber-token "
                                 >
-                                  <ArrowRight className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-                                  <span className="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+                                  <ArrowRight className="h-3.5 w-3.5 text-amber-token mt-0.5 flex-shrink-0" />
+                                  <span className="text-xs text-amber-token leading-relaxed">
                                     {a}
                                   </span>
                                 </div>
@@ -733,8 +730,8 @@ export function SessionAnalysisMerged({
                       coaching.breakthrough_moments.length > 0 && (
                         <div>
                           <div className="flex items-center gap-1.5 mb-2">
-                            <Star className="h-3.5 w-3.5 text-purple-600 dark:text-purple-400" />
-                            <h4 className="text-xs text-purple-700 dark:text-purple-400 uppercase tracking-wider font-medium">
+                            <Star className="h-3.5 w-3.5 text-indigo " />
+                            <h4 className="text-xs text-indigo uppercase tracking-wider font-medium">
                               Breakthrough Moments
                             </h4>
                           </div>
@@ -742,10 +739,10 @@ export function SessionAnalysisMerged({
                             {coaching.breakthrough_moments.map((m, i) => (
                               <div
                                 key={i}
-                                className="flex items-start gap-2 p-2 bg-purple-50 dark:bg-purple-950/20 rounded-lg border border-purple-100 dark:border-purple-900/30"
+                                className="flex items-start gap-2 p-2 bg-indigo-bg rounded-lg border border-indigo "
                               >
-                                <Sparkles className="h-3.5 w-3.5 text-purple-600 dark:text-purple-400 mt-0.5 flex-shrink-0" />
-                                <span className="text-xs text-purple-800 dark:text-purple-300 leading-relaxed">
+                                <Sparkles className="h-3.5 w-3.5 text-indigo mt-0.5 flex-shrink-0" />
+                                <span className="text-xs text-indigo leading-relaxed">
                                   {m}
                                 </span>
                               </div>
@@ -830,7 +827,7 @@ export function SessionAnalysisMerged({
                         key={value.key}
                         className={`text-center p-4 rounded-xl ${colors.bg} border ${colors.border}`}
                       >
-                        <div className="w-10 h-10 mx-auto bg-white dark:bg-gray-800 border border-app-border rounded-full flex items-center justify-center mb-3">
+                        <div className="w-10 h-10 mx-auto bg-surface-1 border border-app-border rounded-full flex items-center justify-center mb-3">
                           <Icon className="h-5 w-5 text-app-secondary" />
                         </div>
                         <h4 className="text-xs font-medium text-app-secondary mb-1">

--- a/src/app/sessions/[sessionId]/components/session-commitments-list.tsx
+++ b/src/app/sessions/[sessionId]/components/session-commitments-list.tsx
@@ -129,11 +129,11 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return <CheckCircle2 className="h-4 w-4 text-green-600" />
+        return <CheckCircle2 className="h-4 w-4 text-forest" />
       case 'in_progress':
-        return <PlayCircle className="h-4 w-4 text-blue-600" />
+        return <PlayCircle className="h-4 w-4 text-ds-accent" />
       case 'draft':
-        return <FileEdit className="h-4 w-4 text-amber-600" />
+        return <FileEdit className="h-4 w-4 text-amber-token" />
       default:
         return <Circle className="h-4 w-4 text-app-secondary" />
     }
@@ -142,11 +142,11 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'text-green-700 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-900/30 dark:border-green-800'
+        return 'text-forest bg-forest-bg border-forest '
       case 'in_progress':
-        return 'text-blue-700 bg-blue-50 border-blue-200 dark:text-blue-400 dark:bg-blue-900/30 dark:border-blue-800'
+        return 'text-ds-accent bg-ds-accent-bg border-ds-accent '
       case 'draft':
-        return 'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-400 dark:bg-amber-900/30 dark:border-amber-800'
+        return 'text-amber-token bg-amber-token-bg border-amber-token '
       default:
         return 'text-app-primary bg-app-surface border-app-border'
     }
@@ -155,22 +155,22 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
   // Draft commitment item - special styling with accept/reject buttons
   if (isDraft) {
     return (
-      <div className="border border-amber-200 dark:border-amber-800 rounded-lg overflow-hidden bg-amber-50 dark:bg-amber-900/20">
+      <div className="border border-amber-token rounded-lg overflow-hidden bg-amber-token-bg ">
         {/* Header */}
         <div className="flex items-center justify-between gap-2 p-3">
           <div className="flex items-center gap-2 flex-1 min-w-0">
             <div className="flex-shrink-0">
-              <FileEdit className="h-4 w-4 text-amber-600" />
+              <FileEdit className="h-4 w-4 text-amber-token" />
             </div>
 
             <button
               onClick={() => setIsExpanded(!isExpanded)}
-              className="flex-shrink-0 p-0.5 hover:bg-amber-100 dark:hover:bg-amber-800/50 rounded transition-colors"
+              className="flex-shrink-0 p-0.5 hover:bg-amber-token-bg rounded transition-colors"
             >
               {isExpanded ? (
-                <ChevronDown className="h-4 w-4 text-amber-700 dark:text-amber-400" />
+                <ChevronDown className="h-4 w-4 text-amber-token " />
               ) : (
-                <ChevronRight className="h-4 w-4 text-amber-700 dark:text-amber-400" />
+                <ChevronRight className="h-4 w-4 text-amber-token " />
               )}
             </button>
 
@@ -191,7 +191,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
 
             <Badge
               variant="secondary"
-              className="bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/40 dark:text-amber-400 dark:border-amber-800 text-xs"
+              className="bg-amber-token-bg text-amber-token border-amber-token text-xs"
             >
               Draft
             </Badge>
@@ -226,7 +226,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
                   variant="outline"
                   onClick={handleConfirm}
                   disabled={isConfirming || isDiscarding}
-                  className="h-7 px-2 border-green-500 text-green-600 hover:bg-green-50 hover:text-green-700 dark:border-green-700 dark:text-green-400 dark:hover:bg-green-900/30 dark:hover:text-green-300"
+                  className="h-7 px-2 border-forest text-forest hover:bg-forest-bg hover:text-forest "
                   title="Accept commitment"
                 >
                   {isConfirming ? (
@@ -250,7 +250,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
                   variant="outline"
                   onClick={handleDiscard}
                   disabled={isConfirming || isDiscarding}
-                  className="h-7 px-2 border-red-300 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-300"
+                  className="h-7 px-2 border-vermillion text-vermillion hover:bg-vermillion-bg hover:text-vermillion "
                   title="Discard commitment"
                 >
                   {isDiscarding ? (
@@ -266,7 +266,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
 
         {/* Expanded Details */}
         {isExpanded && (
-          <div className="px-3 pb-3 pt-1 space-y-3 border-t border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10">
+          <div className="px-3 pb-3 pt-1 space-y-3 border-t border-amber-token bg-amber-token-bg/50 ">
             {/* Description */}
             <div>
               <label className="text-xs font-semibold text-app-primary mb-1 block">
@@ -294,7 +294,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
                 <label className="text-xs font-semibold text-app-primary mb-1 block">
                   From Transcript
                 </label>
-                <p className="text-sm text-app-secondary italic bg-white/50 dark:bg-gray-800/50 p-2 rounded border border-amber-100 dark:border-amber-800">
+                <p className="text-sm text-app-secondary italic bg-surface-1/50 p-2 rounded border border-amber-token ">
                   &ldquo;{commitment.transcript_context}&rdquo;
                 </p>
               </div>
@@ -451,7 +451,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
                 variant="ghost"
                 onClick={handleDiscard}
                 disabled={isDiscarding}
-                className="h-7 px-2 text-gray-400 dark:text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:text-red-400 dark:hover:bg-red-900/30"
+                className="h-7 px-2 text-ink-4 hover:text-vermillion hover:bg-vermillion-bg "
                 title="Delete commitment"
               >
                 {isDiscarding ? (
@@ -664,7 +664,7 @@ export function SessionCommitmentsList({
             {draftCount > 0 && (
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <span className="w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse" />
+                  <span className="w-1.5 h-1.5 bg-amber-token rounded-full animate-pulse" />
                   <span className="text-xs font-medium text-app-secondary uppercase tracking-wide">
                     Pending Review ({draftCount})
                   </span>

--- a/src/app/sessions/[sessionId]/components/session-commitments-list.tsx
+++ b/src/app/sessions/[sessionId]/components/session-commitments-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -525,8 +525,6 @@ interface SessionCommitmentsListProps {
   commitments: any[]
   onViewAll?: () => void
   onUpdate: () => void
-  isCompleted?: boolean
-  commitmentsLoaded?: boolean
   onCreateCommitment?: () => void
 }
 
@@ -536,32 +534,9 @@ export function SessionCommitmentsList({
   commitments,
   onViewAll,
   onUpdate,
-  isCompleted = false,
-  commitmentsLoaded = false,
   onCreateCommitment,
 }: SessionCommitmentsListProps) {
   const [extracting, setExtracting] = useState(false)
-
-  // Auto-extract commitments if none exist for completed sessions
-  // Wait for commitmentsLoaded to ensure query has finished before checking length
-  useEffect(() => {
-    if (!commitmentsLoaded) return
-    const storageKey = `auto-extract-commitments-${sessionId}`
-    if (
-      commitments.length === 0 &&
-      !extracting &&
-      isCompleted &&
-      !sessionStorage.getItem(storageKey)
-    ) {
-      sessionStorage.setItem(storageKey, '1')
-      setExtracting(true)
-      CommitmentService.extractFromSession(sessionId, clientId)
-        .then(() => onUpdate())
-        .catch(err => console.error('Auto-extract commitments failed:', err))
-        .finally(() => setExtracting(false))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [commitmentsLoaded, commitments.length, isCompleted, sessionId])
 
   const handleExtractCommitments = async () => {
     setExtracting(true)

--- a/src/app/sessions/[sessionId]/components/session-header.tsx
+++ b/src/app/sessions/[sessionId]/components/session-header.tsx
@@ -52,18 +52,18 @@ interface SessionHeaderProps {
 function getStatusDot(status: string) {
   switch (status) {
     case 'completed':
-      return 'bg-green-500'
+      return 'bg-forest'
     case 'in_progress':
     case 'active':
-      return 'bg-black animate-pulse'
+      return 'bg-ink animate-pulse'
     case 'pending_upload':
-      return 'bg-amber-500'
+      return 'bg-amber-token'
     case 'processing':
-      return 'bg-gray-400 animate-pulse'
+      return 'bg-line animate-pulse'
     case 'failed':
-      return 'bg-red-500'
+      return 'bg-vermillion'
     default:
-      return 'bg-gray-400'
+      return 'bg-line'
   }
 }
 
@@ -155,7 +155,7 @@ export default function SessionHeader({
 
               {/* Group badge */}
               {session.is_group_session && (
-                <Badge className="bg-purple-50 text-purple-700 border-purple-200 px-2 py-0.5 text-xs font-medium flex items-center gap-1">
+                <Badge className="bg-indigo-bg text-indigo border-indigo px-2 py-0.5 text-xs font-medium flex items-center gap-1">
                   <Users className="h-3 w-3" />
                   {session.participant_client_ids?.length || 0}
                 </Badge>
@@ -200,7 +200,7 @@ export default function SessionHeader({
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           onClick={onDelete}
-                          className="text-red-600 focus:text-red-600 focus:bg-red-50"
+                          className="text-vermillion focus:text-vermillion focus:bg-vermillion-bg"
                         >
                           <Trash2 className="h-4 w-4 mr-2" />
                           Delete Session

--- a/src/app/sessions/[sessionId]/components/session-notes-compact.tsx
+++ b/src/app/sessions/[sessionId]/components/session-notes-compact.tsx
@@ -172,9 +172,7 @@ export function SessionNotesCompact({
                   <div className="flex items-center gap-1.5 flex-shrink-0">
                     <span
                       className={`w-1.5 h-1.5 rounded-full ${
-                        note.note_type === 'shared'
-                          ? 'bg-gray-900 dark:bg-white'
-                          : 'bg-gray-400'
+                        note.note_type === 'shared' ? 'bg-ink ' : 'bg-line'
                       }`}
                     />
                     <span className="text-xs text-app-secondary">
@@ -203,11 +201,11 @@ export function SessionNotesCompact({
                       setCopiedNoteId(note.id)
                       setTimeout(() => setCopiedNoteId(null), 2000)
                     }}
-                    className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+                    className="p-1 text-ink-4 hover:text-ink-3 hover:bg-surface-3 rounded transition-colors"
                     title="Copy note"
                   >
                     {copiedNoteId === note.id ? (
-                      <Check className="h-3.5 w-3.5 text-green-500" />
+                      <Check className="h-3.5 w-3.5 text-forest" />
                     ) : (
                       <Copy className="h-3.5 w-3.5" />
                     )}
@@ -239,14 +237,14 @@ export function SessionNotesCompact({
               <label className="text-sm font-medium text-app-primary mb-1.5 block">
                 Visibility
               </label>
-              <div className="flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700 rounded-md p-0.5 w-fit">
+              <div className="flex items-center gap-0.5 bg-surface-3 rounded-md p-0.5 w-fit">
                 <button
                   type="button"
                   onClick={() => setNewNoteType('coach_private')}
                   className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded transition-colors ${
                     newNoteType === 'coach_private'
-                      ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                      ? 'bg-surface-1 text-ink shadow-sm'
+                      : 'text-ink-3 hover:text-ink-2 '
                   }`}
                 >
                   <Lock className="h-3.5 w-3.5" />
@@ -257,8 +255,8 @@ export function SessionNotesCompact({
                   onClick={() => setNewNoteType('shared')}
                   className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded transition-colors ${
                     newNoteType === 'shared'
-                      ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                      ? 'bg-surface-1 text-ink shadow-sm'
+                      : 'text-ink-3 hover:text-ink-2 '
                   }`}
                 >
                   <Users className="h-3.5 w-3.5" />

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -433,7 +433,7 @@ export function SessionOverviewTab({
                   .map((focus, idx) => (
                     <span
                       key={idx}
-                      className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-white dark:bg-gray-800 border border-app-border text-sm text-app-primary"
+                      className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-surface-1 border border-app-border text-sm text-app-primary"
                     >
                       {focus}
                     </span>

--- a/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
+++ b/src/app/sessions/[sessionId]/components/session-overview-tab.tsx
@@ -72,7 +72,6 @@ interface SessionOverviewTabProps {
   onGenerateClientAnalysis?: () => void
   generatingClientAnalysis?: boolean
   isCompleted?: boolean
-  commitmentsLoaded?: boolean
   onCreateCommitment?: () => void
 }
 
@@ -91,7 +90,6 @@ export function SessionOverviewTab({
   onGenerateClientAnalysis,
   generatingClientAnalysis = false,
   isCompleted = false,
-  commitmentsLoaded = false,
   onCreateCommitment,
 }: SessionOverviewTabProps) {
   const [transcriptOpen, setTranscriptOpen] = useState(false)
@@ -276,8 +274,6 @@ export function SessionOverviewTab({
                   : commitments || []
               }
               onUpdate={onRefreshCommitments || (() => {})}
-              isCompleted={isCompleted}
-              commitmentsLoaded={commitmentsLoaded}
               onCreateCommitment={onCreateCommitment}
             />
           ))}

--- a/src/app/sessions/[sessionId]/components/session-resources-compact.tsx
+++ b/src/app/sessions/[sessionId]/components/session-resources-compact.tsx
@@ -218,7 +218,7 @@ export function SessionResourcesCompact({
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => setDeleteResource(resource)}
-                          className="text-red-600"
+                          className="text-vermillion"
                         >
                           <Trash2 className="h-4 w-4 mr-2" />
                           Delete
@@ -289,7 +289,7 @@ export function SessionResourcesCompact({
                 handleDeleteConfirm()
               }}
               disabled={deleteResourceMutation.isPending}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               {deleteResourceMutation.isPending ? (
                 <>

--- a/src/app/sessions/[sessionId]/components/start-bot-card.tsx
+++ b/src/app/sessions/[sessionId]/components/start-bot-card.tsx
@@ -104,8 +104,8 @@ export function StartBotCard({
       {/* Session Info */}
       <Card className="border-app-border shadow-sm">
         <CardContent className="p-8 text-center">
-          <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-2xl flex items-center justify-center mx-auto mb-6">
-            <Bot className="h-8 w-8 text-gray-500" />
+          <div className="w-16 h-16 bg-surface-3 rounded-2xl flex items-center justify-center mx-auto mb-6">
+            <Bot className="h-8 w-8 text-ink-3" />
           </div>
 
           <h2 className="text-xl font-semibold text-app-primary mb-2">
@@ -129,7 +129,7 @@ export function StartBotCard({
           {(!clientId || editingClient) && (
             <div className="mb-4 mt-4 mx-auto max-w-sm text-left">
               <Label className="text-sm font-medium mb-2 flex items-center gap-1.5">
-                <UserIcon className="h-4 w-4 text-gray-400" />
+                <UserIcon className="h-4 w-4 text-ink-4" />
                 Client {clientId ? '' : '(optional)'}
               </Label>
               <ClientSelector
@@ -175,7 +175,7 @@ export function StartBotCard({
                   })
                 }
                 disabled={sendQuestionnaire.isPending}
-                className="border-gray-300 dark:border-gray-600"
+                className="border-line-strong "
               >
                 {sendQuestionnaire.isPending ? (
                   <>
@@ -198,10 +198,10 @@ export function StartBotCard({
           <div className="text-left space-y-4 mt-6">
             <div className="space-y-2">
               <Label className="text-sm font-medium">
-                Meeting URL <span className="text-red-500">*</span>
+                Meeting URL <span className="text-vermillion">*</span>
               </Label>
               <div className="relative">
-                <Link2 className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Link2 className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4" />
                 <Input
                   value={meetingUrl}
                   onChange={e => setMeetingUrl(e.target.value)}
@@ -231,7 +231,7 @@ export function StartBotCard({
             onClick={handleStartBot}
             disabled={!meetingUrl.trim() || startBot.isPending}
             size="lg"
-            className="w-full mt-6 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 h-12 text-base"
+            className="w-full mt-6 bg-ink hover:bg-ink-2 text-ink-on-dark h-12 text-base"
           >
             {startBot.isPending ? (
               <>

--- a/src/app/sessions/[sessionId]/components/thrill-form-responses.tsx
+++ b/src/app/sessions/[sessionId]/components/thrill-form-responses.tsx
@@ -61,7 +61,7 @@ export function ThrillFormResponses({
           {isCompleted ? (
             <Badge
               variant="secondary"
-              className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-xs"
+              className="bg-forest-bg text-forest border-forest text-xs"
             >
               <CheckCircle2 className="h-3 w-3 mr-1" />
               Completed
@@ -71,7 +71,7 @@ export function ThrillFormResponses({
           ) : (
             <Badge
               variant="secondary"
-              className="bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800 text-xs"
+              className="bg-amber-token-bg text-amber-token border-amber-token text-xs"
             >
               <Clock className="h-3 w-3 mr-1" />
               In Progress
@@ -90,7 +90,7 @@ export function ThrillFormResponses({
                   {qa.question_text}
                 </p>
                 {compact ? (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-semibold bg-gray-100 dark:bg-gray-800 text-app-primary">
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-semibold bg-surface-3 text-app-primary">
                     {formatted}
                   </span>
                 ) : (

--- a/src/app/sessions/[sessionId]/components/transcript-viewer.tsx
+++ b/src/app/sessions/[sessionId]/components/transcript-viewer.tsx
@@ -27,37 +27,37 @@ export default function TranscriptViewer({
   // Viewers cannot see transcript content
   if (isViewer) {
     return (
-      <Card className="hover:shadow-md transition-shadow duration-200 border-gray-200 dark:border-gray-700">
-        <CardHeader className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+      <Card className="hover:shadow-md transition-shadow duration-200 border-line ">
+        <CardHeader className="bg-paper border-b border-line ">
           <CardTitle className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="p-2 bg-gray-400 rounded-lg text-white">
+              <div className="p-2 bg-line rounded-lg text-ink-on-dark">
                 <Lock className="h-5 w-5" />
               </div>
-              <span className="text-lg font-bold text-gray-700 dark:text-gray-300">
+              <span className="text-lg font-bold text-ink-2 ">
                 Meeting Transcript
               </span>
             </div>
             <Badge
               variant="secondary"
-              className="bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600"
+              className="bg-surface-3 text-ink-3 border-line-strong "
             >
               Restricted
             </Badge>
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-center py-16 text-gray-500 dark:text-gray-400">
-            <div className="w-20 h-20 mx-auto mb-4 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center">
-              <Lock className="h-10 w-10 text-gray-400" />
+          <div className="text-center py-16 text-ink-3 ">
+            <div className="w-20 h-20 mx-auto mb-4 bg-surface-3 rounded-full flex items-center justify-center">
+              <Lock className="h-10 w-10 text-ink-4" />
             </div>
-            <p className="text-lg font-medium text-gray-600 dark:text-gray-400">
+            <p className="text-lg font-medium text-ink-3 ">
               Transcript Access Restricted
             </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            <p className="text-sm text-ink-3 mt-2">
               You do not have permission to view session transcripts.
             </p>
-            <p className="text-xs text-gray-400 mt-4">
+            <p className="text-xs text-ink-4 mt-4">
               Contact your administrator for access.
             </p>
           </div>
@@ -67,20 +67,20 @@ export default function TranscriptViewer({
   }
 
   return (
-    <Card className="hover:shadow-md transition-shadow duration-200 border-gray-200 dark:border-gray-700">
-      <CardHeader className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+    <Card className="hover:shadow-md transition-shadow duration-200 border-line ">
+      <CardHeader className="bg-paper border-b border-line ">
         <CardTitle className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="p-2 bg-gray-900 dark:bg-gray-100 rounded-lg text-white dark:text-gray-900">
+            <div className="p-2 bg-ink rounded-lg text-ink-on-dark ">
               <MessageSquare className="h-5 w-5" />
             </div>
-            <span className="text-lg font-bold text-gray-900 dark:text-white">
+            <span className="text-lg font-bold text-ink ">
               Meeting Transcript
             </span>
           </div>
           <Badge
             variant="secondary"
-            className="bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600"
+            className="bg-surface-3 text-ink-2 border-line-strong "
           >
             {transcript.length} messages
           </Badge>
@@ -88,14 +88,14 @@ export default function TranscriptViewer({
       </CardHeader>
       <CardContent className="p-0">
         {transcript.length === 0 ? (
-          <div className="text-center py-16 text-gray-500 dark:text-gray-400">
-            <div className="w-20 h-20 mx-auto mb-4 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center">
-              <MessageSquare className="h-10 w-10 text-gray-300 dark:text-gray-400" />
+          <div className="text-center py-16 text-ink-3 ">
+            <div className="w-20 h-20 mx-auto mb-4 bg-surface-3 rounded-full flex items-center justify-center">
+              <MessageSquare className="h-10 w-10 text-ink-2 " />
             </div>
-            <p className="text-lg font-medium text-gray-400">
+            <p className="text-lg font-medium text-ink-4">
               No transcript available
             </p>
-            <p className="text-sm text-gray-400 mt-1">
+            <p className="text-sm text-ink-4 mt-1">
               Messages will appear here once the meeting starts
             </p>
           </div>
@@ -111,16 +111,16 @@ export default function TranscriptViewer({
                     key={entry.id}
                     className={`flex gap-3 p-4 rounded-lg transition-colors ${
                       isBot
-                        ? 'bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 border border-gray-200 dark:border-gray-700'
-                        : 'bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800 border border-gray-200 dark:border-gray-700'
+                        ? 'bg-paper hover:bg-surface-3 border border-line '
+                        : 'bg-surface-1 hover:bg-paper border border-line '
                     }`}
                   >
                     <div className="flex-shrink-0">
                       <div
                         className={`w-10 h-10 rounded-full flex items-center justify-center ${
                           isBot
-                            ? 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300'
-                            : 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900'
+                            ? 'bg-surface-3 text-ink-2 '
+                            : 'bg-ink text-ink-on-dark '
                         }`}
                       >
                         {isBot ? (
@@ -132,19 +132,19 @@ export default function TranscriptViewer({
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-3 mb-2 flex-wrap">
-                        <span className="font-semibold text-sm text-gray-900 dark:text-white">
+                        <span className="font-semibold text-sm text-ink ">
                           {entry.speaker}
                         </span>
-                        <span className="text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full">
+                        <span className="text-xs text-ink-3 bg-surface-3 px-2 py-1 rounded-full">
                           {formatDate(entry.timestamp, 'HH:mm:ss')}
                         </span>
                         {entry.confidence && (
-                          <span className="text-xs text-gray-400 bg-gray-50 dark:bg-gray-800 px-2 py-1 rounded-full">
+                          <span className="text-xs text-ink-4 bg-paper px-2 py-1 rounded-full">
                             {Math.round(entry.confidence * 100)}% confidence
                           </span>
                         )}
                       </div>
-                      <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+                      <p className="text-sm text-ink-2 leading-relaxed">
                         {entry.text}
                       </p>
                     </div>

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -527,7 +527,7 @@ export default function SessionDetailsPage({
   if (error) {
     return (
       <div className="min-h-screen bg-app-surface flex items-center justify-center p-4">
-        <div className="text-center max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8 border border-app-border">
+        <div className="text-center max-w-md mx-auto bg-surface-1 rounded-lg shadow-sm p-8 border border-app-border">
           <EmptyState
             icon={AlertCircle}
             title="Error Loading Session"
@@ -587,7 +587,7 @@ export default function SessionDetailsPage({
   return (
     <ProtectedRoute loadingMessage="Loading session details...">
       <PageLayout>
-        <div className="min-h-screen bg-white dark:bg-gray-900">
+        <div className="min-h-screen bg-surface-1 ">
           {/* Header */}
           <SessionHeader
             session={session}
@@ -747,14 +747,14 @@ export default function SessionDetailsPage({
                     <TabsList className="bg-app-surface p-1 rounded-lg">
                       <TabsTrigger
                         value="overview"
-                        className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-800 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
+                        className="data-[state=active]:bg-surface-1 dark:data-[state=active]:bg-ink-2 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
                       >
                         <LayoutGrid className="h-4 w-4 mr-2" />
                         Overview
                       </TabsTrigger>
                       <TabsTrigger
                         value="analysis"
-                        className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-800 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
+                        className="data-[state=active]:bg-surface-1 dark:data-[state=active]:bg-ink-2 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
                       >
                         <Brain className="h-4 w-4 mr-2" />
                         Analysis
@@ -765,7 +765,7 @@ export default function SessionDetailsPage({
                           session.video_unavailable) && (
                           <TabsTrigger
                             value="recording"
-                            className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-800 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
+                            className="data-[state=active]:bg-surface-1 dark:data-[state=active]:bg-ink-2 data-[state=active]:text-app-primary data-[state=active]:shadow-sm rounded-md px-4 py-1.5 text-sm font-medium transition-all"
                           >
                             <Video className="h-4 w-4 mr-2" />
                             Recording

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -173,14 +173,13 @@ export default function SessionDetailsPage({
     : baseClientId
 
   // Fetch commitments for this specific session only
-  const { data: commitmentsData, isLoading: commitmentsLoading } =
-    useCommitments(
-      {
-        session_id: resolvedParams.sessionId,
-        include_drafts: true,
-      },
-      { enabled: !!resolvedParams.sessionId },
-    )
+  const { data: commitmentsData } = useCommitments(
+    {
+      session_id: resolvedParams.sessionId,
+      include_drafts: true,
+    },
+    { enabled: !!resolvedParams.sessionId },
+  )
 
   // Helper to refresh commitments and wins from cache
   const refreshCommitments = () => {
@@ -886,7 +885,6 @@ export default function SessionDetailsPage({
                         session.status === 'completed' ||
                         session.transcription_status === 'completed'
                       }
-                      commitmentsLoaded={!commitmentsLoading}
                       onCreateCommitment={
                         !isViewer && clientId
                           ? () => setShowCommitmentCreatePanel(true)

--- a/src/app/sessions/[sessionId]/review/page.tsx
+++ b/src/app/sessions/[sessionId]/review/page.tsx
@@ -104,7 +104,7 @@ export default function SessionReviewPage({
   if (error || !data) {
     return (
       <div className="min-h-screen bg-app-surface flex items-center justify-center p-4">
-        <div className="text-center max-w-md mx-auto bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8 border border-app-border">
+        <div className="text-center max-w-md mx-auto bg-surface-1 rounded-lg shadow-sm p-8 border border-app-border">
           <EmptyState
             icon={AlertCircle}
             title="Session not available"
@@ -133,7 +133,7 @@ export default function SessionReviewPage({
   return (
     <ProtectedRoute loadingMessage="Loading review...">
       <PageLayout>
-        <div className="min-h-screen bg-white dark:bg-gray-900">
+        <div className="min-h-screen bg-surface-1 ">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
             <div className="mb-6 flex items-start justify-between gap-4">
               <div className="min-w-0">

--- a/src/app/sessions/[sessionId]/utils/session-utils.ts
+++ b/src/app/sessions/[sessionId]/utils/session-utils.ts
@@ -1,26 +1,26 @@
 export const getStatusColor = (status: string) => {
   switch (status) {
     case 'completed':
-      return 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
+      return 'bg-ink text-ink-on-dark border-line '
     case 'in_progress':
-      return 'bg-gray-700 text-white border-gray-700'
+      return 'bg-ink-2 text-ink-on-dark border-line'
     case 'error':
-      return 'bg-gray-200 text-gray-900 border-gray-300'
+      return 'bg-surface-3 text-ink border-line-strong'
     case 'pending_upload':
-      return 'bg-white text-gray-900 border-gray-400'
+      return 'bg-surface-1 text-ink border-line-strong'
     default:
-      return 'bg-gray-100 text-gray-700 border-gray-200'
+      return 'bg-surface-3 text-ink-2 border-line'
   }
 }
 
 export const getScoreColor = (score: number) => {
-  if (score >= 8) return 'text-gray-900 font-bold'
-  if (score >= 6) return 'text-gray-700 font-medium'
-  return 'text-gray-500'
+  if (score >= 8) return 'text-ink font-bold'
+  if (score >= 6) return 'text-ink-2 font-medium'
+  return 'text-ink-3'
 }
 
 export const getScoreGradient = (score: number) => {
-  if (score >= 8) return 'from-gray-800 to-gray-900'
-  if (score >= 6) return 'from-gray-600 to-gray-700'
-  return 'from-gray-400 to-gray-500'
+  if (score >= 8) return ''
+  if (score >= 6) return ''
+  return ''
 }

--- a/src/app/sessions/components/client-filter.tsx
+++ b/src/app/sessions/components/client-filter.tsx
@@ -27,8 +27,8 @@ export default function ClientFilter({
     <div className="mb-6">
       <div className="flex items-center gap-4 flex-wrap">
         <div className="flex items-center gap-2">
-          <Filter className="h-4 w-4 text-slate-600" />
-          <span className="text-sm font-medium text-slate-700">
+          <Filter className="h-4 w-4 text-ink-3" />
+          <span className="text-sm font-medium text-ink-2">
             Filter by client:
           </span>
         </div>
@@ -46,9 +46,7 @@ export default function ClientFilter({
             {clients.map(client => (
               <Button
                 key={client.id}
-                variant={
-                  selectedClientId === client.id ? 'default' : 'outline'
-                }
+                variant={selectedClientId === client.id ? 'default' : 'outline'}
                 size="sm"
                 onClick={() => onClientFilter(client.id)}
                 className="text-xs"
@@ -65,7 +63,7 @@ export default function ClientFilter({
             variant="ghost"
             size="sm"
             onClick={() => onClientFilter(null)}
-            className="text-slate-500 hover:text-slate-700 text-xs"
+            className="text-ink-3 hover:text-ink-2 text-xs"
           >
             <X className="h-3 w-3 mr-1" />
             Clear filter
@@ -74,14 +72,14 @@ export default function ClientFilter({
       </div>
 
       {selectedClient && (
-        <div className="mt-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+        <div className="mt-2 p-3 bg-ds-accent-bg border border-ds-accent rounded-lg">
           <div className="flex items-center gap-2">
-            <User className="h-4 w-4 text-blue-600" />
-            <span className="text-sm font-medium text-blue-900">
+            <User className="h-4 w-4 text-ds-accent" />
+            <span className="text-sm font-medium text-ds-accent">
               Showing sessions for: {selectedClient.name}
             </span>
             {selectedClient.company && (
-              <span className="text-xs text-blue-600">
+              <span className="text-xs text-ds-accent">
                 • {selectedClient.company}
               </span>
             )}

--- a/src/app/sessions/components/sessions-filters.tsx
+++ b/src/app/sessions/components/sessions-filters.tsx
@@ -44,12 +44,12 @@ const STATUS_OPTIONS: {
   label: string
   dot: string
 }[] = [
-  { value: 'all', label: 'All Statuses', dot: 'bg-slate-400' },
-  { value: 'completed', label: 'Completed', dot: 'bg-emerald-500' },
-  { value: 'active', label: 'Active', dot: 'bg-rose-500' },
-  { value: 'processing', label: 'Processing', dot: 'bg-amber-500' },
-  { value: 'scheduled', label: 'Scheduled', dot: 'bg-sky-500' },
-  { value: 'pending_upload', label: 'Pending Upload', dot: 'bg-violet-500' },
+  { value: 'all', label: 'All Statuses', dot: 'bg-line' },
+  { value: 'completed', label: 'Completed', dot: 'bg-forest' },
+  { value: 'active', label: 'Active', dot: 'bg-vermillion' },
+  { value: 'processing', label: 'Processing', dot: 'bg-amber-token' },
+  { value: 'scheduled', label: 'Scheduled', dot: 'bg-ds-accent' },
+  { value: 'pending_upload', label: 'Pending Upload', dot: 'bg-indigo' },
 ]
 
 const getStatusOption = (value: SessionStatusFilter) =>
@@ -116,10 +116,8 @@ export default function SessionsFilters({
         {/* Client Filter */}
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <Filter className="h-4 w-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-              Client:
-            </span>
+            <Filter className="h-4 w-4 text-ink-3 " />
+            <span className="text-sm font-medium text-ink-2 ">Client:</span>
           </div>
 
           {!loadingClients && (
@@ -141,9 +139,9 @@ export default function SessionsFilters({
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-[280px] p-0" align="start">
-                <div className="p-2 border-b dark:border-slate-700">
+                <div className="p-2 border-b ">
                   <div className="relative">
-                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-slate-400 dark:text-slate-500" />
+                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-ink-4 " />
                     <Input
                       placeholder="Search clients..."
                       value={clientSearch}
@@ -161,16 +159,16 @@ export default function SessionsFilters({
                         setClientPopoverOpen(false)
                         setClientSearch('')
                       }}
-                      className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                      className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
                         selectedClientId === null
-                          ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                          ? 'bg-surface-3 font-medium'
                           : ''
                       }`}
                     >
                       <Users className="h-3 w-3" />
                       <span className="flex-1 text-left">All Clients</span>
                       {selectedClientId === null && (
-                        <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                        <Check className="h-3 w-3 text-ink-3 " />
                       )}
                     </button>
 
@@ -183,28 +181,28 @@ export default function SessionsFilters({
                           setClientPopoverOpen(false)
                           setClientSearch('')
                         }}
-                        className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                        className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
                           selectedClientId === client.id
-                            ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                            ? 'bg-surface-3 font-medium'
                             : ''
                         }`}
                       >
                         <User className="h-3 w-3" />
                         <span className="flex-1 text-left">{client.name}</span>
                         {selectedClientId === client.id && (
-                          <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                          <Check className="h-3 w-3 text-ink-3 " />
                         )}
                       </button>
                     ))}
 
                     {filteredClients.length === 0 && (
-                      <div className="px-2 py-4 text-xs text-slate-500 dark:text-slate-400 text-center">
+                      <div className="px-2 py-4 text-xs text-ink-3 text-center">
                         No clients found
                       </div>
                     )}
                   </div>
                 </ScrollArea>
-                <div className="p-2 border-t dark:border-slate-700 text-xs text-slate-500 dark:text-slate-400 text-center">
+                <div className="p-2 border-t text-xs text-ink-3 text-center">
                   {clients.length} clients total
                 </div>
               </PopoverContent>
@@ -215,10 +213,8 @@ export default function SessionsFilters({
         {/* Coach Filter */}
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <Users className="h-4 w-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-              Coach:
-            </span>
+            <Users className="h-4 w-4 text-ink-3 " />
+            <span className="text-sm font-medium text-ink-2 ">Coach:</span>
           </div>
 
           <Popover open={coachPopoverOpen} onOpenChange={setCoachPopoverOpen}>
@@ -236,9 +232,9 @@ export default function SessionsFilters({
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-[280px] p-0" align="start">
-              <div className="p-2 border-b dark:border-slate-700">
+              <div className="p-2 border-b ">
                 <div className="relative">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-slate-400 dark:text-slate-500" />
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-ink-4 " />
                   <Input
                     placeholder="Search coaches..."
                     value={coachSearch}
@@ -256,16 +252,14 @@ export default function SessionsFilters({
                       setCoachPopoverOpen(false)
                       setCoachSearch('')
                     }}
-                    className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
-                      selectedCoachId === null
-                        ? 'bg-slate-100 dark:bg-slate-800 font-medium'
-                        : ''
+                    className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
+                      selectedCoachId === null ? 'bg-surface-3 font-medium' : ''
                     }`}
                   >
                     <Users className="h-3 w-3" />
                     <span className="flex-1 text-left">All Coaches</span>
                     {selectedCoachId === null && (
-                      <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                      <Check className="h-3 w-3 text-ink-3 " />
                     )}
                   </button>
 
@@ -278,29 +272,29 @@ export default function SessionsFilters({
                         setCoachPopoverOpen(false)
                         setCoachSearch('')
                       }}
-                      className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                      className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
                         selectedCoachId === coach.id
-                          ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                          ? 'bg-surface-3 font-medium'
                           : ''
                       }`}
                     >
                       <User className="h-3 w-3" />
                       <span className="flex-1 text-left">{coach.name}</span>
                       {selectedCoachId === coach.id && (
-                        <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                        <Check className="h-3 w-3 text-ink-3 " />
                       )}
                     </button>
                   ))}
 
                   {filteredCoaches.length === 0 && (
-                    <div className="px-2 py-4 text-xs text-slate-500 dark:text-slate-400 text-center">
+                    <div className="px-2 py-4 text-xs text-ink-3 text-center">
                       No coaches found
                     </div>
                   )}
                 </div>
               </ScrollArea>
               {coaches.length > 0 && (
-                <div className="p-2 border-t dark:border-slate-700 text-xs text-slate-500 dark:text-slate-400 text-center">
+                <div className="p-2 border-t text-xs text-ink-3 text-center">
                   {coaches.length} coaches total
                 </div>
               )}
@@ -310,19 +304,17 @@ export default function SessionsFilters({
 
         {/* Session Type Filter */}
         <div className="flex items-center gap-3">
-          <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-            Type:
-          </span>
-          <div className="flex items-center border border-slate-200 dark:border-slate-700 rounded-md overflow-hidden">
+          <span className="text-sm font-medium text-ink-2 ">Type:</span>
+          <div className="flex items-center border border-line rounded-md overflow-hidden">
             {(['all', '1:1', 'group'] as SessionTypeFilter[]).map(type => (
               <button
                 key={type}
                 onClick={() => onSessionTypeFilter(type)}
                 className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                   sessionType === type
-                    ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
-                    : 'bg-white text-slate-600 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-400 dark:hover:bg-slate-800'
-                } ${type !== 'all' ? 'border-l border-slate-200 dark:border-slate-700' : ''}`}
+                    ? 'bg-ink text-ink-on-dark '
+                    : 'bg-surface-1 text-ink-3 hover:bg-paper '
+                } ${type !== 'all' ? 'border-l border-line ' : ''}`}
               >
                 {type === 'all' ? 'All' : type === '1:1' ? '1:1' : 'Group'}
               </button>
@@ -333,10 +325,8 @@ export default function SessionsFilters({
         {/* Status Filter */}
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <Activity className="h-4 w-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-              Status:
-            </span>
+            <Activity className="h-4 w-4 text-ink-3 " />
+            <span className="text-sm font-medium text-ink-2 ">Status:</span>
           </div>
 
           <Popover open={statusPopoverOpen} onOpenChange={setStatusPopoverOpen}>
@@ -364,9 +354,9 @@ export default function SessionsFilters({
                     onStatusFilter(option.value)
                     setStatusPopoverOpen(false)
                   }}
-                  className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                  className={`w-full flex items-center gap-2 px-2 py-2 text-xs rounded-md hover:bg-surface-3 ${
                     selectedStatus === option.value
-                      ? 'bg-slate-100 dark:bg-slate-800 font-medium'
+                      ? 'bg-surface-3 font-medium'
                       : ''
                   }`}
                 >
@@ -376,7 +366,7 @@ export default function SessionsFilters({
                   />
                   <span className="flex-1 text-left">{option.label}</span>
                   {selectedStatus === option.value && (
-                    <Check className="h-3 w-3 text-slate-600 dark:text-slate-400" />
+                    <Check className="h-3 w-3 text-ink-3 " />
                   )}
                 </button>
               ))}
@@ -390,7 +380,7 @@ export default function SessionsFilters({
             variant="ghost"
             size="sm"
             onClick={onClearFilters}
-            className="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300 text-xs"
+            className="text-ink-3 hover:text-ink-2 text-xs"
           >
             <X className="h-3 w-3 mr-1" />
             Clear filters
@@ -400,19 +390,19 @@ export default function SessionsFilters({
 
       {/* Active Filters Display */}
       {(selectedClient || selectedCoach) && (
-        <div className="mt-2 p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg space-y-2">
+        <div className="mt-2 p-3 bg-ds-accent-bg border border-ds-accent rounded-lg space-y-2">
           {selectedClient && (
             <div className="flex items-center gap-2">
-              <User className="h-4 w-4 text-blue-600" />
-              <span className="text-sm font-medium text-blue-900 dark:text-blue-100">
+              <User className="h-4 w-4 text-ds-accent" />
+              <span className="text-sm font-medium text-ds-accent ">
                 Client: {selectedClient.name}
               </span>
             </div>
           )}
           {selectedCoach && (
             <div className="flex items-center gap-2">
-              <Users className="h-4 w-4 text-blue-600" />
-              <span className="text-sm font-medium text-blue-900 dark:text-blue-100">
+              <Users className="h-4 w-4 text-ds-accent" />
+              <span className="text-sm font-medium text-ds-accent ">
                 Coach: {selectedCoach.name}
               </span>
             </div>

--- a/src/app/sessions/components/sessions-list.tsx
+++ b/src/app/sessions/components/sessions-list.tsx
@@ -40,11 +40,11 @@ export default function SessionsList({
   const router = useRouter()
 
   return (
-    <Card className="shadow-lg border-slate-200 dark:border-gray-700">
-      <CardHeader className="border-b border-slate-200 bg-slate-50 dark:border-gray-700 dark:bg-gray-800">
+    <Card className="shadow-lg border-line ">
+      <CardHeader className="border-b border-line bg-paper ">
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-3 text-slate-800 dark:text-white">
-            <MessageSquare className="h-5 w-5 text-slate-600 dark:text-gray-400" />
+          <CardTitle className="flex items-center gap-3 text-ink-2 ">
+            <MessageSquare className="h-5 w-5 text-ink-3 " />
             {selectedClientName
               ? `${selectedClientName}'s Sessions`
               : 'All Sessions'}
@@ -52,7 +52,7 @@ export default function SessionsList({
 
           {/* Pagination Info */}
           <div className="flex items-center gap-4">
-            <div className="text-sm text-slate-600 dark:text-gray-400">
+            <div className="text-sm text-ink-3 ">
               {totalSessions > 0 && (
                 <span>
                   Showing {Math.min(pageSize, totalSessions)} of {totalSessions}
@@ -69,7 +69,7 @@ export default function SessionsList({
                 >
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
-                <span className="text-sm text-slate-600 dark:text-gray-400 px-2">
+                <span className="text-sm text-ink-3 px-2">
                   {currentPage + 1}
                 </span>
                 <Button
@@ -97,7 +97,7 @@ export default function SessionsList({
               label: 'Try Again',
               onClick: onRefetch,
             }}
-            iconClassName="bg-red-100"
+            iconClassName="bg-vermillion-bg"
           />
         )}
 
@@ -105,10 +105,7 @@ export default function SessionsList({
         {loading && !sessions.length && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {Array.from({ length: 6 }).map((_, i) => (
-              <Card
-                key={i}
-                className="border border-slate-200 dark:border-gray-700"
-              >
+              <Card key={i} className="border border-line ">
                 <CardContent className="p-6">
                   <div className="space-y-4">
                     <div className="flex items-center justify-between">
@@ -158,7 +155,7 @@ export default function SessionsList({
                 : undefined
             }
             className="py-16"
-            iconClassName="w-16 h-16 bg-slate-100 dark:bg-gray-800"
+            iconClassName="w-16 h-16 bg-surface-3 "
           />
         )}
 

--- a/src/app/sessions/create/manual/page.tsx
+++ b/src/app/sessions/create/manual/page.tsx
@@ -97,40 +97,38 @@ function CreateManualSessionContent() {
 
   if (loadingClients) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-paper">
         <LoadingState message="Loading clients..." className="min-h-screen" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-paper">
       {/* Header */}
-      <div className="bg-white border-b border-gray-200">
+      <div className="bg-surface-1 border-b border-line">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center h-16">
             <Button
               variant="ghost"
               size="sm"
               onClick={() => router.back()}
-              className="mr-4 text-gray-600 hover:text-gray-900"
+              className="mr-4 text-ink-3 hover:text-ink"
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
               Back
             </Button>
-            <h1 className="text-xl font-semibold text-gray-900">
-              Add Past Session
-            </h1>
+            <h1 className="text-xl font-semibold text-ink">Add Past Session</h1>
           </div>
         </div>
       </div>
 
       {/* Main Content */}
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <Card className="border-gray-200">
-          <CardHeader className="border-b border-gray-200">
+        <Card className="border-line">
+          <CardHeader className="border-b border-line">
             <CardTitle className="text-lg">Session Details</CardTitle>
-            <CardDescription className="text-gray-600">
+            <CardDescription className="text-ink-3">
               Create a session to upload and analyze recorded audio or video
               files
             </CardDescription>
@@ -141,9 +139,9 @@ function CreateManualSessionContent() {
               <div className="space-y-2">
                 <Label
                   htmlFor="client"
-                  className="text-base font-medium text-gray-900"
+                  className="text-base font-medium text-ink"
                 >
-                  Client <span className="text-red-500">*</span>
+                  Client <span className="text-vermillion">*</span>
                 </Label>
                 <Select
                   value={formData.client_id}
@@ -151,7 +149,7 @@ function CreateManualSessionContent() {
                     setFormData({ ...formData, client_id: value })
                   }
                 >
-                  <SelectTrigger id="client" className="border-gray-200">
+                  <SelectTrigger id="client" className="border-line">
                     <SelectValue placeholder="Select a client" />
                   </SelectTrigger>
                   <SelectContent>
@@ -168,7 +166,7 @@ function CreateManualSessionContent() {
               <div className="space-y-2">
                 <Label
                   htmlFor="date"
-                  className="text-base font-medium text-gray-900"
+                  className="text-base font-medium text-ink"
                 >
                   Session Date
                 </Label>
@@ -179,7 +177,7 @@ function CreateManualSessionContent() {
                   onChange={e =>
                     setFormData({ ...formData, session_date: e.target.value })
                   }
-                  className="border-gray-200"
+                  className="border-line"
                 />
               </div>
 
@@ -187,10 +185,10 @@ function CreateManualSessionContent() {
               <div className="space-y-2">
                 <Label
                   htmlFor="notes"
-                  className="text-base font-medium text-gray-900"
+                  className="text-base font-medium text-ink"
                 >
                   Notes{' '}
-                  <span className="text-gray-500 font-normal">(Optional)</span>
+                  <span className="text-ink-3 font-normal">(Optional)</span>
                 </Label>
                 <Textarea
                   id="notes"
@@ -200,25 +198,25 @@ function CreateManualSessionContent() {
                     setFormData({ ...formData, notes: e.target.value })
                   }
                   rows={4}
-                  className="border-gray-200"
+                  className="border-line"
                 />
               </div>
 
               {/* Actions */}
-              <div className="flex justify-end gap-3 pt-4 border-t border-gray-200">
+              <div className="flex justify-end gap-3 pt-4 border-t border-line">
                 <Button
                   type="button"
                   variant="outline"
                   onClick={() => router.back()}
                   disabled={creating}
-                  className="border-gray-300 hover:bg-gray-50"
+                  className="border-line-strong hover:bg-paper"
                 >
                   Cancel
                 </Button>
                 <Button
                   type="submit"
                   disabled={creating || !formData.client_id}
-                  className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+                  className="bg-ink hover:bg-ink-2 text-ink-on-dark "
                 >
                   {creating ? (
                     <>Creating...</>

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -61,7 +61,6 @@ export default function SessionsHistoryPage() {
             title="Session History"
             description="Track your coaching progress and performance over time"
             icon={History}
-            iconVariant="gradient"
             actions={
               <div className="flex items-center gap-2">
                 {!isViewer && (
@@ -70,7 +69,7 @@ export default function SessionsHistoryPage() {
                       variant="outline"
                       size="sm"
                       onClick={() => setIsGroupSessionModalOpen(true)}
-                      className="flex items-center gap-2 border-slate-300 dark:border-gray-600 hover:bg-slate-50 dark:hover:bg-gray-800"
+                      className="flex items-center gap-2 border-line-strong hover:bg-paper "
                     >
                       <Users className="h-4 w-4" />
                       Start Group Session
@@ -79,7 +78,7 @@ export default function SessionsHistoryPage() {
                       variant="outline"
                       size="sm"
                       onClick={() => setIsManualSessionModalOpen(true)}
-                      className="flex items-center gap-2 border-slate-300 dark:border-gray-600 hover:bg-slate-50 dark:hover:bg-gray-800"
+                      className="flex items-center gap-2 border-line-strong hover:bg-paper "
                     >
                       <Upload className="h-4 w-4" />
                       Upload Recording
@@ -93,7 +92,7 @@ export default function SessionsHistoryPage() {
                     refetch()
                   }}
                   disabled={historyLoading}
-                  className="flex items-center gap-2 border-slate-300 dark:border-gray-600 hover:bg-slate-50 dark:hover:bg-gray-800"
+                  className="flex items-center gap-2 border-line-strong hover:bg-paper "
                 >
                   <RefreshCw
                     className={`h-4 w-4 ${historyLoading ? 'animate-spin' : ''}`}

--- a/src/app/sessions/shared/page.tsx
+++ b/src/app/sessions/shared/page.tsx
@@ -28,7 +28,6 @@ export default function SharedSessionsPage() {
             title="Shared with me"
             description="Coaching sessions other coaches have shared with you for review."
             icon={Users}
-            iconVariant="gradient"
           />
 
           <div className="mt-6">

--- a/src/app/settings/components/profile-section.tsx
+++ b/src/app/settings/components/profile-section.tsx
@@ -167,15 +167,15 @@ export function ProfileSection() {
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'super_admin':
-        return 'bg-red-100 text-red-800 border-red-200'
+        return 'bg-vermillion-bg text-vermillion border-vermillion'
       case 'admin':
-        return 'bg-blue-100 text-blue-800 border-blue-200'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
       case 'coach':
-        return 'bg-green-100 text-green-800 border-green-200'
+        return 'bg-forest-bg text-forest border-forest'
       case 'viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200'
+        return 'bg-surface-3 text-ink-2 border-line'
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200'
+        return 'bg-surface-3 text-ink-2 border-line'
     }
   }
 
@@ -257,19 +257,19 @@ export function ProfileSection() {
             <div>
               <Label htmlFor="email">Email</Label>
               <div className="flex items-center gap-2 mt-1">
-                <Mail className="h-4 w-4 text-gray-400" />
+                <Mail className="h-4 w-4 text-ink-4" />
                 <Input
                   id="email"
                   value={profile?.email || ''}
                   disabled
-                  className="bg-gray-50"
+                  className="bg-paper"
                 />
               </div>
             </div>
             <div>
               <Label htmlFor="full_name">Full Name</Label>
               <div className="flex items-center gap-2 mt-1">
-                <User className="h-4 w-4 text-gray-400" />
+                <User className="h-4 w-4 text-ink-4" />
                 <Input
                   id="full_name"
                   value={formData.full_name}
@@ -288,10 +288,10 @@ export function ProfileSection() {
 
           {isEditing && (
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-900 mb-3">
+              <h3 className="text-sm font-medium text-ink mb-3">
                 Change Password
               </h3>
-              <p className="text-xs text-gray-500 mb-4">
+              <p className="text-xs text-ink-3 mb-4">
                 Leave blank to keep current password
               </p>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -361,17 +361,17 @@ export function ProfileSection() {
                   {profile?.is_active ? (
                     <Badge
                       variant="outline"
-                      className="bg-green-50 text-green-700 border-green-200"
+                      className="bg-forest-bg text-forest border-forest"
                     >
-                      <div className="w-2 h-2 bg-green-500 rounded-full mr-2" />
+                      <div className="w-2 h-2 bg-forest rounded-full mr-2" />
                       Active
                     </Badge>
                   ) : (
                     <Badge
                       variant="outline"
-                      className="bg-red-50 text-red-700 border-red-200"
+                      className="bg-vermillion-bg text-vermillion border-vermillion"
                     >
-                      <div className="w-2 h-2 bg-red-500 rounded-full mr-2" />
+                      <div className="w-2 h-2 bg-vermillion rounded-full mr-2" />
                       Inactive
                     </Badge>
                   )}
@@ -380,8 +380,8 @@ export function ProfileSection() {
               <div>
                 <Label>Member Since</Label>
                 <div className="flex items-center gap-2 mt-1">
-                  <Calendar className="h-4 w-4 text-gray-400" />
-                  <span className="text-sm text-gray-700">
+                  <Calendar className="h-4 w-4 text-ink-4" />
+                  <span className="text-sm text-ink-2">
                     {profile?.created_at
                       ? formatDate(profile.created_at, 'MMMM d, yyyy')
                       : '-'}
@@ -423,9 +423,7 @@ export function ProfileSection() {
                     )
                   })
                 ) : (
-                  <span className="text-sm text-gray-500">
-                    No roles assigned
-                  </span>
+                  <span className="text-sm text-ink-3">No roles assigned</span>
                 )}
               </div>
             </div>
@@ -439,17 +437,17 @@ export function ProfileSection() {
                     {profile.client_access.map(access => (
                       <div
                         key={access.client_id}
-                        className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                        className="flex items-center justify-between p-3 bg-paper rounded-lg"
                       >
                         <div className="flex items-center gap-3">
-                          <div className="h-8 w-8 bg-gray-200 rounded-full flex items-center justify-center">
-                            <Users className="h-4 w-4 text-gray-600" />
+                          <div className="h-8 w-8 bg-surface-3 rounded-full flex items-center justify-center">
+                            <Users className="h-4 w-4 text-ink-3" />
                           </div>
                           <div>
-                            <p className="text-sm font-medium text-gray-900">
+                            <p className="text-sm font-medium text-ink">
                               {access.client_name}
                             </p>
-                            <p className="text-xs text-gray-500">
+                            <p className="text-xs text-ink-3">
                               ID: {access.client_id}
                             </p>
                           </div>
@@ -459,8 +457,8 @@ export function ProfileSection() {
                           className={cn(
                             'text-xs',
                             access.access_level === 'full'
-                              ? 'bg-green-50 text-green-700 border-green-200'
-                              : 'bg-yellow-50 text-yellow-700 border-yellow-200',
+                              ? 'bg-forest-bg text-forest border-forest'
+                              : 'bg-amber-token-bg text-amber-token border-amber-token',
                           )}
                         >
                           <LockKeyhole className="h-3 w-3 mr-1" />
@@ -497,8 +495,8 @@ export function ProfileSection() {
 
       <div id="integrations" className="scroll-mt-24 space-y-3">
         <div>
-          <h2 className="text-lg font-semibold text-gray-900">Integrations</h2>
-          <p className="text-sm text-gray-500">
+          <h2 className="text-lg font-semibold text-ink">Integrations</h2>
+          <p className="text-sm text-ink-3">
             Connect external services to automate scheduling and recording.
           </p>
         </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -49,8 +49,8 @@ function SettingsContent() {
   return (
     <div className="container max-w-4xl mx-auto py-8 px-4">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">Settings</h1>
-        <p className="text-gray-500 mt-2">
+        <h1 className="text-3xl font-bold text-ink">Settings</h1>
+        <p className="text-ink-3 mt-2">
           Manage your account, coaching style, and connected integrations.
         </p>
       </div>

--- a/src/components/admin/admin-header.tsx
+++ b/src/components/admin/admin-header.tsx
@@ -20,15 +20,15 @@ export function AdminHeader() {
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'super_admin':
-        return 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800'
+        return 'bg-vermillion-bg text-vermillion border-vermillion '
       case 'admin':
-        return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent '
       case 'coach':
-        return 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+        return 'bg-forest-bg text-forest border-forest '
       case 'viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 
@@ -40,15 +40,15 @@ export function AdminHeader() {
   }
 
   return (
-    <header className="bg-white dark:bg-gray-900 shadow-sm border-b border-gray-200 dark:border-gray-700">
+    <header className="bg-surface-1 shadow-sm border-b border-line ">
       <div className="px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              <h1 className="text-2xl font-semibold text-ink ">
                 Administration
               </h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              <p className="text-sm text-ink-3 mt-1">
                 Manage users, roles, and client access
               </p>
             </div>
@@ -76,8 +76,8 @@ export function AdminHeader() {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm" className="gap-2">
-                  <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                    <User className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                  <div className="h-8 w-8 rounded-full bg-surface-3 flex items-center justify-center">
+                    <User className="h-4 w-4 text-ink-3 " />
                   </div>
                   <span className="text-sm font-medium">Admin User</span>
                 </Button>
@@ -96,7 +96,7 @@ export function AdminHeader() {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => signOut()}
-                  className="text-red-600"
+                  className="text-vermillion"
                 >
                   <LogOut className="h-4 w-4 mr-2" />
                   Sign Out

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -75,31 +75,31 @@ export function AdminSidebar() {
   return (
     <div
       className={cn(
-        'bg-gray-900 dark:bg-gray-950 text-white transition-all duration-300 ease-in-out flex flex-col',
+        'bg-ink text-ink-on-dark transition-all duration-300 ease-in-out flex flex-col',
         collapsed ? 'w-16' : 'w-64',
       )}
     >
       {/* Logo Section */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-800">
+      <div className="flex items-center justify-between p-4 border-b border-line">
         <div
           className={cn(
             'flex items-center gap-2',
             collapsed && 'justify-center',
           )}
         >
-          <div className="h-8 w-8 bg-white rounded-lg flex items-center justify-center">
-            <UserCheck className="h-5 w-5 text-gray-900" />
+          <div className="h-8 w-8 bg-surface-1 rounded-lg flex items-center justify-center">
+            <UserCheck className="h-5 w-5 text-ink" />
           </div>
           {!collapsed && (
             <div>
               <h2 className="text-lg font-semibold">Admin Panel</h2>
-              <p className="text-xs text-gray-400">Coach Sidekick</p>
+              <p className="text-xs text-ink-4">Coach Sidekick</p>
             </div>
           )}
         </div>
         <button
           onClick={() => setCollapsed(!collapsed)}
-          className="p-1 rounded hover:bg-gray-800 transition-colors"
+          className="p-1 rounded hover:bg-ink-2 transition-colors"
         >
           {collapsed ? (
             <ChevronRight className="h-4 w-4" />
@@ -122,8 +122,8 @@ export function AdminSidebar() {
                   href={item.href}
                   className={cn(
                     'flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all',
-                    'hover:bg-gray-800',
-                    isActive && 'bg-gray-800 border-l-4 border-white',
+                    'hover:bg-ink-2',
+                    isActive && 'bg-ink-2 border-l-4 border-paper',
                     collapsed && 'justify-center',
                   )}
                   title={collapsed ? item.title : undefined}

--- a/src/components/admin/coach-invitation-modal.tsx
+++ b/src/components/admin/coach-invitation-modal.tsx
@@ -140,25 +140,25 @@ export function CoachInvitationModal({
                 </Alert>
               )}
 
-              <div className="rounded-lg bg-gray-50 p-4 border">
-                <h4 className="text-sm font-medium text-gray-900 mb-3">
+              <div className="rounded-lg bg-paper p-4 border">
+                <h4 className="text-sm font-medium text-ink mb-3">
                   New coaches will have access to:
                 </h4>
                 <div className="grid grid-cols-2 gap-3">
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Users className="h-4 w-4 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-ink-3">
+                    <Users className="h-4 w-4 text-ink-4" />
                     <span>Client Management</span>
                   </div>
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Brain className="h-4 w-4 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-ink-3">
+                    <Brain className="h-4 w-4 text-ink-4" />
                     <span>AI Coaching Insights</span>
                   </div>
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <BarChart3 className="h-4 w-4 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-ink-3">
+                    <BarChart3 className="h-4 w-4 text-ink-4" />
                     <span>Progress Analytics</span>
                   </div>
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Sparkles className="h-4 w-4 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-ink-3">
+                    <Sparkles className="h-4 w-4 text-ink-4" />
                     <span>Session Recording</span>
                   </div>
                 </div>
@@ -199,16 +199,16 @@ export function CoachInvitationModal({
         ) : (
           <div className="py-8">
             <div className="text-center">
-              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100 animate-in fade-in zoom-in duration-500">
-                <CheckCircle className="h-10 w-10 text-green-600" />
+              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-forest-bg animate-in fade-in zoom-in duration-500">
+                <CheckCircle className="h-10 w-10 text-forest" />
               </div>
-              <h3 className="mt-4 text-xl font-semibold text-gray-900">
+              <h3 className="mt-4 text-xl font-semibold text-ink">
                 Invitation Sent Successfully!
               </h3>
               <div className="mt-4 space-y-2">
-                <p className="text-sm font-medium text-gray-700">
+                <p className="text-sm font-medium text-ink-2">
                   <Mail className="inline-block h-4 w-4 mr-1" />
-                  Sent to: <span className="text-gray-900">{email}</span>
+                  Sent to: <span className="text-ink">{email}</span>
                 </p>
                 <p className="text-sm text-muted-foreground">
                   The new coach will receive an email with instructions to set
@@ -216,11 +216,11 @@ export function CoachInvitationModal({
                 </p>
               </div>
 
-              <div className="mt-6 rounded-lg bg-blue-50 p-4 text-left">
-                <h4 className="text-sm font-medium text-blue-900 mb-2">
+              <div className="mt-6 rounded-lg bg-ds-accent-bg p-4 text-left">
+                <h4 className="text-sm font-medium text-ds-accent mb-2">
                   What happens next:
                 </h4>
-                <ul className="space-y-1.5 text-xs text-blue-700">
+                <ul className="space-y-1.5 text-xs text-ds-accent">
                   <li className="flex items-start">
                     <span className="mr-2">1.</span>
                     <span>

--- a/src/components/auth/admin-route.tsx
+++ b/src/components/auth/admin-route.tsx
@@ -11,10 +11,10 @@ interface AdminRouteProps {
   requireSuperAdmin?: boolean
 }
 
-export function AdminRoute({ 
-  children, 
+export function AdminRoute({
+  children,
   requiredRoles = ['admin', 'super_admin'],
-  requireSuperAdmin = false 
+  requireSuperAdmin = false,
 }: AdminRouteProps) {
   const { isAuthenticated, loading, hasAnyRole, isSuperAdmin } = useAuth()
   const router = useRouter()
@@ -29,12 +29,20 @@ export function AdminRoute({
         router.push('/unauthorized')
       }
     }
-  }, [isAuthenticated, loading, hasAnyRole, requiredRoles, requireSuperAdmin, isSuperAdmin, router])
+  }, [
+    isAuthenticated,
+    loading,
+    hasAnyRole,
+    requiredRoles,
+    requireSuperAdmin,
+    isSuperAdmin,
+    router,
+  ])
 
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+        <Loader2 className="h-8 w-8 animate-spin text-ink-4" />
       </div>
     )
   }

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -150,7 +150,7 @@ export function AuthForm() {
           <div className="inline-flex items-center justify-center gap-3.5 mb-3">
             <div className="relative">
               <div className="absolute -inset-1.5 bg-app-accent/20 rounded-2xl blur-lg" />
-              <div className="relative w-14 h-14 bg-app-primary rounded-2xl p-2 flex items-center justify-center shadow-lg ring-1 ring-white/10">
+              <div className="relative w-14 h-14 bg-app-primary rounded-2xl p-2 flex items-center justify-center shadow-lg ring-1 ring-paper/10">
                 <Image
                   src="/novus-global-logo.webp"
                   alt="Novus Global Logo"
@@ -280,14 +280,14 @@ export function AuthForm() {
                     </div>
 
                     {error && (
-                      <div className="flex items-start gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/30 p-3 rounded-lg border border-red-200 dark:border-red-900/50">
+                      <div className="flex items-start gap-2 text-vermillion text-sm bg-vermillion-bg p-3 rounded-lg border border-vermillion ">
                         <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                         <span>{error}</span>
                       </div>
                     )}
 
                     {success && (
-                      <div className="flex items-start gap-2 text-green-600 dark:text-green-400 text-sm bg-green-50 dark:bg-green-950/30 p-3 rounded-lg border border-green-200 dark:border-green-900/50">
+                      <div className="flex items-start gap-2 text-forest text-sm bg-forest-bg p-3 rounded-lg border border-forest ">
                         <CheckCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                         <span>{success}</span>
                       </div>
@@ -295,12 +295,12 @@ export function AuthForm() {
 
                     <Button
                       type="submit"
-                      className="w-full bg-app-accent hover:bg-app-accent/90 text-white font-medium py-2.5 shadow-md shadow-app-accent/20 transition-all duration-200 hover:shadow-lg hover:shadow-app-accent/25"
+                      className="w-full bg-app-accent hover:bg-app-accent/90 text-ink-on-dark font-medium py-2.5 shadow-md shadow-app-accent/20 transition-all duration-200 hover:shadow-lg hover:shadow-app-accent/25"
                       disabled={loading}
                     >
                       {loading ? (
                         <div className="flex items-center gap-2">
-                          <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent" />
+                          <div className="animate-spin rounded-full h-4 w-4 border-2 border-paper border-t-transparent" />
                           Signing in...
                         </div>
                       ) : (
@@ -398,14 +398,14 @@ export function AuthForm() {
                     </div>
 
                     {error && (
-                      <div className="flex items-start gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/30 p-3 rounded-lg border border-red-200 dark:border-red-900/50">
+                      <div className="flex items-start gap-2 text-vermillion text-sm bg-vermillion-bg p-3 rounded-lg border border-vermillion ">
                         <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                         <span>{error}</span>
                       </div>
                     )}
 
                     {success && (
-                      <div className="flex items-start gap-2 text-green-600 dark:text-green-400 text-sm bg-green-50 dark:bg-green-950/30 p-3 rounded-lg border border-green-200 dark:border-green-900/50">
+                      <div className="flex items-start gap-2 text-forest text-sm bg-forest-bg p-3 rounded-lg border border-forest ">
                         <CheckCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                         <span>{success}</span>
                       </div>
@@ -413,12 +413,12 @@ export function AuthForm() {
 
                     <Button
                       type="submit"
-                      className="w-full bg-app-accent hover:bg-app-accent/90 text-white font-medium py-2.5 shadow-md shadow-app-accent/20 transition-all duration-200 hover:shadow-lg hover:shadow-app-accent/25"
+                      className="w-full bg-app-accent hover:bg-app-accent/90 text-ink-on-dark font-medium py-2.5 shadow-md shadow-app-accent/20 transition-all duration-200 hover:shadow-lg hover:shadow-app-accent/25"
                       disabled={loading}
                     >
                       {loading ? (
                         <div className="flex items-center gap-2">
-                          <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent" />
+                          <div className="animate-spin rounded-full h-4 w-4 border-2 border-paper border-t-transparent" />
                           Creating account...
                         </div>
                       ) : (

--- a/src/components/auth/client-route.tsx
+++ b/src/components/auth/client-route.tsx
@@ -31,7 +31,7 @@ export function ClientRoute({ children }: ClientRouteProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+        <Loader2 className="h-8 w-8 animate-spin text-ink-4" />
       </div>
     )
   }
@@ -46,12 +46,12 @@ export function ClientRoute({ children }: ClientRouteProps) {
   if (!hasRole('client') && !isImpersonating) {
     // Not a client - show friendly message instead of redirecting
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gray-50">
+      <div className="flex items-center justify-center min-h-screen bg-paper">
         <div className="text-center space-y-4">
-          <p className="text-gray-600">
+          <p className="text-ink-3">
             You don&apos;t have access to the portal.
           </p>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-ink-3">
             Please contact your administrator.
           </p>
           <Button variant="outline" onClick={handleGoBackToSignIn}>

--- a/src/components/auth/coach-route.tsx
+++ b/src/components/auth/coach-route.tsx
@@ -36,7 +36,7 @@ export function CoachRoute({ children }: CoachRouteProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+        <Loader2 className="h-8 w-8 animate-spin text-ink-4" />
       </div>
     )
   }

--- a/src/components/auth/forgot-password-request.tsx
+++ b/src/components/auth/forgot-password-request.tsx
@@ -71,15 +71,15 @@ export function ForgotPasswordRequest({ onBack }: ForgotPasswordRequestProps) {
 
   if (submitted) {
     return (
-      <Card className="border-green-200 dark:border-green-900/50 bg-green-50/50 dark:bg-green-950/20">
+      <Card className="border-forest bg-forest-bg/50 ">
         <CardHeader>
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-green-100 dark:bg-green-900/40 rounded-full">
-              <CheckCircle className="h-6 w-6 text-green-600 dark:text-green-400" />
+            <div className="p-2 bg-forest-bg rounded-full">
+              <CheckCircle className="h-6 w-6 text-forest " />
             </div>
             <div>
               <CardTitle className="text-lg">Check Your Email</CardTitle>
-              <CardDescription className="text-green-700 dark:text-green-400">
+              <CardDescription className="text-forest ">
                 Password reset instructions sent
               </CardDescription>
             </div>
@@ -92,7 +92,7 @@ export function ForgotPasswordRequest({ onBack }: ForgotPasswordRequestProps) {
             receive password reset instructions within a few minutes.
           </p>
 
-          <div className="bg-card rounded-lg p-4 border border-green-200 dark:border-green-900/50">
+          <div className="bg-card rounded-lg p-4 border border-forest ">
             <h4 className="font-medium text-sm text-foreground mb-2">
               Next steps:
             </h4>
@@ -174,7 +174,7 @@ export function ForgotPasswordRequest({ onBack }: ForgotPasswordRequestProps) {
           </div>
 
           {error && (
-            <div className="flex items-start gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/30 p-3 rounded-lg border border-red-200 dark:border-red-900/50">
+            <div className="flex items-start gap-2 text-vermillion text-sm bg-vermillion-bg p-3 rounded-lg border border-vermillion ">
               <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
               <span>{error}</span>
             </div>
@@ -182,7 +182,7 @@ export function ForgotPasswordRequest({ onBack }: ForgotPasswordRequestProps) {
 
           <Button
             type="submit"
-            className="w-full bg-app-accent hover:bg-app-accent/90 text-white font-medium py-2.5 shadow-md shadow-app-accent/20 transition-all duration-200 hover:shadow-lg hover:shadow-app-accent/25"
+            className="w-full bg-app-accent hover:bg-app-accent/90 text-ink-on-dark font-medium py-2.5 shadow-md shadow-app-accent/20 transition-all duration-200 hover:shadow-lg hover:shadow-app-accent/25"
             disabled={loading || !email.trim()}
           >
             {loading ? (

--- a/src/components/auth/password-strength-indicator.tsx
+++ b/src/components/auth/password-strength-indicator.tsx
@@ -78,9 +78,7 @@ export function PasswordStrengthIndicator({
               <div
                 key={key}
                 className={`flex items-center gap-2 text-sm transition-colors ${
-                  met
-                    ? 'text-green-600 dark:text-green-400'
-                    : 'text-muted-foreground/60'
+                  met ? 'text-forest ' : 'text-muted-foreground/60'
                 }`}
               >
                 {met ? (

--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -11,10 +11,10 @@ interface ProtectedRouteProps {
   loadingMessage?: string
 }
 
-export function ProtectedRoute({ 
-  children, 
+export function ProtectedRoute({
+  children,
   redirectTo = '/auth',
-  loadingMessage = 'Loading...'
+  loadingMessage = 'Loading...',
 }: ProtectedRouteProps) {
   const { isAuthenticated, loading } = useAuth()
   const router = useRouter()
@@ -27,7 +27,7 @@ export function ProtectedRoute({
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-gray-50 to-white">
+      <div className="min-h-screen flex items-center justify-center  ">
         <LoadingState message={loadingMessage} />
       </div>
     )

--- a/src/components/auth/role-switcher.tsx
+++ b/src/components/auth/role-switcher.tsx
@@ -105,7 +105,7 @@ export function RoleSwitcher() {
             <DropdownMenuItem
               key={view.role}
               onClick={() => router.push(dashboardPath)}
-              className={`cursor-pointer ${isCurrentView ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
+              className={`cursor-pointer ${isCurrentView ? 'bg-surface-3 ' : ''}`}
             >
               <div className="flex items-start gap-3 w-full">
                 <Icon className="h-4 w-4 mt-0.5" />
@@ -116,7 +116,7 @@ export function RoleSwitcher() {
                   </div>
                 </div>
                 {isCurrentView && (
-                  <div className="text-xs text-blue-600 dark:text-blue-400 font-medium mt-0.5">
+                  <div className="text-xs text-ds-accent font-medium mt-0.5">
                     Current
                   </div>
                 )}

--- a/src/components/client-portal/active-sessions-card.tsx
+++ b/src/components/client-portal/active-sessions-card.tsx
@@ -103,12 +103,12 @@ export function ActiveSessionsCard() {
   }
 
   return (
-    <Card className="border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-900/20">
+    <Card className="border-forest bg-forest-bg/50 ">
       <CardHeader className="pb-3">
-        <CardTitle className="text-lg font-semibold flex items-center gap-2 text-green-800 dark:text-green-400">
+        <CardTitle className="text-lg font-semibold flex items-center gap-2 text-forest ">
           <span className="relative flex h-3 w-3">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-            <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-forest opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-3 w-3 bg-forest"></span>
           </span>
           Live Session
         </CardTitle>
@@ -117,13 +117,13 @@ export function ActiveSessionsCard() {
         {activeSessions.map(session => (
           <div
             key={session.session_id}
-            className="flex items-center justify-between p-4 bg-white rounded-lg border border-green-200 dark:bg-gray-800 dark:border-green-800"
+            className="flex items-center justify-between p-4 bg-surface-1 rounded-lg border border-forest "
           >
             <div className="space-y-1">
-              <p className="font-medium text-gray-900 dark:text-white">
+              <p className="font-medium text-ink ">
                 Session with {session.coach_name}
               </p>
-              <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+              <div className="flex items-center gap-3 text-sm text-ink-3 ">
                 <span className="flex items-center gap-1">
                   <Clock className="h-3.5 w-3.5" />
                   {formatDuration(session.duration_seconds)} elapsed
@@ -134,16 +134,13 @@ export function ActiveSessionsCard() {
 
             {session.client_meeting_url ? (
               <Link href={session.client_meeting_url}>
-                <Button className="bg-green-600 hover:bg-green-700 text-white">
+                <Button className="bg-forest hover:bg-forest text-ink-on-dark">
                   <Radio className="h-4 w-4 mr-2" />
                   Join Session
                 </Button>
               </Link>
             ) : (
-              <Badge
-                variant="secondary"
-                className="bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-              >
+              <Badge variant="secondary" className="bg-surface-3 text-ink-3 ">
                 No link available
               </Badge>
             )}

--- a/src/components/client-portal/client-last-session-insights.tsx
+++ b/src/components/client-portal/client-last-session-insights.tsx
@@ -77,47 +77,46 @@ function SessionCommitmentItem({
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return <CheckCircle2 className="h-4 w-4 text-green-600" />
+        return <CheckCircle2 className="h-4 w-4 text-forest" />
       case 'in_progress':
-        return <PlayCircle className="h-4 w-4 text-blue-600" />
+        return <PlayCircle className="h-4 w-4 text-ds-accent" />
       default:
-        return <Circle className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+        return <Circle className="h-4 w-4 text-ink-3 " />
     }
   }
 
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'text-green-700 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-900/30 dark:border-green-800'
+        return 'text-forest bg-forest-bg border-forest '
       case 'in_progress':
-        return 'text-blue-700 bg-blue-50 border-blue-200 dark:text-blue-400 dark:bg-blue-900/30 dark:border-blue-800'
+        return 'text-ds-accent bg-ds-accent-bg border-ds-accent '
       default:
-        return 'text-gray-700 bg-gray-50 border-gray-200 dark:text-gray-300 dark:bg-gray-800 dark:border-gray-600'
+        return 'text-ink-2 bg-paper border-line '
     }
   }
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between gap-2 p-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+    <div className="border border-line rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between gap-2 p-3 hover:bg-paper transition-colors">
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <div className="flex-shrink-0">
             {getStatusIcon(commitment.status)}
           </div>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="flex-shrink-0 p-0.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+            className="flex-shrink-0 p-0.5 hover:bg-surface-3 rounded transition-colors"
           >
             {isExpanded ? (
-              <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronDown className="h-4 w-4 text-ink-3 " />
             ) : (
-              <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              <ChevronRight className="h-4 w-4 text-ink-3 " />
             )}
           </button>
           <p
             className={cn(
-              'text-sm font-medium flex-1 dark:text-gray-200',
-              commitment.status === 'completed' &&
-                'line-through text-gray-500 dark:text-gray-500',
+              'text-sm font-medium flex-1 ',
+              commitment.status === 'completed' && 'line-through text-ink-3 ',
             )}
           >
             {commitment.title}
@@ -155,13 +154,11 @@ function SessionCommitmentItem({
         </Select>
       </div>
       {isExpanded && (
-        <div className="px-3 pb-3 pt-1 space-y-2 border-t border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+        <div className="px-3 pb-3 pt-1 space-y-2 border-t border-line bg-paper ">
           {commitment.description && (
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              {commitment.description}
-            </p>
+            <p className="text-sm text-ink-3 ">{commitment.description}</p>
           )}
-          <div className="flex flex-wrap gap-3 text-xs text-gray-600 dark:text-gray-400">
+          <div className="flex flex-wrap gap-3 text-xs text-ink-3 ">
             {commitment.priority && (
               <span>
                 Priority: <strong>{commitment.priority}</strong>
@@ -202,13 +199,11 @@ export function ClientLastSessionInsights({
 
   if (!session) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700">
+      <Card className="border-line ">
         <CardContent className="py-8 text-center">
-          <FileText className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
-          <h3 className="font-medium text-gray-900 dark:text-white mb-1 text-sm">
-            No sessions yet
-          </h3>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <FileText className="h-10 w-10 text-ink-2 mx-auto mb-3" />
+          <h3 className="font-medium text-ink mb-1 text-sm">No sessions yet</h3>
+          <p className="text-xs text-ink-3 ">
             Your coaching sessions will appear here after your first call.
           </p>
         </CardContent>
@@ -222,11 +217,11 @@ export function ClientLastSessionInsights({
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700">
-      <CardHeader className="pb-3 border-b border-gray-200 dark:border-gray-700">
+    <Card className="border-line ">
+      <CardHeader className="pb-3 border-b border-line ">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-semibold flex items-center gap-2">
-            <FileText className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+            <FileText className="h-4 w-4 text-ink-3 " />
             Last Session Insights
           </CardTitle>
           <Link href={`/client-portal/sessions/${session.id}`}>
@@ -241,17 +236,17 @@ export function ClientLastSessionInsights({
         {/* Session Info */}
         <div className="flex items-start justify-between">
           <div>
-            <p className="text-sm font-medium text-gray-900 dark:text-white">
+            <p className="text-sm font-medium text-ink ">
               {formatDate(session.date, 'EEEE, MMMM d, yyyy')}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            <p className="text-xs text-ink-3 mt-0.5">
               {formatRelativeTime(session.date)}
             </p>
           </div>
           <div className="flex items-center gap-2">
             <Badge
               variant="secondary"
-              className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-xs"
+              className="bg-surface-3 text-ink-2 text-xs"
             >
               <Clock className="h-3 w-3 mr-1" />
               {session.duration_minutes} min
@@ -259,7 +254,7 @@ export function ClientLastSessionInsights({
             {session.score && (
               <Badge
                 variant="secondary"
-                className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-xs"
+                className="bg-surface-3 text-ink-2 text-xs"
               >
                 <TrendingUp className="h-3 w-3 mr-1" />
                 {session.score}/10
@@ -270,7 +265,7 @@ export function ClientLastSessionInsights({
 
         {/* Summary */}
         {session.summary && (
-          <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+          <p className="text-sm text-ink-3 leading-relaxed">
             {session.summary}
           </p>
         )}
@@ -282,7 +277,7 @@ export function ClientLastSessionInsights({
               <Badge
                 key={idx}
                 variant="outline"
-                className="text-xs border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400"
+                className="text-xs border-line text-ink-3 "
               >
                 {topic}
               </Badge>
@@ -293,7 +288,7 @@ export function ClientLastSessionInsights({
         {/* Session Commitments */}
         {commitments?.commitments && commitments.commitments.length > 0 && (
           <div>
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+            <h4 className="text-sm font-semibold text-ink-2 mb-3 flex items-center gap-2">
               <TargetIcon className="h-4 w-4" />
               Commitments from This Session ({commitments.commitments.length})
             </h4>
@@ -312,7 +307,7 @@ export function ClientLastSessionInsights({
         {/* Action Items / Next Session Focus */}
         {session.action_items && session.action_items.length > 0 && (
           <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
-            <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+            <h4 className="text-sm font-semibold text-ink mb-2 flex items-center gap-2">
               <TargetIcon className="h-4 w-4 text-primary" />
               Next Session Focus
             </h4>
@@ -322,14 +317,14 @@ export function ClientLastSessionInsights({
                 .map((item: string, index: number) => (
                   <li
                     key={index}
-                    className="text-sm text-gray-700 dark:text-gray-300 flex items-start gap-2"
+                    className="text-sm text-ink-2 flex items-start gap-2"
                   >
                     <span className="text-primary mt-0.5">&#8594;</span>
                     <span>{item}</span>
                   </li>
                 ))}
               {session.action_items.length > 3 && (
-                <li className="text-xs text-gray-600 dark:text-gray-400 ml-5">
+                <li className="text-xs text-ink-3 ml-5">
                   +{session.action_items.length - 3} more items
                 </li>
               )}

--- a/src/components/client-portal/client-navigation.tsx
+++ b/src/components/client-portal/client-navigation.tsx
@@ -13,11 +13,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
-  LayoutDashboard,
-  History,
+  Home,
+  MessageSquareText,
+  UserRound,
   User,
   LogOut,
-  Sparkles,
+  Bell,
+  Search,
   Menu,
   X,
   Eye,
@@ -30,11 +32,19 @@ import { ThemeToggle } from '@/components/ui/theme-toggle'
 const navItems = [
   {
     path: '/client-portal/dashboard',
-    label: 'Dashboard',
-    icon: LayoutDashboard,
+    label: 'Home',
+    icon: Home,
   },
-  { path: '/client-portal/sessions', label: 'Sessions', icon: History },
-  { path: '/client-portal/persona', label: 'My Profile', icon: User },
+  {
+    path: '/client-portal/sessions',
+    label: 'Sessions',
+    icon: MessageSquareText,
+  },
+  {
+    path: '/client-portal/persona',
+    label: 'Coaching Profile',
+    icon: UserRound,
+  },
 ]
 
 export function ClientNavigation() {
@@ -115,70 +125,74 @@ export function ClientNavigation() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             {/* Logo Section */}
-            <div className="flex items-center gap-10">
+            <div className="flex items-center gap-8">
               <button
                 onClick={() => router.push('/client-portal/dashboard')}
                 className="flex items-center gap-3 group"
               >
-                <div className="relative">
-                  <div className="absolute inset-0 bg-ink rounded-xl blur-sm opacity-20 group-hover:opacity-30 transition-opacity"></div>
-                  <div className="relative w-11 h-11 bg-ink rounded-xl p-1.5 flex items-center justify-center group-hover:scale-105 transition-transform">
-                    <Image
-                      src="/novus-global-logo.webp"
-                      alt="Novus Global Logo"
-                      width={32}
-                      height={32}
-                      className="object-contain filter brightness-0 invert"
-                    />
-                  </div>
+                <div className="w-10 h-10 bg-ink rounded-xl flex items-center justify-center flex-shrink-0">
+                  <Image
+                    src="/novus-global-logo.webp"
+                    alt=""
+                    width={28}
+                    height={28}
+                    className="object-contain filter brightness-0 invert"
+                  />
                 </div>
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <h1 className="text-xl font-bold text-ink ">
-                      Client Portal
-                    </h1>
-                  </div>
-                  <div className="hidden sm:flex items-center gap-1 px-2 py-0.5 bg-surface-3 rounded-full">
-                    <Sparkles className="w-3 h-3 text-ink-3 " />
-                    <span className="text-xs font-medium text-ink-3 ">
-                      Novus Global
-                    </span>
-                  </div>
+                <div className="flex flex-col items-start gap-0.5">
+                  <span className="text-[16px] font-bold tracking-tight text-ink leading-none">
+                    Coach Sidekick
+                  </span>
+                  <span className="text-[11px] font-medium uppercase tracking-[0.04em] text-ink-3 leading-none">
+                    Client portal
+                  </span>
                 </div>
               </button>
 
               {/* Desktop Navigation Links */}
-              <nav className="hidden md:flex items-center">
-                <div className="flex items-center bg-paper rounded-lg p-1">
-                  {navItems.map(item => {
-                    const Icon = item.icon
-                    const isActive = isActivePath(item.path)
+              <nav className="hidden md:flex items-center gap-1">
+                {navItems.map(item => {
+                  const Icon = item.icon
+                  const isActive = isActivePath(item.path)
 
-                    return (
-                      <button
-                        key={item.path}
-                        onClick={() => router.push(item.path)}
-                        className={`
-                        flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium
-                        transition-all duration-200 cursor-pointer
+                  return (
+                    <button
+                      key={item.path}
+                      onClick={() => router.push(item.path)}
+                      className={`
+                        inline-flex items-center gap-2 px-3 py-2 rounded-md text-[13px] font-medium
+                        transition-colors duration-150 cursor-pointer
                         ${
                           isActive
-                            ? 'bg-surface-1 text-ink shadow-sm '
-                            : 'text-ink-3 hover:text-ink hover:bg-surface-1 hover:shadow-sm '
+                            ? 'bg-surface-3 text-ink'
+                            : 'text-ink-3 hover:bg-surface-3 hover:text-ink'
                         }
                       `}
-                      >
-                        <Icon className="h-4 w-4" />
-                        {item.label}
-                      </button>
-                    )
-                  })}
-                </div>
+                    >
+                      <Icon className="h-[15px] w-[15px]" strokeWidth={1.75} />
+                      {item.label}
+                    </button>
+                  )
+                })}
               </nav>
             </div>
 
             {/* Right Section */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3">
+              <button
+                aria-label="Notifications"
+                className="hidden sm:inline-flex h-8 w-8 items-center justify-center rounded-md text-ink-3 hover:bg-surface-3 hover:text-ink transition-colors"
+              >
+                <Bell className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+              <button
+                aria-label="Search"
+                className="hidden sm:inline-flex h-8 w-8 items-center justify-center rounded-md text-ink-3 hover:bg-surface-3 hover:text-ink transition-colors"
+              >
+                <Search className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+              <div className="hidden sm:block w-px h-5 bg-line" />
+
               <ThemeToggle />
 
               {/* Role Switcher - Only show if user has other roles */}
@@ -189,10 +203,10 @@ export function ClientNavigation() {
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
-                    className="relative h-8 w-8 rounded-full"
+                    className="relative h-8 w-8 rounded-full p-0 hover:bg-transparent"
                   >
                     <Avatar className="h-8 w-8">
-                      <AvatarFallback className="bg-ds-accent-bg text-ds-accent ">
+                      <AvatarFallback className="bg-ink text-ink-on-dark text-xs font-semibold">
                         {getInitials()}
                       </AvatarFallback>
                     </Avatar>

--- a/src/components/client-portal/client-navigation.tsx
+++ b/src/components/client-portal/client-navigation.tsx
@@ -98,7 +98,7 @@ export function ClientNavigation() {
   return (
     <>
       {impersonatedClientName && (
-        <div className="bg-amber-500 text-white px-4 py-2 text-center text-sm font-medium flex items-center justify-center gap-3 sticky top-0 z-[60]">
+        <div className="bg-amber-token text-ink-on-dark px-4 py-2 text-center text-sm font-medium flex items-center justify-center gap-3 sticky top-0 z-[60]">
           <Eye className="h-4 w-4 shrink-0" />
           <span>Viewing portal as: {impersonatedClientName}</span>
           <Button
@@ -111,7 +111,7 @@ export function ClientNavigation() {
           </Button>
         </div>
       )}
-      <header className="bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 sticky top-0 z-50">
+      <header className="bg-surface-1 border-b border-line sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             {/* Logo Section */}
@@ -121,8 +121,8 @@ export function ClientNavigation() {
                 className="flex items-center gap-3 group"
               >
                 <div className="relative">
-                  <div className="absolute inset-0 bg-gray-900 rounded-xl blur-sm opacity-20 group-hover:opacity-30 transition-opacity"></div>
-                  <div className="relative w-11 h-11 bg-gray-900 rounded-xl p-1.5 flex items-center justify-center group-hover:scale-105 transition-transform">
+                  <div className="absolute inset-0 bg-ink rounded-xl blur-sm opacity-20 group-hover:opacity-30 transition-opacity"></div>
+                  <div className="relative w-11 h-11 bg-ink rounded-xl p-1.5 flex items-center justify-center group-hover:scale-105 transition-transform">
                     <Image
                       src="/novus-global-logo.webp"
                       alt="Novus Global Logo"
@@ -134,13 +134,13 @@ export function ClientNavigation() {
                 </div>
                 <div className="flex flex-col">
                   <div className="flex items-center gap-2">
-                    <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+                    <h1 className="text-xl font-bold text-ink ">
                       Client Portal
                     </h1>
                   </div>
-                  <div className="hidden sm:flex items-center gap-1 px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded-full">
-                    <Sparkles className="w-3 h-3 text-gray-600 dark:text-gray-400" />
-                    <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                  <div className="hidden sm:flex items-center gap-1 px-2 py-0.5 bg-surface-3 rounded-full">
+                    <Sparkles className="w-3 h-3 text-ink-3 " />
+                    <span className="text-xs font-medium text-ink-3 ">
                       Novus Global
                     </span>
                   </div>
@@ -149,7 +149,7 @@ export function ClientNavigation() {
 
               {/* Desktop Navigation Links */}
               <nav className="hidden md:flex items-center">
-                <div className="flex items-center bg-gray-50 dark:bg-gray-800 rounded-lg p-1">
+                <div className="flex items-center bg-paper rounded-lg p-1">
                   {navItems.map(item => {
                     const Icon = item.icon
                     const isActive = isActivePath(item.path)
@@ -163,8 +163,8 @@ export function ClientNavigation() {
                         transition-all duration-200 cursor-pointer
                         ${
                           isActive
-                            ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                            : 'text-gray-600 hover:text-gray-900 hover:bg-white hover:shadow-sm dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700'
+                            ? 'bg-surface-1 text-ink shadow-sm '
+                            : 'text-ink-3 hover:text-ink hover:bg-surface-1 hover:shadow-sm '
                         }
                       `}
                       >
@@ -192,7 +192,7 @@ export function ClientNavigation() {
                     className="relative h-8 w-8 rounded-full"
                   >
                     <Avatar className="h-8 w-8">
-                      <AvatarFallback className="bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                      <AvatarFallback className="bg-ds-accent-bg text-ds-accent ">
                         {getInitials()}
                       </AvatarFallback>
                     </Avatar>
@@ -220,7 +220,7 @@ export function ClientNavigation() {
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     onSelect={handleSignOut}
-                    className="cursor-pointer text-red-600"
+                    className="cursor-pointer text-vermillion"
                   >
                     <LogOut className="mr-2 h-4 w-4" />
                     <span>Log out</span>
@@ -246,7 +246,7 @@ export function ClientNavigation() {
 
           {/* Mobile Navigation */}
           {mobileMenuOpen && (
-            <div className="md:hidden py-4 border-t border-gray-100 dark:border-gray-800">
+            <div className="md:hidden py-4 border-t border-line ">
               <nav className="flex flex-col gap-1">
                 {navItems.map(item => {
                   const Icon = item.icon
@@ -264,8 +264,8 @@ export function ClientNavigation() {
                       transition-all duration-200
                       ${
                         isActive
-                          ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
-                          : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-800'
+                          ? 'bg-surface-3 text-ink '
+                          : 'text-ink-3 hover:text-ink hover:bg-paper '
                       }
                     `}
                     >

--- a/src/components/client-portal/client-portal-chat.tsx
+++ b/src/components/client-portal/client-portal-chat.tsx
@@ -243,28 +243,28 @@ export function ClientPortalChat() {
     return (
       <div className="flex flex-col h-full">
         <div className="flex items-center justify-center flex-1">
-          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
         </div>
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+    <div className="flex flex-col h-full bg-surface-1 rounded-xl shadow-sm border border-line overflow-hidden">
       {/* Header */}
-      <div className="bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-800 border-b border-gray-200 dark:border-gray-700">
+      <div className=" border-b border-line ">
         <div className="px-5 py-4">
           {/* Title Row */}
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-white dark:bg-gray-900 shadow-sm flex items-center justify-center border border-gray-200 dark:border-gray-700">
-                <MessageSquare className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+              <div className="h-10 w-10 rounded-lg bg-surface-1 shadow-sm flex items-center justify-center border border-line ">
+                <MessageSquare className="h-5 w-5 text-ink-2 " />
               </div>
               <div>
-                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                <h3 className="text-base font-semibold text-ink ">
                   AI Coaching Assistant
                 </h3>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                <p className="text-xs text-ink-3 mt-0.5">
                   Reflect on your coaching journey
                 </p>
               </div>
@@ -275,7 +275,7 @@ export function ClientPortalChat() {
               size="sm"
               variant="ghost"
               onClick={handleClearChat}
-              className="h-9 w-9 p-0 rounded-lg text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700"
+              className="h-9 w-9 p-0 rounded-lg text-ink-3 hover:text-ink hover:bg-surface-3 "
               title="Clear chat"
             >
               <RotateCw className="h-3.5 w-3.5" />
@@ -285,15 +285,15 @@ export function ClientPortalChat() {
           {/* Stats Bar */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-900 rounded-full border border-gray-200 dark:border-gray-700 shadow-sm">
-                <div className="h-1.5 w-1.5 rounded-full bg-green-500"></div>
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-1 rounded-full border border-line shadow-sm">
+                <div className="h-1.5 w-1.5 rounded-full bg-forest"></div>
+                <span className="text-xs font-medium text-ink-2 ">
                   {stats?.unique_sessions ?? 0} sessions
                 </span>
               </div>
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-900 rounded-full border border-gray-200 dark:border-gray-700 shadow-sm">
-                <Database className="h-3 w-3 text-gray-500 dark:text-gray-400" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-1 rounded-full border border-line shadow-sm">
+                <Database className="h-3 w-3 text-ink-3 " />
+                <span className="text-xs font-medium text-ink-2 ">
                   {stats?.total_chunks ?? 0} insights
                 </span>
               </div>
@@ -303,18 +303,18 @@ export function ClientPortalChat() {
       </div>
 
       {/* Messages Area */}
-      <ScrollArea className="flex-1 bg-gray-50/50 dark:bg-gray-900/50">
+      <ScrollArea className="flex-1 bg-paper/50 ">
         <div className="p-5 space-y-4">
           {messages.length === 0 ? (
             <div>
               <div className="text-center py-8">
-                <div className="h-14 w-14 rounded-full bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 mx-auto mb-4 flex items-center justify-center shadow-sm">
-                  <Bot className="h-7 w-7 text-gray-600 dark:text-gray-300" />
+                <div className="h-14 w-14 rounded-full  mx-auto mb-4 flex items-center justify-center shadow-sm">
+                  <Bot className="h-7 w-7 text-ink-3 " />
                 </div>
-                <p className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+                <p className="text-sm font-medium text-ink mb-1">
                   Ask about your coaching journey
                 </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-3 ">
                   Reflect on your sessions, goals, and progress
                 </p>
               </div>
@@ -322,20 +322,20 @@ export function ClientPortalChat() {
               {/* Suggested Questions */}
               {suggestedQuestions.length > 0 && (
                 <div className="space-y-2">
-                  <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">
+                  <p className="text-xs text-ink-3 uppercase tracking-wider text-center">
                     Suggested Questions
                   </p>
                   {suggestedQuestions.slice(0, 3).map((question, idx) => (
                     <button
                       key={idx}
                       onClick={() => handleSuggestedQuestion(question)}
-                      className="w-full text-left p-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all group"
+                      className="w-full text-left p-3 rounded-lg bg-surface-1 border border-line hover:border-line-strong hover:shadow-sm transition-all group"
                     >
                       <div className="flex items-start gap-2.5">
-                        <div className="h-6 w-6 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0 group-hover:bg-gray-200 dark:group-hover:bg-gray-600 transition-colors">
-                          <Sparkles className="h-3 w-3 text-gray-600 dark:text-gray-300" />
+                        <div className="h-6 w-6 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 group-hover:bg-surface-3 transition-colors">
+                          <Sparkles className="h-3 w-3 text-ink-3 " />
                         </div>
-                        <span className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed font-medium">
+                        <span className="text-xs text-ink-2 leading-relaxed font-medium">
                           {question}
                         </span>
                       </div>
@@ -359,8 +359,8 @@ export function ClientPortalChat() {
                   >
                     {isAssistant && (
                       <div className="flex-shrink-0">
-                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center shadow-sm">
-                          <Bot className="h-4 w-4 text-gray-700 dark:text-gray-300" />
+                        <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                          <Bot className="h-4 w-4 text-ink-2 " />
                         </div>
                       </div>
                     )}
@@ -375,15 +375,15 @@ export function ClientPortalChat() {
                         className={cn(
                           'rounded-lg px-3.5 py-2.5 shadow-sm',
                           isAssistant
-                            ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700'
-                            : 'bg-gray-900 dark:bg-gray-700 text-white border border-gray-800 dark:border-gray-600',
+                            ? 'bg-surface-1 text-ink border border-line '
+                            : 'bg-ink text-ink-on-dark border border-line ',
                         )}
                       >
                         {message.isVoice && (
                           <div
                             className={cn(
                               'flex items-center gap-1.5 mb-1.5 text-xs',
-                              isAssistant ? 'text-gray-500' : 'text-gray-400',
+                              isAssistant ? 'text-ink-3' : 'text-ink-4',
                             )}
                           >
                             <Volume2 className="h-3 w-3" />
@@ -407,7 +407,7 @@ export function ClientPortalChat() {
                           <div className="space-y-1">
                             <button
                               onClick={() => toggleSources(idx)}
-                              className="inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-2 py-1 rounded transition-colors"
+                              className="inline-flex items-center gap-1.5 text-xs text-ink-3 hover:text-ink-2 bg-surface-3 hover:bg-surface-3 px-2 py-1 rounded transition-colors"
                             >
                               <BookOpen className="h-3 w-3" />
                               <span>
@@ -429,15 +429,15 @@ export function ClientPortalChat() {
                                   (source: any, sourceIdx: number) => (
                                     <div
                                       key={sourceIdx}
-                                      className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-2.5"
+                                      className="bg-surface-1 rounded-lg border border-line p-2.5"
                                     >
                                       <div className="flex items-start justify-between mb-1">
-                                        <span className="text-xs text-gray-600 dark:text-gray-400">
+                                        <span className="text-xs text-ink-3 ">
                                           {formatDate(
                                             source.date || source.timestamp,
                                           )}
                                         </span>
-                                        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                                        <span className="text-xs font-medium text-ink-3 ">
                                           {(
                                             source.relevance_score * 100
                                           ).toFixed(0)}
@@ -445,7 +445,7 @@ export function ClientPortalChat() {
                                         </span>
                                       </div>
                                       {source.content && (
-                                        <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed line-clamp-3">
+                                        <p className="text-xs text-ink-2 leading-relaxed line-clamp-3">
                                           {source.content}
                                         </p>
                                       )}
@@ -460,8 +460,8 @@ export function ClientPortalChat() {
 
                     {!isAssistant && (
                       <div className="flex-shrink-0">
-                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-800 to-gray-900 flex items-center justify-center shadow-sm">
-                          <User className="h-4 w-4 text-white" />
+                        <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                          <User className="h-4 w-4 text-ink-on-dark" />
                         </div>
                       </div>
                     )}
@@ -472,14 +472,12 @@ export function ClientPortalChat() {
               {/* Loading state */}
               {isLoading && (
                 <div className="flex gap-2 justify-start">
-                  <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-600 flex items-center justify-center shadow-sm">
-                    <Bot className="h-4 w-4 text-gray-700 dark:text-gray-300" />
+                  <div className="h-8 w-8 rounded-lg bg-surface-3 flex items-center justify-center shadow-sm">
+                    <Bot className="h-4 w-4 text-ink-2 " />
                   </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg px-4 py-3 border border-gray-200 dark:border-gray-700 shadow-sm flex items-center gap-2">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-600 dark:text-gray-400" />
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      Thinking...
-                    </span>
+                  <div className="bg-surface-1 rounded-lg px-4 py-3 border border-line shadow-sm flex items-center gap-2">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-ink-3 " />
+                    <span className="text-xs text-ink-3 ">Thinking...</span>
                   </div>
                 </div>
               )}
@@ -487,8 +485,8 @@ export function ClientPortalChat() {
               {/* Voice status indicators */}
               {isListening && (
                 <div className="flex gap-2 justify-end">
-                  <div className="bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg px-3 py-2 flex items-center gap-2">
-                    <div className="h-2 w-2 rounded-full bg-red-500 animate-pulse" />
+                  <div className="bg-vermillion-bg text-vermillion rounded-lg px-3 py-2 flex items-center gap-2">
+                    <div className="h-2 w-2 rounded-full bg-vermillion animate-pulse" />
                     <span className="text-sm">Listening...</span>
                     {interimTranscript && (
                       <span className="text-sm italic ml-2">
@@ -502,7 +500,7 @@ export function ClientPortalChat() {
               {isSpeaking && (
                 <div className="flex gap-2 justify-start">
                   <div className="h-8 w-8" />
-                  <div className="bg-violet-50 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 rounded-lg px-3 py-2 flex items-center gap-2">
+                  <div className="bg-indigo-bg text-indigo rounded-lg px-3 py-2 flex items-center gap-2">
                     <Volume2 className="h-4 w-4 animate-pulse" />
                     <span className="text-sm">Speaking...</span>
                   </div>
@@ -516,7 +514,7 @@ export function ClientPortalChat() {
       </ScrollArea>
 
       {/* Input Area */}
-      <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <div className="border-t border-line p-4  ">
         <div className="flex gap-2">
           {/* Voice/Text Toggle */}
           <TooltipProvider>
@@ -529,8 +527,8 @@ export function ClientPortalChat() {
                   className={cn(
                     'h-10 w-10 p-0 rounded-lg transition-all flex-shrink-0',
                     inputMode === 'voice'
-                      ? 'bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900'
-                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800',
+                      ? 'bg-ink hover:bg-ink-2 text-ink-on-dark '
+                      : 'text-ink-3 hover:text-ink hover:bg-surface-3 ',
                   )}
                   disabled={isListening}
                 >
@@ -560,7 +558,7 @@ export function ClientPortalChat() {
                 onChange={e => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="Ask about your coaching journey..."
-                className="w-full min-h-[40px] max-h-[120px] pl-4 pr-12 py-2.5 text-sm border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-gray-500 bg-white dark:bg-gray-800 dark:text-white shadow-sm"
+                className="w-full min-h-[40px] max-h-[120px] pl-4 pr-12 py-2.5 text-sm border border-line rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-line-strong focus:border-transparent placeholder:text-ink-4 bg-surface-1 shadow-sm"
                 disabled={isLoading}
                 rows={1}
               />
@@ -568,7 +566,7 @@ export function ClientPortalChat() {
                 onClick={() => handleSend()}
                 disabled={!input.trim() || isLoading}
                 size="sm"
-                className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 h-7 w-7 p-0 rounded-lg shadow-sm transition-all disabled:opacity-50"
+                className="absolute right-2 top-1/2 -translate-y-1/2 bg-ink hover:bg-ink-2 text-ink-on-dark h-7 w-7 p-0 rounded-lg shadow-sm transition-all disabled:opacity-50"
               >
                 {isLoading ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -613,7 +611,7 @@ export function ClientPortalChat() {
                 </Button>
               )}
 
-              <span className="text-xs text-gray-500 dark:text-gray-400">
+              <span className="text-xs text-ink-3 ">
                 {isListening ? 'Release to send' : 'Hold to speak'}
               </span>
             </div>
@@ -622,13 +620,13 @@ export function ClientPortalChat() {
 
         {/* Status Bar */}
         <div className="flex items-center justify-between mt-2">
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-ink-3 ">
             {inputMode === 'voice'
               ? 'Classic Voice \u2022 Text-to-speech enabled'
               : 'Enter to send \u2022 Shift+Enter for new line'}
           </p>
           {messages.length > 0 && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">
+            <span className="text-xs text-ink-4 ">
               {messages.length} messages
             </span>
           )}

--- a/src/components/client-portal/next-session-card.tsx
+++ b/src/components/client-portal/next-session-card.tsx
@@ -13,17 +13,15 @@ interface NextSessionCardProps {
 export function NextSessionCard({ nextSession }: NextSessionCardProps) {
   if (!nextSession) {
     return (
-      <Card className="border-gray-200">
+      <Card className="border-line">
         <CardContent className="p-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800">
-              <Calendar className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-surface-3 ">
+              <Calendar className="h-4 w-4 text-ink-4 " />
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
-                Next Session
-              </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-sm font-medium text-ink ">Next Session</p>
+              <p className="text-xs text-ink-3 ">
                 No upcoming session scheduled
               </p>
             </div>
@@ -36,32 +34,26 @@ export function NextSessionCard({ nextSession }: NextSessionCardProps) {
   const relativeTime = formatRelativeTime(nextSession)
 
   return (
-    <Card className="border-gray-200">
+    <Card className="border-line">
       <CardContent className="p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/30">
-              <Calendar className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-ds-accent-bg ">
+              <Calendar className="h-4 w-4 text-ds-accent " />
             </div>
             <div>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
-                Next Session
-              </p>
+              <p className="text-sm font-medium text-ink ">Next Session</p>
               <div className="flex items-center gap-2 mt-0.5">
-                <p className="text-xs text-gray-700 dark:text-gray-300 font-medium">
+                <p className="text-xs text-ink-2 font-medium">
                   {formatDate(nextSession, 'EEEE, MMM d')}
                 </p>
-                <span className="text-xs text-gray-400 dark:text-gray-500">
-                  ·
-                </span>
-                <p className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                <span className="text-xs text-ink-4 ">·</span>
+                <p className="text-xs text-ink-3 flex items-center gap-1">
                   <Clock className="h-3 w-3" />
                   {formatDate(nextSession, 'h:mm a')}
                 </p>
               </div>
-              <p className="text-xs text-blue-600 dark:text-blue-400 mt-0.5">
-                {relativeTime}
-              </p>
+              <p className="text-xs text-ds-accent mt-0.5">{relativeTime}</p>
             </div>
           </div>
           <Link href="/client-portal/sessions">

--- a/src/components/client-portal/progress-summary-widget.tsx
+++ b/src/components/client-portal/progress-summary-widget.tsx
@@ -44,11 +44,11 @@ export function ProgressSummaryWidget({
   if (totalItems === 0) return null
 
   return (
-    <Card className="border-gray-200">
+    <Card className="border-line">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-semibold flex items-center gap-2">
-            <Target className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+            <Target className="h-4 w-4 text-ink-3 " />
             Commitments & Meta Performance Outcomes
           </CardTitle>
           <Link href="/client-portal/my-commitments">
@@ -62,21 +62,21 @@ export function ProgressSummaryWidget({
       <CardContent className="pt-0">
         <div className="flex items-center gap-4 mb-3">
           <div className="text-center flex-1">
-            <p className="text-lg font-bold text-gray-900 dark:text-white">
+            <p className="text-lg font-bold text-ink ">
               {activeOutcomes.length + activeCommitments.length}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Active</p>
+            <p className="text-xs text-ink-3 ">Active</p>
           </div>
-          <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" />
+          <div className="h-8 w-px bg-surface-3 " />
           <div className="text-center flex-1">
-            <p className="text-lg font-bold text-gray-900 dark:text-white">
+            <p className="text-lg font-bold text-ink ">
               {completedOutcomes.length + completedCommitments.length}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Done</p>
+            <p className="text-xs text-ink-3 ">Done</p>
           </div>
         </div>
         <div>
-          <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <div className="flex items-center justify-between text-xs text-ink-3 mb-1">
             <span>Progress</span>
             <span className="font-medium">{avgProgress}%</span>
           </div>

--- a/src/components/client-portal/recent-resources-widget.tsx
+++ b/src/components/client-portal/recent-resources-widget.tsx
@@ -53,9 +53,7 @@ function ResourceDetailDialog({
             {resource.title}
           </DialogTitle>
           {resource.description && (
-            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              {resource.description}
-            </p>
+            <p className="text-sm text-ink-3 mt-1">{resource.description}</p>
           )}
         </DialogHeader>
 
@@ -73,24 +71,24 @@ function ResourceDetailDialog({
                 {CATEGORY_LABELS[resource.category as ResourceCategory] ||
                   resource.category}
               </Badge>
-              <span className="text-xs text-gray-400 dark:text-gray-500">
+              <span className="text-xs text-ink-4 ">
                 {formatDate(resource.created_at)}
               </span>
             </div>
 
             {resource.content && (
-              <div className="prose prose-sm max-w-none p-6 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed">
+              <div className="prose prose-sm max-w-none p-6 bg-paper rounded-lg">
+                <div className="whitespace-pre-wrap text-ink-2 leading-relaxed">
                   {resource.content}
                 </div>
               </div>
             )}
 
             {resource.file_url && (
-              <div className="flex items-center gap-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <FileText className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+              <div className="flex items-center gap-3 p-4 bg-paper rounded-lg">
+                <FileText className="h-5 w-5 text-ink-3 " />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="text-sm font-medium text-ink ">
                     {resource.file_type || 'File'}
                   </p>
                 </div>
@@ -106,9 +104,9 @@ function ResourceDetailDialog({
             )}
 
             {resource.content_url && (
-              <div className="flex items-center gap-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <Link2 className="h-5 w-5 text-gray-500 dark:text-gray-400" />
-                <p className="flex-1 text-sm text-blue-600 dark:text-blue-400 truncate">
+              <div className="flex items-center gap-3 p-4 bg-paper rounded-lg">
+                <Link2 className="h-5 w-5 text-ink-3 " />
+                <p className="flex-1 text-sm text-ds-accent truncate">
                   {resource.content_url}
                 </p>
                 <Button
@@ -181,13 +179,13 @@ function ResourceRow({
     <div className="flex items-center gap-3 py-2.5 group">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+          <p className="text-sm font-medium text-ink truncate">
             {resource.title}
           </p>
           {!resource.is_viewed && (
             <Badge
               variant="secondary"
-              className="text-[10px] px-1.5 py-0 h-4 bg-blue-100 text-blue-700 font-semibold shrink-0"
+              className="text-[10px] px-1.5 py-0 h-4 bg-ds-accent-bg text-ds-accent font-semibold shrink-0"
             >
               NEW
             </Badge>
@@ -200,7 +198,7 @@ function ResourceRow({
           >
             {resource.category}
           </Badge>
-          <span className="text-[11px] text-gray-400 dark:text-gray-500">
+          <span className="text-[11px] text-ink-4 ">
             {formatDate(resource.created_at)}
           </span>
         </div>
@@ -212,7 +210,7 @@ function ResourceRow({
           <Button
             size="sm"
             variant="ghost"
-            className="h-7 w-7 p-0 text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+            className="h-7 w-7 p-0 text-ink-4 hover:text-ink-2 "
             onClick={handleDownload}
             title="Download"
           >
@@ -223,7 +221,7 @@ function ResourceRow({
           <Button
             size="sm"
             variant="ghost"
-            className="h-7 w-7 p-0 text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+            className="h-7 w-7 p-0 text-ink-4 hover:text-ink-2 "
             onClick={handleOpenLink}
             title="Open link"
           >
@@ -234,7 +232,7 @@ function ResourceRow({
           <Button
             size="sm"
             variant="ghost"
-            className="h-7 w-7 p-0 text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+            className="h-7 w-7 p-0 text-ink-4 hover:text-ink-2 "
             onClick={e => {
               e.preventDefault()
               e.stopPropagation()
@@ -250,7 +248,7 @@ function ResourceRow({
             <Button
               size="sm"
               variant="ghost"
-              className="h-7 w-7 p-0 text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+              className="h-7 w-7 p-0 text-ink-4 hover:text-ink-2 "
               onClick={e => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -276,10 +274,10 @@ export function RecentResourcesWidget() {
 
   return (
     <>
-      <Card className="border-gray-200">
+      <Card className="border-line">
         <CardHeader className="pb-3">
           <CardTitle className="text-sm font-semibold flex items-center gap-2">
-            <BookOpen className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+            <BookOpen className="h-4 w-4 text-ink-3 " />
             Recent Resources
           </CardTitle>
         </CardHeader>
@@ -289,16 +287,16 @@ export function RecentResourcesWidget() {
               {[1, 2, 3].map(i => (
                 <div
                   key={i}
-                  className="h-12 bg-gray-100 dark:bg-gray-800 rounded animate-pulse"
+                  className="h-12 bg-surface-3 rounded animate-pulse"
                 />
               ))}
             </div>
           ) : resources.length === 0 ? (
-            <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+            <p className="text-sm text-ink-3 text-center py-4">
               No resources shared yet
             </p>
           ) : (
-            <div className="divide-y divide-gray-100 dark:divide-gray-800">
+            <div className="divide-y divide-line ">
               {resources.map(resource => (
                 <ResourceRow
                   key={resource.id}

--- a/src/components/client-portal/upcoming-tasks-widget.tsx
+++ b/src/components/client-portal/upcoming-tasks-widget.tsx
@@ -21,11 +21,10 @@ interface UpcomingCommitmentsWidgetProps {
 }
 
 const priorityColors: Record<string, string> = {
-  urgent: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-  high: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-  medium:
-    'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-  low: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  urgent: 'bg-vermillion-bg text-vermillion ',
+  high: 'bg-amber-token-bg text-amber-token ',
+  medium: 'bg-amber-token-bg text-amber-token ',
+  low: 'bg-surface-3 text-ink-3 ',
 }
 
 export function UpcomingTasksWidget({
@@ -50,11 +49,11 @@ export function UpcomingTasksWidget({
     .slice(0, 5)
 
   return (
-    <Card className="border-gray-200">
+    <Card className="border-line">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-semibold flex items-center gap-2">
-            <Target className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+            <Target className="h-4 w-4 text-ink-3 " />
             Upcoming Commitments
           </CardTitle>
           <Link href="/client-portal/dashboard">
@@ -67,7 +66,7 @@ export function UpcomingTasksWidget({
       </CardHeader>
       <CardContent className="pt-0">
         {upcoming.length === 0 ? (
-          <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+          <p className="text-sm text-ink-3 text-center py-4">
             No active commitments
           </p>
         ) : (
@@ -82,13 +81,13 @@ export function UpcomingTasksWidget({
                 >
                   <div className="flex-shrink-0 mt-0.5">
                     {commitment.status === 'in_progress' ? (
-                      <PlayCircle className="h-4 w-4 text-blue-600" />
+                      <PlayCircle className="h-4 w-4 text-ds-accent" />
                     ) : (
-                      <Circle className="h-4 w-4 text-gray-400" />
+                      <Circle className="h-4 w-4 text-ink-4" />
                     )}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    <p className="text-sm font-medium text-ink truncate">
                       {commitment.title}
                     </p>
                     <div className="flex items-center gap-2 mt-0.5">
@@ -99,7 +98,7 @@ export function UpcomingTasksWidget({
                         {commitment.priority}
                       </Badge>
                       {commitment.type && (
-                        <span className="text-[10px] text-gray-500 dark:text-gray-400">
+                        <span className="text-[10px] text-ink-3 ">
                           {commitmentTypeLabels[commitment.type] ||
                             commitment.type}
                         </span>
@@ -108,8 +107,8 @@ export function UpcomingTasksWidget({
                         <span
                           className={`text-xs flex items-center gap-1 ${
                             isOverdue
-                              ? 'text-red-600 dark:text-red-400 font-medium'
-                              : 'text-gray-500 dark:text-gray-400'
+                              ? 'text-vermillion font-medium'
+                              : 'text-ink-3 '
                           }`}
                         >
                           {isOverdue && <AlertCircle className="h-3 w-3" />}

--- a/src/components/client/client-page-layout.tsx
+++ b/src/components/client/client-page-layout.tsx
@@ -13,7 +13,7 @@ export function ClientPageLayout({
   className = '',
 }: ClientPageLayoutProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900">
+    <div className="min-h-screen  ">
       <ClientNavigation />
       <main className={`${className}`}>{children}</main>
     </div>

--- a/src/components/client/current-sprint-widget.tsx
+++ b/src/components/client/current-sprint-widget.tsx
@@ -64,7 +64,7 @@ export function CurrentSprintWidget({
         </CardHeader>
         <CardContent>
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-line"></div>
           </div>
         </CardContent>
       </Card>
@@ -98,12 +98,12 @@ export function CurrentSprintWidget({
         </CardHeader>
         <CardContent>
           <div className="text-center py-8">
-            <Target className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-            <p className="text-gray-600 mb-4">No active sprint</p>
+            <Target className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+            <p className="text-ink-3 mb-4">No active sprint</p>
             {onCreateSprint && (
               <Button
                 onClick={onCreateSprint}
-                className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+                className="bg-ink hover:bg-ink-2 "
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Create New Sprint
@@ -121,7 +121,7 @@ export function CurrentSprintWidget({
   )
 
   return (
-    <Card className="border-gray-200 hover:shadow-md transition-shadow">
+    <Card className="border-line hover:shadow-md transition-shadow">
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2">
@@ -132,10 +132,10 @@ export function CurrentSprintWidget({
             <Badge
               className={
                 sprint.status === 'active'
-                  ? 'bg-green-100 text-green-800 border-green-200'
+                  ? 'bg-forest-bg text-forest border-forest'
                   : sprint.status === 'completed'
-                    ? 'bg-gray-100 text-gray-800 border-gray-200'
-                    : 'bg-yellow-100 text-yellow-800 border-yellow-200'
+                    ? 'bg-surface-3 text-ink-2 border-line'
+                    : 'bg-amber-token-bg text-amber-token border-amber-token'
               }
             >
               {sprint.status}
@@ -145,7 +145,7 @@ export function CurrentSprintWidget({
                 variant="outline"
                 size="sm"
                 onClick={handleFinishSprint}
-                className="border-green-600 text-green-700 hover:bg-green-50"
+                className="border-forest text-forest hover:bg-forest-bg"
               >
                 <CheckCircle className="h-4 w-4 mr-1" />
                 Finish Sprint
@@ -176,17 +176,17 @@ export function CurrentSprintWidget({
       <CardContent className="space-y-4">
         {/* Sprint Title */}
         <div>
-          <h3 className="font-semibold text-gray-900">{sprint.title}</h3>
+          <h3 className="font-semibold text-ink">{sprint.title}</h3>
           {sprint.description && (
-            <p className="text-sm text-gray-600 mt-1">{sprint.description}</p>
+            <p className="text-sm text-ink-3 mt-1">{sprint.description}</p>
           )}
         </div>
 
         {/* Progress */}
         <div>
           <div className="flex items-center justify-between text-sm mb-2">
-            <span className="text-gray-600">Overall Progress</span>
-            <span className="font-semibold text-gray-900">
+            <span className="text-ink-3">Overall Progress</span>
+            <span className="font-semibold text-ink">
               {sprint.progress_percentage || 0}%
             </span>
           </div>
@@ -194,29 +194,27 @@ export function CurrentSprintWidget({
         </div>
 
         {/* Stats Grid */}
-        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-gray-100">
+        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-line">
           <div className="text-center">
-            <div className="text-lg font-bold text-gray-900">
+            <div className="text-lg font-bold text-ink">
               {sprint.target_count || 0}
             </div>
-            <div className="text-xs text-gray-600">Desired Wins</div>
+            <div className="text-xs text-ink-3">Desired Wins</div>
           </div>
           <div className="text-center">
-            <div className="text-lg font-bold text-gray-900">
-              {daysRemaining}
-            </div>
-            <div className="text-xs text-gray-600">Days Left</div>
+            <div className="text-lg font-bold text-ink">{daysRemaining}</div>
+            <div className="text-xs text-ink-3">Days Left</div>
           </div>
           <div className="text-center">
-            <div className="text-lg font-bold text-gray-900">
+            <div className="text-lg font-bold text-ink">
               {sprint.duration_weeks || 0}w
             </div>
-            <div className="text-xs text-gray-600">Duration</div>
+            <div className="text-xs text-ink-3">Duration</div>
           </div>
         </div>
 
         {/* Dates */}
-        <div className="flex items-center justify-between text-xs text-gray-500 pt-2 border-t border-gray-100">
+        <div className="flex items-center justify-between text-xs text-ink-3 pt-2 border-t border-line">
           <div className="flex items-center gap-1">
             <Calendar className="h-3 w-3" />
             <span>{formatDate(sprint.start_date, 'MMM d')}</span>
@@ -256,8 +254,8 @@ export function CurrentSprintWidget({
 
         {/* Vision Preview */}
         {sprint.targets && sprint.targets.length > 0 && (
-          <div className="pt-3 border-t border-gray-100">
-            <p className="text-xs font-semibold text-gray-600 mb-2">
+          <div className="pt-3 border-t border-line">
+            <p className="text-xs font-semibold text-ink-3 mb-2">
               Active Desired Wins ({sprint.completed_target_count || 0}/
               {sprint.target_count || 0} completed)
             </p>
@@ -270,22 +268,18 @@ export function CurrentSprintWidget({
                   <div className="flex items-center gap-2 flex-1 min-w-0">
                     <div
                       className={`h-2 w-2 rounded-full flex-shrink-0 ${
-                        target.status === 'completed'
-                          ? 'bg-green-500'
-                          : 'bg-gray-300'
+                        target.status === 'completed' ? 'bg-forest' : 'bg-line'
                       }`}
                     />
-                    <span className="text-gray-700 truncate">
-                      {target.title}
-                    </span>
+                    <span className="text-ink-2 truncate">{target.title}</span>
                   </div>
-                  <span className="text-xs text-gray-500 ml-2">
+                  <span className="text-xs text-ink-3 ml-2">
                     {target.progress_percentage}%
                   </span>
                 </div>
               ))}
               {sprint.targets.length > 3 && (
-                <p className="text-xs text-gray-500 text-center pt-1">
+                <p className="text-xs text-ink-3 text-center pt-1">
                   +{sprint.targets.length - 3} more desired wins
                 </p>
               )}

--- a/src/components/clients/client-invitation-modal.tsx
+++ b/src/components/clients/client-invitation-modal.tsx
@@ -245,19 +245,18 @@ export function ClientInvitationModal({
         ) : (
           <div className="py-8">
             <div className="text-center">
-              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30 animate-in fade-in zoom-in duration-500">
-                <CheckCircle className="h-10 w-10 text-green-600 dark:text-green-400" />
+              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-forest-bg animate-in fade-in zoom-in duration-500">
+                <CheckCircle className="h-10 w-10 text-forest " />
               </div>
-              <h3 className="mt-4 text-xl font-semibold text-gray-900 dark:text-white">
+              <h3 className="mt-4 text-xl font-semibold text-ink ">
                 {invitationType === 'access_invitation_sent'
                   ? 'Access Invitation Sent!'
                   : 'Invitation Sent Successfully!'}
               </h3>
               <div className="mt-4 space-y-2">
-                <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                <p className="text-sm font-medium text-ink-2 ">
                   <Mail className="inline-block h-4 w-4 mr-1" />
-                  Sent to:{' '}
-                  <span className="text-gray-900 dark:text-white">{email}</span>
+                  Sent to: <span className="text-ink ">{email}</span>
                 </p>
                 <p className="text-sm text-muted-foreground">
                   {responseMessage ||
@@ -265,12 +264,12 @@ export function ClientInvitationModal({
                 </p>
               </div>
 
-              <div className="mt-6 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-4 text-left">
-                <h4 className="text-sm font-medium text-blue-900 dark:text-blue-300 mb-2">
+              <div className="mt-6 rounded-lg bg-ds-accent-bg p-4 text-left">
+                <h4 className="text-sm font-medium text-ds-accent mb-2">
                   What happens next:
                 </h4>
                 {invitationType === 'access_invitation_sent' ? (
-                  <ul className="space-y-1.5 text-xs text-blue-700 dark:text-blue-300">
+                  <ul className="space-y-1.5 text-xs text-ds-accent ">
                     <li className="flex items-start">
                       <span className="mr-2">•</span>
                       <span>
@@ -296,7 +295,7 @@ export function ClientInvitationModal({
                     </li>
                   </ul>
                 ) : (
-                  <ul className="space-y-1.5 text-xs text-blue-700 dark:text-blue-300">
+                  <ul className="space-y-1.5 text-xs text-ds-accent ">
                     <li className="flex items-start">
                       <span className="mr-2">•</span>
                       <span>

--- a/src/components/clients/client-modal.tsx
+++ b/src/components/clients/client-modal.tsx
@@ -168,7 +168,7 @@ export default function ClientModal({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[400px] p-0 gap-0 overflow-hidden">
         <DialogHeader className="px-6 pt-6 pb-4">
-          <DialogTitle className="text-lg font-semibold text-gray-900 dark:text-white">
+          <DialogTitle className="text-lg font-semibold text-ink ">
             {mode === 'create' ? 'New Client' : 'Edit Client'}
           </DialogTitle>
         </DialogHeader>
@@ -179,7 +179,7 @@ export default function ClientModal({
             <div>
               <label
                 htmlFor="name"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5"
+                className="block text-sm font-medium text-ink-2 mb-1.5"
               >
                 Name
               </label>
@@ -189,15 +189,15 @@ export default function ClientModal({
                 onChange={e => handleFieldChange('name', e.target.value)}
                 className={`h-10 ${
                   errors.name
-                    ? 'border-red-300 focus:border-red-500 focus:ring-red-200'
-                    : 'border-gray-200 dark:border-gray-600 focus:border-gray-400 dark:focus:border-gray-500'
+                    ? 'border-vermillion focus:border-vermillion focus:ring-vermillion'
+                    : 'border-line focus:border-line-strong '
                 }`}
                 placeholder="Client's full name"
                 disabled={isLoading}
                 autoFocus
               />
               {errors.name && (
-                <p className="text-xs text-red-600 mt-1">{errors.name}</p>
+                <p className="text-xs text-vermillion mt-1">{errors.name}</p>
               )}
             </div>
 
@@ -205,7 +205,7 @@ export default function ClientModal({
             <div>
               <label
                 htmlFor="email"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5"
+                className="block text-sm font-medium text-ink-2 mb-1.5"
               >
                 Email
               </label>
@@ -216,23 +216,23 @@ export default function ClientModal({
                 onChange={e => handleFieldChange('email', e.target.value)}
                 className={`h-10 ${
                   errors.email
-                    ? 'border-red-300 focus:border-red-500 focus:ring-red-200'
-                    : 'border-gray-200 dark:border-gray-600 focus:border-gray-400 dark:focus:border-gray-500'
+                    ? 'border-vermillion focus:border-vermillion focus:ring-vermillion'
+                    : 'border-line focus:border-line-strong '
                 }`}
                 placeholder="client@example.com"
                 disabled={isLoading}
               />
               {errors.email && (
-                <p className="text-xs text-red-600 mt-1">{errors.email}</p>
+                <p className="text-xs text-vermillion mt-1">{errors.email}</p>
               )}
             </div>
 
             {/* Invite Toggle - Only show in create mode when email is entered */}
             {mode === 'create' && formData.email.trim() && (
-              <div className="flex items-center justify-between py-3 px-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <div className="flex items-center justify-between py-3 px-4 bg-paper rounded-lg">
                 <div className="flex items-center gap-2">
-                  <Send className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                  <Send className="h-4 w-4 text-ink-3 " />
+                  <span className="text-sm text-ink-2 ">
                     Send portal invitation
                   </span>
                 </div>
@@ -251,21 +251,19 @@ export default function ClientModal({
 
             {/* Error message */}
             {errors.submit && (
-              <div className="rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 p-3">
-                <p className="text-sm text-red-700 dark:text-red-400">
-                  {errors.submit}
-                </p>
+              <div className="rounded-lg bg-vermillion-bg border border-vermillion p-3">
+                <p className="text-sm text-vermillion ">{errors.submit}</p>
               </div>
             )}
           </div>
 
           {/* Footer */}
-          <div className="flex gap-3 px-6 py-4 mt-4 border-t border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+          <div className="flex gap-3 px-6 py-4 mt-4 border-t border-line bg-paper/50 ">
             <Button
               type="button"
               variant="outline"
               onClick={onClose}
-              className="flex-1 h-10 border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+              className="flex-1 h-10 border-line hover:bg-surface-3 text-ink-2 "
               disabled={isLoading}
             >
               Cancel
@@ -273,7 +271,7 @@ export default function ClientModal({
             <Button
               type="submit"
               disabled={isLoading || !formData.name.trim()}
-              className="flex-1 h-10 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+              className="flex-1 h-10 bg-ink hover:bg-ink-2 text-ink-on-dark "
             >
               {isLoading ? (
                 <>

--- a/src/components/clients/client-selector.tsx
+++ b/src/components/clients/client-selector.tsx
@@ -78,21 +78,21 @@ export default function ClientSelector({
       <div className="relative">
         {selectedClient ? (
           <div
-            className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-md bg-white dark:bg-gray-900 cursor-pointer hover:border-neutral-400 dark:hover:border-neutral-500 flex items-center justify-between"
+            className="w-full px-3 py-2 border border-line rounded-md bg-surface-1 cursor-pointer hover:border-line-strong flex items-center justify-between"
             onClick={() => setIsOpen(!isOpen)}
           >
             <div className="flex items-center gap-3">
-              <Avatar className="h-8 w-8 bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700">
-                <AvatarFallback className="bg-white dark:bg-gray-900 text-neutral-700 dark:text-neutral-300 text-sm">
+              <Avatar className="h-8 w-8 bg-surface-3 border border-line ">
+                <AvatarFallback className="bg-surface-1 text-ink-2 text-sm">
                   {getClientInitials(selectedClient.name)}
                 </AvatarFallback>
               </Avatar>
               <div>
-                <span className="font-medium text-neutral-900 dark:text-white">
+                <span className="font-medium text-ink ">
                   {selectedClient.name}
                 </span>
                 {selectedClient.notes && (
-                  <span className="text-sm text-neutral-500 dark:text-neutral-400 ml-2 truncate max-w-[200px] inline-block align-middle">
+                  <span className="text-sm text-ink-3 ml-2 truncate max-w-[200px] inline-block align-middle">
                     {selectedClient.notes}
                   </span>
                 )}
@@ -106,7 +106,7 @@ export default function ClientSelector({
                   e.stopPropagation()
                   handleClientSelect(null)
                 }}
-                className="h-6 w-6 p-0 hover:bg-neutral-50 dark:hover:bg-neutral-800 text-neutral-500 dark:text-neutral-400"
+                className="h-6 w-6 p-0 hover:bg-paper text-ink-3 "
               >
                 ×
               </Button>
@@ -118,13 +118,13 @@ export default function ClientSelector({
             value={searchTerm}
             onChange={handleSearchChange}
             onFocus={() => setIsOpen(true)}
-            className="cursor-pointer border-neutral-200 dark:border-neutral-700 focus:border-neutral-400 dark:focus:border-neutral-500 focus:ring-0"
+            className="cursor-pointer border-line focus:border-line-strong focus:ring-0"
           />
         )}
       </div>
 
       {isOpen && (
-        <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-gray-900 border border-neutral-200 dark:border-neutral-700 rounded-md shadow-lg z-50 max-h-64 overflow-y-auto">
+        <div className="absolute top-full left-0 right-0 mt-1 bg-surface-1 border border-line rounded-md shadow-lg z-50 max-h-64 overflow-y-auto">
           {!selectedClient && (
             <div className="p-2">
               <Input
@@ -132,7 +132,7 @@ export default function ClientSelector({
                 value={searchTerm}
                 onChange={handleSearchChange}
                 autoFocus
-                className="w-full border-neutral-200 dark:border-neutral-700 focus:border-neutral-400 dark:focus:border-neutral-500 focus:ring-0"
+                className="w-full border-line focus:border-line-strong focus:ring-0"
               />
             </div>
           )}
@@ -140,61 +140,57 @@ export default function ClientSelector({
           {/* Add Client Option */}
           {onAddClient && (
             <div
-              className="px-3 py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-800 cursor-pointer flex items-center gap-2 border-b border-neutral-100 dark:border-neutral-700"
+              className="px-3 py-2.5 hover:bg-paper cursor-pointer flex items-center gap-2 border-b border-line "
               onClick={() => {
                 setIsOpen(false)
                 onAddClient()
               }}
             >
-              <div className="w-8 h-8 rounded-full bg-gray-900 dark:bg-white flex items-center justify-center">
-                <Plus className="h-4 w-4 text-white dark:text-gray-900" />
+              <div className="w-8 h-8 rounded-full bg-ink flex items-center justify-center">
+                <Plus className="h-4 w-4 text-ink-on-dark " />
               </div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Add new client
-              </span>
+              <span className="font-medium text-ink ">Add new client</span>
             </div>
           )}
 
           <div className="py-1">
             {allowNone && !selectedClient && (
               <div
-                className="px-3 py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800 cursor-pointer border-b border-neutral-100 dark:border-neutral-700"
+                className="px-3 py-2 hover:bg-paper cursor-pointer border-b border-line "
                 onClick={() => handleClientSelect(null)}
               >
-                <span className="text-neutral-500 dark:text-neutral-400 italic">
-                  No client selected
-                </span>
+                <span className="text-ink-3 italic">No client selected</span>
               </div>
             )}
 
             {loading && clients.length === 0 ? (
-              <div className="px-3 py-4 text-center text-neutral-500 dark:text-neutral-400">
+              <div className="px-3 py-4 text-center text-ink-3 ">
                 Loading clients...
               </div>
             ) : filteredClients.length === 0 ? (
-              <div className="px-3 py-4 text-center text-neutral-500 dark:text-neutral-400">
+              <div className="px-3 py-4 text-center text-ink-3 ">
                 {searchTerm ? 'No clients found' : 'No clients available'}
               </div>
             ) : (
               filteredClients.map(client => (
                 <div
                   key={client.id}
-                  className="px-3 py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800 cursor-pointer flex items-center gap-3"
+                  className="px-3 py-2 hover:bg-paper cursor-pointer flex items-center gap-3"
                   onClick={() => handleClientSelect(client as Client)}
                 >
-                  <Avatar className="h-8 w-8 bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700">
-                    <AvatarFallback className="bg-white dark:bg-gray-900 text-neutral-700 dark:text-neutral-300 text-sm">
+                  <Avatar className="h-8 w-8 bg-surface-3 border border-line ">
+                    <AvatarFallback className="bg-surface-1 text-ink-2 text-sm">
                       {getClientInitials(client.name)}
                     </AvatarFallback>
                   </Avatar>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium text-neutral-900 dark:text-white truncate">
+                      <span className="font-medium text-ink truncate">
                         {client.name}
                       </span>
                     </div>
                     {client.email && (
-                      <div className="text-sm text-neutral-500 dark:text-neutral-400 truncate">
+                      <div className="text-sm text-ink-3 truncate">
                         {client.email}
                       </div>
                     )}

--- a/src/components/commitments/commitment-card.tsx
+++ b/src/components/commitments/commitment-card.tsx
@@ -50,23 +50,23 @@ const statusConfig: Record<
 > = {
   draft: {
     label: 'Draft',
-    className: 'bg-gray-500/10 text-gray-500 border-gray-500/20',
+    className: 'bg-ink-4/10 text-ink-3 border-line-strong/20',
   },
   active: {
     label: 'Active',
-    className: 'bg-blue-500/10 text-blue-500 border-blue-500/20',
+    className: 'bg-ds-accent/10 text-ds-accent border-ds-accent/20',
   },
   in_progress: {
     label: 'In Progress',
-    className: 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20',
+    className: 'bg-amber-token/10 text-amber-token border-amber-token/20',
   },
   completed: {
     label: 'Completed',
-    className: 'bg-green-500/10 text-green-500 border-green-500/20',
+    className: 'bg-forest/10 text-forest border-forest/20',
   },
   abandoned: {
     label: 'Abandoned',
-    className: 'bg-red-500/10 text-red-500 border-red-500/20',
+    className: 'bg-vermillion/10 text-vermillion border-vermillion/20',
   },
 }
 
@@ -76,19 +76,19 @@ const priorityConfig: Record<
 > = {
   low: {
     label: 'Low',
-    className: 'bg-gray-500/10 text-gray-600 border-gray-500/20',
+    className: 'bg-ink-4/10 text-ink-3 border-line-strong/20',
   },
   medium: {
     label: 'Medium',
-    className: 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20',
+    className: 'bg-amber-token/10 text-amber-token border-amber-token/20',
   },
   high: {
     label: 'High',
-    className: 'bg-orange-500/10 text-orange-600 border-orange-500/20',
+    className: 'bg-amber-token/10 text-amber-token border-amber-token/20',
   },
   urgent: {
     label: 'Urgent',
-    className: 'bg-red-500/10 text-red-600 border-red-500/20',
+    className: 'bg-vermillion/10 text-vermillion border-vermillion/20',
   },
 }
 
@@ -121,13 +121,13 @@ export function CommitmentCard({
     if (isOverdue) {
       return {
         text: `Overdue by ${Math.abs(daysUntil)} days`,
-        className: 'text-red-600',
+        className: 'text-vermillion',
         icon: AlertCircle,
       }
     } else if (daysUntil <= 7) {
       return {
         text: `Due in ${daysUntil} days`,
-        className: 'text-orange-600',
+        className: 'text-amber-token',
         icon: Clock,
       }
     } else {
@@ -186,10 +186,7 @@ export function CommitmentCard({
               </Badge>
               <Badge variant="outline">{typeLabels[commitment.type]}</Badge>
               {commitment.extracted_from_transcript && (
-                <Badge
-                  variant="outline"
-                  className="bg-gray-500/10 text-gray-600"
-                >
+                <Badge variant="outline" className="bg-ink-4/10 text-ink-3">
                   AI Extracted
                 </Badge>
               )}

--- a/src/components/commitments/commitment-create-panel.tsx
+++ b/src/components/commitments/commitment-create-panel.tsx
@@ -125,7 +125,7 @@ export function CommitmentCreatePanel({
       {/* Backdrop overlay */}
       {isOpen && (
         <div
-          className="fixed inset-0 z-[60] bg-black/50 animate-in fade-in duration-200"
+          className="fixed inset-0 z-[60] bg-overlay animate-in fade-in duration-200"
           onClick={onClose}
         />
       )}
@@ -134,7 +134,7 @@ export function CommitmentCreatePanel({
       <div
         ref={panelRef}
         className={cn(
-          'fixed right-0 top-0 h-full w-full md:w-[640px] z-[70] bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 shadow-2xl',
+          'fixed right-0 top-0 h-full w-full md:w-[640px] z-[70] bg-surface-1 border-l border-line shadow-2xl',
           'transition-transform duration-300 ease-in-out',
           isOpen ? 'translate-x-0' : 'translate-x-full',
         )}
@@ -150,7 +150,7 @@ export function CommitmentCreatePanel({
                     value={title}
                     onChange={e => setTitle(e.target.value)}
                     placeholder="Commitment title..."
-                    className="text-xl font-bold border-none shadow-none focus-visible:ring-0 px-2 py-1 -mx-2 h-auto placeholder:text-gray-400 placeholder:font-bold"
+                    className="text-xl font-bold border-none shadow-none focus-visible:ring-0 px-2 py-1 -mx-2 h-auto placeholder:text-ink-4 placeholder:font-bold"
                     maxLength={200}
                   />
                 </div>
@@ -199,10 +199,10 @@ export function CommitmentCreatePanel({
               )}
 
               {/* Fields Grid — mirrors FieldsGrid from detail panel */}
-              <div className="grid grid-cols-2 gap-4 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+              <div className="grid grid-cols-2 gap-4 p-4 bg-paper rounded-lg">
                 {/* Priority */}
                 <div className="space-y-1">
-                  <label className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                  <label className="text-xs font-medium text-ink-3 ">
                     Priority
                   </label>
                   <Select
@@ -218,10 +218,7 @@ export function CommitmentCreatePanel({
                       <SelectItem value="low">
                         <div className="flex items-center gap-2">
                           <div
-                            className={cn(
-                              'w-2 h-2 rounded-full',
-                              'bg-gray-400',
-                            )}
+                            className={cn('w-2 h-2 rounded-full', 'bg-line')}
                           />
                           Low
                         </div>
@@ -231,7 +228,7 @@ export function CommitmentCreatePanel({
                           <div
                             className={cn(
                               'w-2 h-2 rounded-full',
-                              'bg-yellow-400',
+                              'bg-amber-token',
                             )}
                           />
                           Medium
@@ -242,7 +239,7 @@ export function CommitmentCreatePanel({
                           <div
                             className={cn(
                               'w-2 h-2 rounded-full',
-                              'bg-orange-400',
+                              'bg-amber-token',
                             )}
                           />
                           High
@@ -251,7 +248,10 @@ export function CommitmentCreatePanel({
                       <SelectItem value="urgent">
                         <div className="flex items-center gap-2">
                           <div
-                            className={cn('w-2 h-2 rounded-full', 'bg-red-500')}
+                            className={cn(
+                              'w-2 h-2 rounded-full',
+                              'bg-vermillion',
+                            )}
                           />
                           Urgent
                         </div>
@@ -262,7 +262,7 @@ export function CommitmentCreatePanel({
 
                 {/* Due Date */}
                 <div className="space-y-1">
-                  <label className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                  <label className="text-xs font-medium text-ink-3 ">
                     Due Date
                   </label>
                   <Popover open={dueDateOpen} onOpenChange={setDueDateOpen}>
@@ -271,7 +271,7 @@ export function CommitmentCreatePanel({
                         variant="outline"
                         className={cn(
                           'h-9 w-full justify-start text-left text-sm font-normal',
-                          !targetDate && 'text-gray-500',
+                          !targetDate && 'text-ink-3',
                         )}
                       >
                         <CalendarIcon className="h-3.5 w-3.5 mr-2" />
@@ -299,8 +299,8 @@ export function CommitmentCreatePanel({
               {/* Outcomes — tag UI matching LinkedOutcomesSection */}
               {clientTargets.length > 0 && (
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
-                    <Zap className="h-3.5 w-3.5 text-blue-500" />
+                  <label className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
+                    <Zap className="h-3.5 w-3.5 text-ds-accent" />
                     Meta Performance Outcomes
                   </label>
                   <div className="flex flex-wrap gap-1.5">
@@ -322,8 +322,8 @@ export function CommitmentCreatePanel({
                           className={cn(
                             'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border',
                             isSelected
-                              ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
-                              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700 hover:text-blue-600 dark:hover:text-blue-400',
+                              ? 'bg-ds-accent-bg text-ds-accent border-ds-accent '
+                              : 'bg-surface-1 text-ink-3 border-line hover:border-ds-accent hover:text-ds-accent ',
                           )}
                         >
                           {isSelected && (
@@ -352,8 +352,8 @@ export function CommitmentCreatePanel({
               {/* Sprints — tag UI matching LinkedOutcomesSection */}
               {allSprints.length > 0 && (
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
-                    <CalendarIcon className="h-3.5 w-3.5 text-green-500" />
+                  <label className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
+                    <CalendarIcon className="h-3.5 w-3.5 text-forest" />
                     Sprints
                   </label>
                   <div className="flex flex-wrap gap-1.5">
@@ -375,8 +375,8 @@ export function CommitmentCreatePanel({
                           className={cn(
                             'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border',
                             isLinked
-                              ? 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700'
-                              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:border-green-300 dark:hover:border-green-700 hover:text-green-600 dark:hover:text-green-400',
+                              ? 'bg-forest-bg text-forest border-forest '
+                              : 'bg-surface-1 text-ink-3 border-line hover:border-forest hover:text-forest ',
                           )}
                         >
                           {isLinked && (
@@ -395,7 +395,7 @@ export function CommitmentCreatePanel({
                             </svg>
                           )}
                           {sprint.status === 'active' && (
-                            <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                            <span className="w-1.5 h-1.5 rounded-full bg-forest" />
                           )}
                           {sprint.title}
                         </button>
@@ -407,7 +407,7 @@ export function CommitmentCreatePanel({
 
               {/* Description — mirrors DescriptionSection with RichTextEditor */}
               <div className="space-y-2">
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                <label className="text-sm font-medium text-ink-2 ">
                   Description
                 </label>
                 <RichTextEditor
@@ -421,7 +421,7 @@ export function CommitmentCreatePanel({
           </ScrollArea>
 
           {/* Sticky Footer */}
-          <div className="border-t border-gray-200 dark:border-gray-700 p-4 flex justify-end gap-3">
+          <div className="border-t border-line p-4 flex justify-end gap-3">
             <Button variant="outline" onClick={onClose}>
               Cancel
             </Button>

--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -244,7 +244,7 @@ export function CommitmentDetailPanel({
       {/* Backdrop overlay */}
       {isOpen && (
         <div
-          className="fixed inset-0 z-[60] bg-black/50 animate-in fade-in duration-200"
+          className="fixed inset-0 z-[60] bg-overlay animate-in fade-in duration-200"
           onClick={onClose}
         />
       )}
@@ -253,7 +253,7 @@ export function CommitmentDetailPanel({
       <div
         ref={panelRef}
         className={cn(
-          'fixed right-0 top-0 h-full w-full md:w-[640px] z-[70] bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 shadow-2xl',
+          'fixed right-0 top-0 h-full w-full md:w-[640px] z-[70] bg-surface-1 border-l border-line shadow-2xl',
           'transition-transform duration-300 ease-in-out',
           isOpen ? 'translate-x-0' : 'translate-x-full',
         )}
@@ -322,7 +322,7 @@ export function CommitmentDetailPanel({
               </div>
             </ScrollArea>
           ) : (
-            <div className="flex items-center justify-center h-full text-gray-500">
+            <div className="flex items-center justify-center h-full text-ink-3">
               Commitment not found
             </div>
           )}
@@ -343,7 +343,7 @@ export function CommitmentDetailPanel({
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               Delete
             </AlertDialogAction>
@@ -410,7 +410,7 @@ function PanelHeader({
           />
         ) : (
           <h2
-            className="text-xl font-bold text-gray-900 dark:text-white cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 rounded px-2 py-1 -mx-2 truncate"
+            className="text-xl font-bold text-ink cursor-pointer hover:bg-surface-3 rounded px-2 py-1 -mx-2 truncate"
             onClick={() => setIsEditingTitle(true)}
           >
             {commitment.title}
@@ -427,7 +427,7 @@ function PanelHeader({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={onDelete} className="text-red-600">
+            <DropdownMenuItem onClick={onDelete} className="text-vermillion">
               <Trash2 className="h-4 w-4 mr-2" />
               Delete
             </DropdownMenuItem>
@@ -458,11 +458,10 @@ function FieldsGrid({
   const [calendarOpen, setCalendarOpen] = useState(false)
 
   const _priorityColors: Record<string, string> = {
-    urgent: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-    high: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-    medium:
-      'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-    low: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    urgent: 'bg-vermillion-bg text-vermillion ',
+    high: 'bg-amber-token-bg text-amber-token ',
+    medium: 'bg-amber-token-bg text-amber-token ',
+    low: 'bg-surface-3 text-ink-2 ',
   }
 
   const statusOptions: {
@@ -474,37 +473,32 @@ function FieldsGrid({
     {
       value: 'active',
       label: 'Active',
-      selected:
-        'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/50 dark:text-blue-300 dark:border-blue-800',
+      selected: 'bg-ds-accent-bg text-ds-accent border-ds-accent ',
       unselected:
-        'bg-transparent text-gray-500 border-gray-200 hover:bg-blue-50 hover:text-blue-700 hover:border-blue-200 dark:text-gray-400 dark:border-gray-700 dark:hover:bg-blue-900/30 dark:hover:text-blue-300',
+        'bg-transparent text-ink-3 border-line hover:bg-ds-accent-bg hover:text-ds-accent hover:border-ds-accent ',
     },
     {
       value: 'completed',
       label: 'Completed',
-      selected:
-        'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/50 dark:text-green-300 dark:border-green-800',
+      selected: 'bg-forest-bg text-forest border-forest ',
       unselected:
-        'bg-transparent text-gray-500 border-gray-200 hover:bg-green-50 hover:text-green-700 hover:border-green-200 dark:text-gray-400 dark:border-gray-700 dark:hover:bg-green-900/30 dark:hover:text-green-300',
+        'bg-transparent text-ink-3 border-line hover:bg-forest-bg hover:text-forest hover:border-forest ',
     },
     {
       value: 'abandoned',
       label: 'Abandoned',
-      selected:
-        'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/50 dark:text-red-300 dark:border-red-800',
+      selected: 'bg-vermillion-bg text-vermillion border-vermillion ',
       unselected:
-        'bg-transparent text-gray-500 border-gray-200 hover:bg-red-50 hover:text-red-700 hover:border-red-200 dark:text-gray-400 dark:border-gray-700 dark:hover:bg-red-900/30 dark:hover:text-red-300',
+        'bg-transparent text-ink-3 border-line hover:bg-vermillion-bg hover:text-vermillion hover:border-vermillion ',
     },
   ]
 
   return (
-    <div className="p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg space-y-4">
+    <div className="p-4 bg-paper rounded-lg space-y-4">
       <div className="grid grid-cols-2 gap-4">
         {/* Priority */}
         <div className="space-y-1">
-          <label className="text-xs font-medium text-gray-500 dark:text-gray-400">
-            Priority
-          </label>
+          <label className="text-xs font-medium text-ink-3 ">Priority</label>
           <Select
             value={commitment.priority}
             onValueChange={value => onFieldUpdate('priority', value)}
@@ -515,14 +509,14 @@ function FieldsGrid({
             <SelectContent>
               <SelectItem value="low">
                 <div className="flex items-center gap-2">
-                  <div className={cn('w-2 h-2 rounded-full', 'bg-gray-400')} />
+                  <div className={cn('w-2 h-2 rounded-full', 'bg-line')} />
                   Low
                 </div>
               </SelectItem>
               <SelectItem value="medium">
                 <div className="flex items-center gap-2">
                   <div
-                    className={cn('w-2 h-2 rounded-full', 'bg-yellow-400')}
+                    className={cn('w-2 h-2 rounded-full', 'bg-amber-token')}
                   />
                   Medium
                 </div>
@@ -530,14 +524,16 @@ function FieldsGrid({
               <SelectItem value="high">
                 <div className="flex items-center gap-2">
                   <div
-                    className={cn('w-2 h-2 rounded-full', 'bg-orange-400')}
+                    className={cn('w-2 h-2 rounded-full', 'bg-amber-token')}
                   />
                   High
                 </div>
               </SelectItem>
               <SelectItem value="urgent">
                 <div className="flex items-center gap-2">
-                  <div className={cn('w-2 h-2 rounded-full', 'bg-red-500')} />
+                  <div
+                    className={cn('w-2 h-2 rounded-full', 'bg-vermillion')}
+                  />
                   Urgent
                 </div>
               </SelectItem>
@@ -547,16 +543,14 @@ function FieldsGrid({
 
         {/* Due Date */}
         <div className="space-y-1">
-          <label className="text-xs font-medium text-gray-500 dark:text-gray-400">
-            Due Date
-          </label>
+          <label className="text-xs font-medium text-ink-3 ">Due Date</label>
           <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
                 className={cn(
                   'h-9 w-full justify-start text-left text-sm font-normal',
-                  !commitment.target_date && 'text-gray-500',
+                  !commitment.target_date && 'text-ink-3',
                 )}
               >
                 <CalendarIcon className="h-3.5 w-3.5 mr-2" />
@@ -588,9 +582,7 @@ function FieldsGrid({
 
       {/* Status */}
       <div className="space-y-1">
-        <label className="text-xs font-medium text-gray-500 dark:text-gray-400">
-          Status
-        </label>
+        <label className="text-xs font-medium text-ink-3 ">Status</label>
         <div className="flex flex-wrap gap-1.5">
           {statusOptions.map(opt => {
             const isSelected = commitment.status === opt.value
@@ -768,8 +760,8 @@ function LinkedOutcomesSection({
       {/* Outcomes as tags */}
       {allTargets.length > 0 && (
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
-            <Zap className="h-3.5 w-3.5 text-blue-500" />
+          <label className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
+            <Zap className="h-3.5 w-3.5 text-ds-accent" />
             Meta Performance Outcomes
           </label>
           <div className="flex flex-wrap gap-1.5">
@@ -782,8 +774,8 @@ function LinkedOutcomesSection({
                   className={cn(
                     'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border',
                     isLinked
-                      ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
-                      : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700 hover:text-blue-600 dark:hover:text-blue-400',
+                      ? 'bg-ds-accent-bg text-ds-accent border-ds-accent '
+                      : 'bg-surface-1 text-ink-3 border-line hover:border-ds-accent hover:text-ds-accent ',
                   )}
                 >
                   {isLinked && (
@@ -812,8 +804,8 @@ function LinkedOutcomesSection({
       {/* Sprints as tags */}
       {allSprints.length > 0 && (
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
-            <CalendarIcon className="h-3.5 w-3.5 text-green-500" />
+          <label className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
+            <CalendarIcon className="h-3.5 w-3.5 text-forest" />
             Sprints
           </label>
           <div className="flex flex-wrap gap-1.5">
@@ -826,8 +818,8 @@ function LinkedOutcomesSection({
                   className={cn(
                     'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border',
                     isLinked
-                      ? 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700'
-                      : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:border-green-300 dark:hover:border-green-700 hover:text-green-600 dark:hover:text-green-400',
+                      ? 'bg-forest-bg text-forest border-forest '
+                      : 'bg-surface-1 text-ink-3 border-line hover:border-forest hover:text-forest ',
                   )}
                 >
                   {isLinked && (
@@ -846,7 +838,7 @@ function LinkedOutcomesSection({
                     </svg>
                   )}
                   {sprint.status === 'active' && (
-                    <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                    <span className="w-1.5 h-1.5 rounded-full bg-forest" />
                   )}
                   {sprint.title}
                 </button>
@@ -887,9 +879,7 @@ function DescriptionSection({
 
   return (
     <div className="space-y-2">
-      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-        Description
-      </label>
+      <label className="text-sm font-medium text-ink-2 ">Description</label>
       {isEditing ? (
         <div className="space-y-2">
           <RichTextEditor
@@ -909,18 +899,16 @@ function DescriptionSection({
         </div>
       ) : (
         <div
-          className="min-h-[40px] p-3 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          className="min-h-[40px] p-3 rounded-lg border border-line cursor-pointer hover:bg-paper transition-colors"
           onClick={() => setIsEditing(true)}
         >
           {commitment.description ? (
             <div
-              className="prose prose-sm dark:prose-invert max-w-none text-gray-700 dark:text-gray-300"
+              className="prose prose-sm dark:prose-invert max-w-none text-ink-2 "
               dangerouslySetInnerHTML={{ __html: commitment.description }}
             />
           ) : (
-            <p className="text-sm text-gray-400 dark:text-gray-500 italic">
-              Add a description...
-            </p>
+            <p className="text-sm text-ink-4 italic">Add a description...</p>
           )}
         </div>
       )}
@@ -1030,13 +1018,11 @@ function AttachmentsSection({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+        <label className="text-sm font-medium text-ink-2 flex items-center gap-1.5">
           <Paperclip className="h-3.5 w-3.5" />
           Attachments
           {attachments.length > 0 && (
-            <span className="text-xs text-gray-400">
-              ({attachments.length})
-            </span>
+            <span className="text-xs text-ink-4">({attachments.length})</span>
           )}
         </label>
         <Button
@@ -1069,29 +1055,25 @@ function AttachmentsSection({
         onDragLeave={handleDragLeave}
         className={cn(
           'border-2 border-dashed rounded-lg p-3 transition-colors text-center',
-          isDragging
-            ? 'border-blue-400 bg-blue-50 dark:bg-blue-900/20'
-            : 'border-gray-200 dark:border-gray-700',
+          isDragging ? 'border-ds-accent bg-ds-accent-bg ' : 'border-line ',
           attachments.length === 0 && !uploadProgress ? 'py-6' : 'py-2',
         )}
       >
         {uploadProgress !== null ? (
           <div className="space-y-2 px-2">
-            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex items-center gap-2 text-sm text-ink-3 ">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Uploading... {uploadProgress}%
             </div>
             <Progress value={uploadProgress} className="h-1.5" />
           </div>
         ) : attachments.length === 0 ? (
-          <div className="text-sm text-gray-400 dark:text-gray-500">
+          <div className="text-sm text-ink-4 ">
             <p>Drop files here or click &ldquo;Attach file&rdquo;</p>
             <p className="text-xs mt-1">Max 25MB per file</p>
           </div>
         ) : (
-          <p className="text-xs text-gray-400 dark:text-gray-500">
-            Drop files to attach
-          </p>
+          <p className="text-xs text-ink-4 ">Drop files to attach</p>
         )}
       </div>
 
@@ -1105,15 +1087,15 @@ function AttachmentsSection({
             return (
               <div
                 key={attachment.id}
-                className="flex items-center gap-2 group py-1.5 px-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 group py-1.5 px-2 rounded hover:bg-paper "
               >
                 {isUploading ? (
-                  <Loader2 className="h-4 w-4 text-gray-400 animate-spin flex-shrink-0" />
+                  <Loader2 className="h-4 w-4 text-ink-4 animate-spin flex-shrink-0" />
                 ) : (
-                  <Icon className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                  <Icon className="h-4 w-4 text-ink-4 flex-shrink-0" />
                 )}
                 <button
-                  className="text-sm text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 truncate flex-1 text-left"
+                  className="text-sm text-ink-2 hover:text-ds-accent truncate flex-1 text-left"
                   onClick={() =>
                     !isUploading && handleOpenAttachment(attachment)
                   }
@@ -1121,7 +1103,7 @@ function AttachmentsSection({
                 >
                   {attachment.filename}
                 </button>
-                <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
+                <span className="text-xs text-ink-4 flex-shrink-0">
                   {formatFileSize(attachment.file_size)}
                 </span>
                 {!isUploading && (
@@ -1162,7 +1144,7 @@ function AttachmentsSection({
                   setDeleteConfirmId(null)
                 }
               }}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-vermillion hover:bg-vermillion"
             >
               Delete
             </AlertDialogAction>
@@ -1214,11 +1196,9 @@ function MilestonesSection({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-          Subtasks
-        </label>
+        <label className="text-sm font-medium text-ink-2 ">Subtasks</label>
         {milestones.length > 0 && (
-          <span className="text-xs text-gray-500 dark:text-gray-400">
+          <span className="text-xs text-ink-3 ">
             {completedCount}/{milestones.length}
           </span>
         )}
@@ -1244,7 +1224,7 @@ function MilestonesSection({
 
       {/* Add milestone input */}
       <div className="flex items-center gap-2">
-        <Plus className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        <Plus className="h-4 w-4 text-ink-4 flex-shrink-0" />
         <Input
           value={newMilestoneTitle}
           onChange={e => setNewMilestoneTitle(e.target.value)}
@@ -1295,7 +1275,7 @@ function MilestoneItem({
   const isCompleted = milestone.status === 'completed'
 
   return (
-    <div className="flex items-center gap-2 group py-1 px-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800">
+    <div className="flex items-center gap-2 group py-1 px-2 rounded hover:bg-paper ">
       <Checkbox
         checked={isCompleted}
         onCheckedChange={onToggle}
@@ -1320,7 +1300,7 @@ function MilestoneItem({
         <span
           className={cn(
             'text-sm flex-1 cursor-pointer',
-            isCompleted && 'line-through text-gray-400 dark:text-gray-500',
+            isCompleted && 'line-through text-ink-4 ',
           )}
           onClick={() => setIsEditing(true)}
         >
@@ -1328,7 +1308,7 @@ function MilestoneItem({
         </span>
       )}
       {milestone.target_date && (
-        <span className="text-xs text-gray-400 dark:text-gray-500">
+        <span className="text-xs text-ink-4 ">
           {formatDate(milestone.target_date, 'MMM d')}
         </span>
       )}
@@ -1401,9 +1381,7 @@ function ActivitySection({
 
   return (
     <div className="space-y-3">
-      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-        Comments
-      </label>
+      <label className="text-sm font-medium text-ink-2 ">Comments</label>
 
       {/* Always-visible comment input */}
       <div className="space-y-2">
@@ -1421,7 +1399,7 @@ function ActivitySection({
         <div className="flex items-center justify-between">
           <button
             type="button"
-            className="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 flex items-center gap-1"
+            className="text-xs text-ink-3 hover:text-ink-2 flex items-center gap-1"
             onClick={() => setShowExtras(!showExtras)}
           >
             {showExtras ? (
@@ -1432,7 +1410,7 @@ function ActivitySection({
             Wins & Blockers
           </button>
           <div className="flex items-center gap-2">
-            <span className="text-[10px] text-gray-400 dark:text-gray-500">
+            <span className="text-[10px] text-ink-4 ">
               {navigator.platform?.includes('Mac') ? '⌘' : 'Ctrl'}+Enter
             </span>
             <Button
@@ -1449,7 +1427,7 @@ function ActivitySection({
         {showExtras && (
           <div className="space-y-2">
             <div>
-              <label className="text-xs text-green-600 font-medium">Wins</label>
+              <label className="text-xs text-forest font-medium">Wins</label>
               <Textarea
                 value={wins}
                 onChange={e => setWins(e.target.value)}
@@ -1459,7 +1437,7 @@ function ActivitySection({
               />
             </div>
             <div>
-              <label className="text-xs text-red-600 font-medium">
+              <label className="text-xs text-vermillion font-medium">
                 Blockers
               </label>
               <Textarea
@@ -1480,46 +1458,38 @@ function ActivitySection({
           {updates.map(update => (
             <div
               key={update.id}
-              className="pl-3 border-l-2 border-gray-200 dark:border-gray-700 space-y-1.5"
+              className="pl-3 border-l-2 border-line space-y-1.5"
             >
               {/* Timestamp */}
-              <span className="text-xs text-gray-400 dark:text-gray-500">
+              <span className="text-xs text-ink-4 ">
                 {formatRelativeTime(update.created_at)}
               </span>
 
               {/* Note */}
               {update.note && (
-                <p className="text-sm text-gray-700 dark:text-gray-300">
-                  {update.note}
-                </p>
+                <p className="text-sm text-ink-2 ">{update.note}</p>
               )}
 
               {/* Wins */}
               {update.wins && (
-                <div className="flex items-start gap-2 px-2 py-1.5 bg-green-50 dark:bg-green-900/20 rounded text-sm">
-                  <Trophy className="h-3.5 w-3.5 text-green-600 mt-0.5 flex-shrink-0" />
-                  <span className="text-green-800 dark:text-green-300">
-                    {update.wins}
-                  </span>
+                <div className="flex items-start gap-2 px-2 py-1.5 bg-forest-bg rounded text-sm">
+                  <Trophy className="h-3.5 w-3.5 text-forest mt-0.5 flex-shrink-0" />
+                  <span className="text-forest ">{update.wins}</span>
                 </div>
               )}
 
               {/* Blockers */}
               {update.blockers && (
-                <div className="flex items-start gap-2 px-2 py-1.5 bg-red-50 dark:bg-red-900/20 rounded text-sm">
-                  <AlertTriangle className="h-3.5 w-3.5 text-red-600 mt-0.5 flex-shrink-0" />
-                  <span className="text-red-800 dark:text-red-300">
-                    {update.blockers}
-                  </span>
+                <div className="flex items-start gap-2 px-2 py-1.5 bg-vermillion-bg rounded text-sm">
+                  <AlertTriangle className="h-3.5 w-3.5 text-vermillion mt-0.5 flex-shrink-0" />
+                  <span className="text-vermillion ">{update.blockers}</span>
                 </div>
               )}
             </div>
           ))}
         </div>
       ) : (
-        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-2">
-          No comments yet
-        </p>
+        <p className="text-sm text-ink-4 text-center py-2">No comments yet</p>
       )}
     </div>
   )
@@ -1529,17 +1499,17 @@ function ActivitySection({
 
 function MetadataFooter({ commitment }: { commitment: Commitment }) {
   return (
-    <div className="pt-4 border-t border-gray-200 dark:border-gray-700 space-y-1">
-      <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+    <div className="pt-4 border-t border-line space-y-1">
+      <div className="flex items-center gap-2 text-xs text-ink-4 ">
         <Clock className="h-3 w-3" />
         Created {formatDate(commitment.created_at, 'MMM d, yyyy')}
       </div>
-      <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+      <div className="flex items-center gap-2 text-xs text-ink-4 ">
         <Clock className="h-3 w-3" />
         Updated {formatRelativeTime(commitment.updated_at)}
       </div>
       {commitment.extracted_from_transcript && (
-        <div className="flex items-center gap-2 text-xs text-purple-500 dark:text-purple-400">
+        <div className="flex items-center gap-2 text-xs text-indigo ">
           <Sparkles className="h-3 w-3" />
           AI Extracted
           {commitment.extraction_confidence &&

--- a/src/components/commitments/commitment-kanban-board.tsx
+++ b/src/components/commitments/commitment-kanban-board.tsx
@@ -70,7 +70,7 @@ function KanbanColumn({
   }
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 flex flex-col h-full min-h-0 overflow-hidden">
+    <Card className="border-line flex flex-col h-full min-h-0 overflow-hidden">
       <CardHeader
         className={cn(
           'py-3 pt-4 -mt-2 rounded-t-xl border-b flex-shrink-0',
@@ -80,7 +80,7 @@ function KanbanColumn({
         <CardTitle className="text-sm font-semibold flex items-center gap-2">
           <div className={iconColor}>{icon}</div>
           <span>{title}</span>
-          <span className="ml-auto text-xs font-normal text-gray-500 dark:text-gray-400">
+          <span className="ml-auto text-xs font-normal text-ink-3 ">
             ({commitments.length})
           </span>
         </CardTitle>
@@ -109,9 +109,7 @@ function KanbanColumn({
             ))
           ) : (
             <div className="text-center py-8 px-4">
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {emptyMessage}
-              </p>
+              <p className="text-sm text-ink-3 ">{emptyMessage}</p>
             </div>
           )}
         </div>
@@ -153,8 +151,8 @@ export function CommitmentKanbanBoard({
         onDelete={onDelete}
         onDrop={onDrop}
         emptyMessage="No commitments yet. Create one to get started!"
-        iconColor="text-gray-600 dark:text-gray-400"
-        headerBgColor="bg-gray-50 dark:bg-gray-800"
+        iconColor="text-ink-3 "
+        headerBgColor="bg-paper "
       />
 
       <KanbanColumn
@@ -169,8 +167,8 @@ export function CommitmentKanbanBoard({
         onDelete={onDelete}
         onDrop={onDrop}
         emptyMessage="Drag commitments here when you start working on them"
-        iconColor="text-blue-600 dark:text-blue-400"
-        headerBgColor="bg-blue-50 dark:bg-blue-900/30"
+        iconColor="text-ds-accent "
+        headerBgColor="bg-ds-accent-bg "
       />
 
       <KanbanColumn
@@ -185,8 +183,8 @@ export function CommitmentKanbanBoard({
         onDelete={onDelete}
         onDrop={onDrop}
         emptyMessage="Completed commitments will appear here"
-        iconColor="text-green-600 dark:text-green-400"
-        headerBgColor="bg-green-50 dark:bg-green-900/30"
+        iconColor="text-forest "
+        headerBgColor="bg-forest-bg "
       />
     </div>
   )

--- a/src/components/commitments/commitment-kanban-card.tsx
+++ b/src/components/commitments/commitment-kanban-card.tsx
@@ -59,12 +59,10 @@ export function CommitmentKanbanCard({
     !isCompleted
 
   const priorityColors = {
-    urgent:
-      'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800',
-    high: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800',
-    medium:
-      'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800',
-    low: 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600',
+    urgent: 'bg-vermillion-bg text-vermillion border-vermillion ',
+    high: 'bg-amber-token-bg text-amber-token border-amber-token ',
+    medium: 'bg-amber-token-bg text-amber-token border-amber-token ',
+    low: 'bg-surface-3 text-ink-2 border-line ',
   }
 
   const getBorderColor = () => {
@@ -75,8 +73,8 @@ export function CommitmentKanbanCard({
   }
 
   const getBgColor = () => {
-    if (isCompleted) return 'bg-green-50/50 dark:bg-green-900/10'
-    if (isInProgress) return 'bg-blue-50/50 dark:bg-blue-900/10'
+    if (isCompleted) return 'bg-forest-bg/50 '
+    if (isInProgress) return 'bg-ds-accent-bg/50 '
     return ''
   }
 
@@ -140,7 +138,7 @@ export function CommitmentKanbanCard({
             {commitment.is_coach_commitment ? (
               <Badge
                 variant="outline"
-                className="bg-amber-50 dark:bg-amber-900/30 border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-400 text-xs w-fit"
+                className="bg-amber-token-bg border-amber-token text-amber-token text-xs w-fit"
               >
                 <Briefcase className="h-3 w-3 mr-1" />
                 Coach Task
@@ -148,7 +146,7 @@ export function CommitmentKanbanCard({
             ) : (
               <Badge
                 variant="outline"
-                className="bg-slate-50 dark:bg-slate-900/30 border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 text-xs w-fit"
+                className="bg-paper border-line text-ink-3 text-xs w-fit"
               >
                 <User className="h-3 w-3 mr-1" />
                 Client Task
@@ -181,7 +179,10 @@ export function CommitmentKanbanCard({
                   </DropdownMenuItem>
                 )}
                 {onDelete && (
-                  <DropdownMenuItem onClick={onDelete} className="text-red-600">
+                  <DropdownMenuItem
+                    onClick={onDelete}
+                    className="text-vermillion"
+                  >
                     <Trash2 className="h-4 w-4 mr-2" />
                     Delete
                   </DropdownMenuItem>
@@ -195,9 +196,7 @@ export function CommitmentKanbanCard({
         <h4
           className={cn(
             'text-sm font-semibold line-clamp-2',
-            isCompleted
-              ? 'text-green-700 dark:text-green-400 line-through'
-              : 'text-gray-900 dark:text-white',
+            isCompleted ? 'text-forest line-through' : 'text-ink ',
           )}
         >
           {commitment.title}
@@ -205,7 +204,7 @@ export function CommitmentKanbanCard({
 
         {/* Description */}
         {commitment.description && (
-          <p className="text-xs text-gray-600 dark:text-gray-400 line-clamp-2">
+          <p className="text-xs text-ink-3 line-clamp-2">
             {commitment.description}
           </p>
         )}
@@ -217,7 +216,7 @@ export function CommitmentKanbanCard({
               <Badge
                 key={outcome.id}
                 variant="outline"
-                className="bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-xs w-fit"
+                className="bg-paper border-line text-ink-2 text-xs w-fit"
               >
                 <Target className="h-3 w-3 mr-1" />
                 {outcome.title}
@@ -227,14 +226,12 @@ export function CommitmentKanbanCard({
         )}
 
         {/* Footer: Date and Priority */}
-        <div className="flex items-center justify-between gap-2 pt-2 border-t border-gray-100 dark:border-gray-700">
+        <div className="flex items-center justify-between gap-2 pt-2 border-t border-line ">
           {commitment.target_date && (
             <div
               className={cn(
                 'flex items-center gap-1 text-xs',
-                isOverdue
-                  ? 'text-red-600 font-medium'
-                  : 'text-gray-600 dark:text-gray-400',
+                isOverdue ? 'text-vermillion font-medium' : 'text-ink-3 ',
               )}
             >
               {isOverdue && <AlertCircle className="h-3 w-3" />}

--- a/src/components/commitments/commitment-list-item.tsx
+++ b/src/components/commitments/commitment-list-item.tsx
@@ -17,15 +17,13 @@ export function CommitmentListItem({
   onEdit,
 }: CommitmentListItemProps) {
   return (
-    <Card className="border-gray-200 dark:border-gray-700 hover:border-blue-200 dark:hover:border-blue-800 transition-colors">
+    <Card className="border-line hover:border-ds-accent transition-colors">
       <CardContent className="p-4">
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
-            <h5 className="font-medium text-gray-900 dark:text-white mb-1">
-              {commitment.title}
-            </h5>
+            <h5 className="font-medium text-ink mb-1">{commitment.title}</h5>
             {commitment.description && (
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-2 line-clamp-2">
+              <p className="text-sm text-ink-3 mb-2 line-clamp-2">
                 {commitment.description}
               </p>
             )}
@@ -38,10 +36,10 @@ export function CommitmentListItem({
                 className={
                   commitment.priority === 'high' ||
                   commitment.priority === 'urgent'
-                    ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                    ? 'bg-vermillion-bg text-vermillion '
                     : commitment.priority === 'medium'
-                      ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-                      : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
+                      ? 'bg-amber-token-bg text-amber-token '
+                      : 'bg-surface-3 text-ink-2 '
                 }
               >
                 {commitment.priority}
@@ -54,16 +52,13 @@ export function CommitmentListItem({
               {commitment.progress_percentage > 0 && (
                 <Badge
                   variant="secondary"
-                  className="bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                  className="bg-forest-bg text-forest "
                 >
                   {commitment.progress_percentage}% complete
                 </Badge>
               )}
               {commitment.extracted_from_transcript && (
-                <Badge
-                  variant="secondary"
-                  className="bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
-                >
+                <Badge variant="secondary" className="bg-surface-3 text-ink-2 ">
                   <Sparkles className="h-3 w-3 mr-1" />
                   AI Extracted
                 </Badge>

--- a/src/components/commitments/commitment-panel.tsx
+++ b/src/components/commitments/commitment-panel.tsx
@@ -168,17 +168,15 @@ function DraftCommitmentCard({
   }
 
   return (
-    <div className="border border-dashed border-gray-300 dark:border-gray-600 bg-gray-50/50 dark:bg-gray-800/50 rounded-lg p-3">
+    <div className="border border-dashed border-line-strong bg-paper/50 rounded-lg p-3">
       {/* Header row */}
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-1.5">
-          <Sparkles className="h-3 w-3 text-violet-600 dark:text-violet-400" />
-          <span className="text-xs font-medium text-violet-600 dark:text-violet-400">
-            Suggested
-          </span>
+          <Sparkles className="h-3 w-3 text-indigo " />
+          <span className="text-xs font-medium text-indigo ">Suggested</span>
         </div>
         {commitment.extraction_confidence != null && (
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-ink-4">
             {Math.round(commitment.extraction_confidence * 100)}% confidence
           </span>
         )}
@@ -188,13 +186,13 @@ function DraftCommitmentCard({
       <Input
         value={editTitle}
         onChange={e => setEditTitle(e.target.value)}
-        className="h-8 text-sm border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 mb-2"
+        className="h-8 text-sm border-line bg-surface-1 mb-2"
         placeholder="Commitment title"
       />
 
       {/* Transcript context */}
       {commitment.transcript_context && (
-        <p className="text-xs italic text-gray-500 dark:text-gray-400 bg-white/80 dark:bg-gray-700/50 rounded px-2 py-1 mb-2">
+        <p className="text-xs italic text-ink-3 bg-surface-1/80 rounded px-2 py-1 mb-2">
           &ldquo;{commitment.transcript_context}&rdquo;
         </p>
       )}
@@ -218,8 +216,8 @@ function DraftCommitmentCard({
             className={cn(
               'h-6 text-xs px-2',
               editDate?.toDateString() === option.date.toDateString()
-                ? 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900'
-                : 'border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400',
+                ? 'bg-ink hover:bg-ink-2 text-ink-on-dark '
+                : 'border-line text-ink-3 ',
             )}
           >
             {option.label}
@@ -232,12 +230,12 @@ function DraftCommitmentCard({
               size="sm"
               variant="outline"
               className={cn(
-                'h-6 text-xs px-2 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400',
+                'h-6 text-xs px-2 border-line text-ink-3 ',
                 editDate &&
                   ![addWeeks(new Date(), 1), addWeeks(new Date(), 2)].some(
                     d => d.toDateString() === editDate.toDateString(),
                   ) &&
-                  'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-white',
+                  'bg-ink hover:bg-ink-2 text-ink-on-dark border-line ',
               )}
             >
               <CalendarIcon className="h-3 w-3 mr-1" />
@@ -265,7 +263,7 @@ function DraftCommitmentCard({
           <button
             type="button"
             onClick={() => setEditDate(undefined)}
-            className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            className="text-xs text-ink-4 hover:text-ink-3 "
           >
             <X className="h-3 w-3" />
           </button>
@@ -275,7 +273,7 @@ function DraftCommitmentCard({
       {/* Outcome chips */}
       {targets.length > 0 && (
         <div className="mb-2">
-          <span className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+          <span className="text-xs font-medium text-ink-3 mb-1 block">
             Link to Meta Performance Outcomes
           </span>
           <div className="flex flex-wrap gap-1.5">
@@ -298,7 +296,7 @@ function DraftCommitmentCard({
                     'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border transition-colors',
                     isSelected
                       ? accentChipSelected
-                      : `bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-600 ${accentChipHover}`,
+                      : `bg-surface-1 text-ink-2 border-line ${accentChipHover}`,
                   )}
                 >
                   {isSelected && <Check className="h-2.5 w-2.5" />}
@@ -316,7 +314,7 @@ function DraftCommitmentCard({
           size="sm"
           variant="ghost"
           onClick={() => onReject(commitment.id)}
-          className="h-7 text-xs text-gray-500 hover:text-red-500"
+          className="h-7 text-xs text-ink-3 hover:text-vermillion"
         >
           <X className="h-3 w-3 mr-1" />
           Dismiss
@@ -325,7 +323,7 @@ function DraftCommitmentCard({
           size="sm"
           onClick={handleAccept}
           disabled={!editTitle.trim()}
-          className="h-7 text-xs bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900"
+          className="h-7 text-xs bg-ink hover:bg-ink-2 text-ink-on-dark "
         >
           <Check className="h-3 w-3 mr-1" />
           Accept
@@ -384,33 +382,24 @@ export function CommitmentPanel({
   // Accent classes
   const accent = isCoach
     ? {
-        button:
-          'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600',
-        tabActive:
-          'text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400 bg-blue-50/50 dark:bg-blue-900/20',
-        chipSelected:
-          'bg-blue-600 text-white border-blue-600 dark:bg-blue-500 dark:border-blue-500',
-        chipHover: 'hover:border-blue-300 dark:hover:border-blue-600',
-        dateText: 'text-blue-600 dark:text-blue-400',
-        dateButtonActive: 'bg-blue-600 hover:bg-blue-700 text-white',
-        inputFocus: 'focus:border-blue-400',
-        itemHover:
-          'hover:border-blue-300 dark:hover:border-blue-600 hover:shadow-sm',
+        button: 'bg-ds-accent hover:bg-ds-accent ',
+        tabActive: 'text-ds-accent border-ds-accent bg-ds-accent-bg/50 ',
+        chipSelected: 'bg-ds-accent text-ink-on-dark border-ds-accent ',
+        chipHover: 'hover:border-ds-accent ',
+        dateText: 'text-ds-accent ',
+        dateButtonActive: 'bg-ds-accent hover:bg-ds-accent text-ink-on-dark',
+        inputFocus: 'focus:border-ds-accent',
+        itemHover: 'hover:border-ds-accent hover:shadow-sm',
       }
     : {
-        button:
-          'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900',
-        tabActive:
-          'text-gray-900 dark:text-white border-gray-900 dark:border-white bg-gray-50 dark:bg-gray-700/50',
-        chipSelected:
-          'bg-gray-900 text-white border-gray-900 dark:bg-white dark:text-gray-900 dark:border-white',
-        chipHover: 'hover:border-gray-400 dark:hover:border-gray-500',
-        dateText: 'text-gray-700 dark:text-gray-300',
-        dateButtonActive:
-          'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900',
-        inputFocus: 'focus:border-gray-400',
-        itemHover:
-          'hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-sm',
+        button: 'bg-ink hover:bg-ink-2 text-ink-on-dark ',
+        tabActive: 'text-ink border-line bg-paper ',
+        chipSelected: 'bg-ink text-ink-on-dark border-line ',
+        chipHover: 'hover:border-line-strong ',
+        dateText: 'text-ink-2 ',
+        dateButtonActive: 'bg-ink hover:bg-ink-2 text-ink-on-dark ',
+        inputFocus: 'focus:border-line-strong',
+        itemHover: 'hover:border-line-strong hover:shadow-sm',
       }
 
   // ─── Handlers ───
@@ -510,13 +499,13 @@ export function CommitmentPanel({
   const getPriorityColor = (priority: string) => {
     switch (priority) {
       case 'urgent':
-        return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800'
+        return 'bg-vermillion-bg text-vermillion border-vermillion '
       case 'high':
-        return 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 border-orange-200 dark:border-orange-800'
+        return 'bg-amber-token-bg text-amber-token border-amber-token '
       case 'medium':
-        return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800'
+        return 'bg-amber-token-bg text-amber-token border-amber-token '
       default:
-        return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-600'
+        return 'bg-surface-3 text-ink-3 border-line '
     }
   }
 
@@ -549,11 +538,11 @@ export function CommitmentPanel({
     // Inline edit mode (coach only)
     if (isCoach && editingId === commitment.id) {
       return (
-        <div className="space-y-2 p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
+        <div className="space-y-2 p-3 bg-ds-accent-bg rounded-lg">
           <Input
             value={editTitle}
             onChange={e => setEditTitle(e.target.value)}
-            className="h-9 text-sm border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800"
+            className="h-9 text-sm border-line bg-surface-1 "
             placeholder="Commitment title"
             autoFocus
           />
@@ -562,7 +551,7 @@ export function CommitmentPanel({
               <Button
                 variant="outline"
                 className={cn(
-                  'w-full justify-start text-left font-normal h-8 text-xs border-gray-200 bg-white',
+                  'w-full justify-start text-left font-normal h-8 text-xs border-line bg-surface-1',
                   !editDate && 'text-muted-foreground',
                 )}
               >
@@ -597,7 +586,7 @@ export function CommitmentPanel({
               size="sm"
               onClick={() => handleSaveEdit(commitment.id)}
               disabled={!editTitle.trim() || isEditSaving}
-              className="h-7 text-xs bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+              className="h-7 text-xs bg-ds-accent hover:bg-ds-accent "
             >
               {isEditSaving ? (
                 <Loader2 className="h-3 w-3 mr-1 animate-spin" />
@@ -616,10 +605,10 @@ export function CommitmentPanel({
         className={cn(
           'group p-3 rounded-lg border transition-all',
           commitment.status === 'completed'
-            ? 'bg-gray-50 dark:bg-gray-700/50 border-gray-200 dark:border-gray-600'
+            ? 'bg-paper border-line '
             : isOverdue
-              ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
-              : `bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 ${accent.itemHover}`,
+              ? 'bg-vermillion-bg border-vermillion '
+              : `bg-surface-1 border-line ${accent.itemHover}`,
           onOpenFull && 'cursor-pointer',
         )}
         onClick={() => onOpenFull?.(commitment)}
@@ -634,8 +623,8 @@ export function CommitmentPanel({
               className={cn(
                 'mt-0.5 flex-shrink-0 transition-colors',
                 commitment.status === 'completed'
-                  ? 'text-green-500'
-                  : 'text-gray-300 hover:text-green-500',
+                  ? 'text-forest'
+                  : 'text-ink-2 hover:text-forest',
               )}
             >
               {commitment.status === 'completed' ? (
@@ -652,8 +641,8 @@ export function CommitmentPanel({
                 className={cn(
                   'text-sm font-medium line-clamp-2',
                   commitment.status === 'completed'
-                    ? 'text-gray-500 dark:text-gray-400 line-through'
-                    : 'text-gray-900 dark:text-white',
+                    ? 'text-ink-3 line-through'
+                    : 'text-ink ',
                 )}
               >
                 {commitment.title}
@@ -667,7 +656,7 @@ export function CommitmentPanel({
                 >
                   <button
                     onClick={() => handleStartEdit(commitment)}
-                    className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                    className="p-1 text-ink-4 hover:text-ink-3 hover:bg-surface-3 rounded"
                     title="Edit"
                   >
                     <Pencil className="h-3.5 w-3.5" />
@@ -680,17 +669,14 @@ export function CommitmentPanel({
                   >
                     <PopoverTrigger asChild>
                       <button
-                        className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded"
+                        className="p-1 text-ink-4 hover:text-vermillion hover:bg-vermillion-bg rounded"
                         title="Delete"
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
                     </PopoverTrigger>
-                    <PopoverContent
-                      className="w-auto p-3 dark:bg-gray-800 dark:border-gray-700"
-                      align="end"
-                    >
-                      <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
+                    <PopoverContent className="w-auto p-3 " align="end">
+                      <p className="text-sm text-ink-2 mb-2">
                         Delete this commitment?
                       </p>
                       <div className="flex items-center gap-2">
@@ -730,8 +716,8 @@ export function CommitmentPanel({
                   className={cn(
                     'text-xs px-1.5 py-0 h-5',
                     commitment.is_coach_commitment
-                      ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700'
-                      : 'border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30',
+                      ? 'border-line-strong text-ink-2 bg-paper '
+                      : 'border-ds-accent text-ds-accent bg-ds-accent-bg ',
                   )}
                 >
                   {commitment.is_coach_commitment ? (
@@ -758,7 +744,7 @@ export function CommitmentPanel({
                 )}
 
               {progress > 0 && commitment.status !== 'completed' && (
-                <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                <span className="flex items-center gap-1 text-xs text-forest ">
                   <TrendingUp className="h-3 w-3" />
                   {progress}%
                 </span>
@@ -768,9 +754,7 @@ export function CommitmentPanel({
                 <span
                   className={cn(
                     'flex items-center gap-1 text-xs',
-                    isOverdue
-                      ? 'text-red-600 dark:text-red-400 font-medium'
-                      : 'text-gray-500 dark:text-gray-400',
+                    isOverdue ? 'text-vermillion font-medium' : 'text-ink-3 ',
                   )}
                 >
                   <CalendarIcon className="h-3 w-3" />
@@ -780,7 +764,7 @@ export function CommitmentPanel({
               )}
 
               {isCoach && (
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-ink-4">
                   {formatRelativeTime(commitment.created_at)}
                 </span>
               )}
@@ -789,9 +773,9 @@ export function CommitmentPanel({
             {progress > 0 &&
               progress < 100 &&
               commitment.status !== 'completed' && (
-                <div className="mt-2 w-full bg-gray-100 dark:bg-gray-700 rounded-full h-1.5">
+                <div className="mt-2 w-full bg-surface-3 rounded-full h-1.5">
                   <div
-                    className="bg-gradient-to-r from-blue-500 to-blue-600 h-1.5 rounded-full transition-all"
+                    className=" h-1.5 rounded-full transition-all"
                     style={{ width: `${progress}%` }}
                   />
                 </div>
@@ -807,7 +791,7 @@ export function CommitmentPanel({
   const renderPastGroups = () => {
     if (loadingPast) {
       return (
-        <div className="p-4 flex items-center justify-center gap-2 text-gray-400">
+        <div className="p-4 flex items-center justify-center gap-2 text-ink-4">
           <Loader2 className="h-4 w-4 animate-spin" />
           <span className="text-xs">Loading...</span>
         </div>
@@ -817,11 +801,9 @@ export function CommitmentPanel({
     if (pastGroups.length === 0) {
       return (
         <div className="p-6 text-center">
-          <History className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            No past commitments
-          </p>
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          <History className="h-8 w-8 text-ink-2 mx-auto mb-2" />
+          <p className="text-sm text-ink-3 ">No past commitments</p>
+          <p className="text-xs text-ink-4 mt-1">
             {isCoach
               ? 'Completed and abandoned commitments will appear here'
               : 'Previous session commitments will appear here'}
@@ -834,25 +816,24 @@ export function CommitmentPanel({
       <div className="p-3 space-y-4">
         {pastGroups.map((group, idx) => (
           <div key={idx}>
-            <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 flex items-center gap-1">
+            <div className="text-xs font-medium text-ink-3 mb-2 flex items-center gap-1">
               <CalendarIcon className="h-3 w-3" />
               {group.date
                 ? formatDate(group.date, 'MMM d, yyyy')
                 : 'Previous Sessions'}
             </div>
-            <div className="space-y-2 pl-3 border-l-2 border-gray-100 dark:border-gray-700">
+            <div className="space-y-2 pl-3 border-l-2 border-line ">
               {(group.commitments || []).map(commitment => (
                 <div
                   key={commitment.id}
                   className={cn(
                     'flex items-start gap-2 rounded px-1 -mx-1',
-                    onOpenFull &&
-                      'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                    onOpenFull && 'cursor-pointer hover:bg-paper ',
                   )}
                   onClick={() => onOpenFull?.(commitment)}
                 >
                   {commitment.status === 'abandoned' ? (
-                    <X className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
+                    <X className="h-4 w-4 text-vermillion flex-shrink-0 mt-0.5" />
                   ) : (
                     <button
                       onClick={e => {
@@ -862,8 +843,8 @@ export function CommitmentPanel({
                       className={cn(
                         'mt-0.5 flex-shrink-0 transition-colors',
                         commitment.status === 'completed'
-                          ? 'text-green-500'
-                          : 'text-gray-300 dark:text-gray-500 hover:text-green-500',
+                          ? 'text-forest'
+                          : 'text-ink-2 hover:text-forest',
                       )}
                       title={
                         commitment.status === 'completed'
@@ -883,10 +864,10 @@ export function CommitmentPanel({
                       className={cn(
                         'text-xs',
                         commitment.status === 'completed'
-                          ? 'text-gray-500 dark:text-gray-400 line-through'
+                          ? 'text-ink-3 line-through'
                           : commitment.status === 'abandoned'
-                            ? 'text-gray-400 dark:text-gray-500 line-through'
-                            : 'text-gray-700 dark:text-gray-300',
+                            ? 'text-ink-4 line-through'
+                            : 'text-ink-2 ',
                       )}
                     >
                       {commitment.title}
@@ -897,18 +878,18 @@ export function CommitmentPanel({
                         className={cn(
                           'text-[10px] px-1.5 py-0',
                           commitment.status === 'completed'
-                            ? 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-400'
+                            ? 'bg-forest-bg text-forest '
                             : commitment.status === 'abandoned'
-                              ? 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400'
+                              ? 'bg-vermillion-bg text-vermillion '
                               : commitment.status === 'active'
-                                ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400'
-                                : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-400',
+                                ? 'bg-ds-accent-bg text-ds-accent '
+                                : 'bg-surface-3 text-ink-2 ',
                         )}
                       >
                         {commitment.status}
                       </Badge>
                       {commitment.target_date && (
-                        <span className="text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-0.5">
+                        <span className="text-[10px] text-ink-4 flex items-center gap-0.5">
                           <CalendarIcon className="h-2.5 w-2.5" />
                           {formatDate(commitment.target_date, 'MMM d')}
                         </span>
@@ -916,7 +897,7 @@ export function CommitmentPanel({
                       {isCoach && commitment.is_coach_commitment && (
                         <Badge
                           variant="outline"
-                          className="text-[10px] px-1 py-0 border-gray-300 dark:border-gray-600"
+                          className="text-[10px] px-1 py-0 border-line-strong "
                         >
                           <Briefcase className="h-2 w-2 mr-0.5" />
                           Coach
@@ -974,21 +955,19 @@ export function CommitmentPanel({
   // ─── Main Render ───
 
   return (
-    <Card className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 flex flex-col h-full">
+    <Card className="bg-surface-1 rounded-xl shadow-sm border border-line flex flex-col h-full">
       {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between flex-shrink-0">
+      <div className="px-4 py-3 border-b border-line flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-2">
-          <Target className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-          <span className="text-sm font-semibold text-gray-900 dark:text-white">
-            Commitments
-          </span>
+          <Target className="h-4 w-4 text-ink-2 " />
+          <span className="text-sm font-semibold text-ink ">Commitments</span>
           {onExtract && (
             <Button
               size="sm"
               variant="outline"
               onClick={onExtract}
               disabled={isExtracting}
-              className="h-7 text-xs border-gray-300 dark:border-gray-600 text-violet-600 dark:text-violet-400 hover:bg-violet-50 dark:hover:bg-violet-900/20"
+              className="h-7 text-xs border-line-strong text-indigo hover:bg-indigo-bg "
             >
               {isExtracting ? (
                 <Loader2 className="h-3 w-3 mr-1 animate-spin" />
@@ -1001,14 +980,14 @@ export function CommitmentPanel({
         </div>
 
         {isCoach && (
-          <div className="flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700 rounded-md p-0.5">
+          <div className="flex items-center gap-0.5 bg-surface-3 rounded-md p-0.5">
             <button
               onClick={() => setAssigneeType('client')}
               className={cn(
                 'flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors',
                 assigneeType === 'client'
-                  ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300',
+                  ? 'bg-surface-1 text-ink shadow-sm'
+                  : 'text-ink-3 hover:text-ink-2 ',
               )}
             >
               <User className="h-3 w-3" />
@@ -1019,8 +998,8 @@ export function CommitmentPanel({
               className={cn(
                 'flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors',
                 assigneeType === 'coach'
-                  ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300',
+                  ? 'bg-surface-1 text-ink shadow-sm'
+                  : 'text-ink-3 hover:text-ink-2 ',
               )}
             >
               <Briefcase className="h-3 w-3" />
@@ -1044,10 +1023,7 @@ export function CommitmentPanel({
             value={title}
             onChange={e => setTitle(e.target.value)}
             onKeyDown={handleKeyDown}
-            className={cn(
-              'border-gray-200 dark:border-gray-600 dark:bg-gray-700 text-sm h-10',
-              accent.inputFocus,
-            )}
+            className={cn('border-line text-sm h-10', accent.inputFocus)}
             maxLength={200}
           />
 
@@ -1057,7 +1033,7 @@ export function CommitmentPanel({
               <button
                 type="button"
                 onClick={() => setShowOutcomes(!showOutcomes)}
-                className="flex items-center gap-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                className="flex items-center gap-1.5 text-xs font-medium text-ink-3 hover:text-ink-2 transition-colors"
               >
                 {showOutcomes ? (
                   <ChevronUp className="h-3 w-3" />
@@ -1077,7 +1053,7 @@ export function CommitmentPanel({
               {showOutcomes && (
                 <div className="mt-2 flex flex-wrap gap-1.5 max-h-[120px] overflow-y-auto">
                   {loadingTargets ? (
-                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                    <span className="text-xs text-ink-4 ">
                       Loading meta performance outcomes...
                     </span>
                   ) : (
@@ -1100,7 +1076,7 @@ export function CommitmentPanel({
                             'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors',
                             isSelected
                               ? accent.chipSelected
-                              : `bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-600 ${accent.chipHover}`,
+                              : `bg-surface-1 text-ink-2 border-line ${accent.chipHover}`,
                           )}
                           title={
                             target.goal_titles && target.goal_titles.length > 0
@@ -1125,7 +1101,7 @@ export function CommitmentPanel({
               <button
                 type="button"
                 onClick={() => setShowSprints(!showSprints)}
-                className="flex items-center gap-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                className="flex items-center gap-1.5 text-xs font-medium text-ink-3 hover:text-ink-2 transition-colors"
               >
                 {showSprints ? (
                   <ChevronUp className="h-3 w-3" />
@@ -1176,7 +1152,7 @@ export function CommitmentPanel({
                           'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors',
                           isSelected
                             ? accent.chipSelected
-                            : `bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-600 ${accent.chipHover}`,
+                            : `bg-surface-1 text-ink-2 border-line ${accent.chipHover}`,
                         )}
                       >
                         {isSelected ? (
@@ -1201,7 +1177,7 @@ export function CommitmentPanel({
           {/* Due Date */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <label className="text-xs font-medium text-gray-600 dark:text-gray-400">
+              <label className="text-xs font-medium text-ink-3 ">
                 Due Date
               </label>
               <Button
@@ -1209,7 +1185,7 @@ export function CommitmentPanel({
                 size="sm"
                 variant="ghost"
                 onClick={() => setShowCalendar(!showCalendar)}
-                className="h-6 px-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                className="h-6 px-2 text-xs text-ink-3 hover:text-ink-2 "
               >
                 {showCalendar ? (
                   <>
@@ -1246,7 +1222,7 @@ export function CommitmentPanel({
                     'h-7 text-xs',
                     targetDate?.toDateString() === option.date.toDateString()
                       ? accent.dateButtonActive
-                      : `border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 ${accent.chipHover}`,
+                      : `border-line text-ink-3 ${accent.chipHover}`,
                   )}
                 >
                   {option.label}
@@ -1258,7 +1234,7 @@ export function CommitmentPanel({
                   size="sm"
                   variant="ghost"
                   onClick={() => setTargetDate(undefined)}
-                  className="h-7 text-xs text-gray-400 hover:text-gray-600"
+                  className="h-7 text-xs text-ink-4 hover:text-ink-3"
                 >
                   <X className="h-3 w-3 mr-1" />
                   Clear
@@ -1267,7 +1243,7 @@ export function CommitmentPanel({
             </div>
 
             {showCalendar && (
-              <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 overflow-hidden">
+              <div className="rounded-lg border border-line bg-surface-1 overflow-hidden">
                 <Calendar
                   mode="single"
                   selected={targetDate}
@@ -1307,7 +1283,7 @@ export function CommitmentPanel({
       </CardContent>
 
       {/* Tabs */}
-      <div className="border-t border-gray-100 dark:border-gray-700 flex-shrink-0">
+      <div className="border-t border-line flex-shrink-0">
         <div className="flex">
           {tabs.map(tab => (
             <button
@@ -1317,7 +1293,7 @@ export function CommitmentPanel({
                 'flex-1 py-2.5 text-xs font-medium transition-colors border-b-2',
                 activeTab === tab.id
                   ? accent.tabActive
-                  : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700',
+                  : 'text-ink-3 border-transparent hover:text-ink-2 hover:bg-paper ',
               )}
             >
               <tab.icon className="h-3.5 w-3.5 inline mr-1.5" />
@@ -1339,17 +1315,15 @@ export function CommitmentPanel({
       <div className="flex-1 overflow-y-auto min-h-0">
         {activeTab === 'session' ? (
           loadingSession ? (
-            <div className="p-4 flex items-center justify-center gap-2 text-gray-400">
+            <div className="p-4 flex items-center justify-center gap-2 text-ink-4">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span className="text-xs">Loading...</span>
             </div>
           ) : sessionCommitments.length === 0 ? (
             <div className="p-6 text-center">
-              <Target className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                No commitments this session
-              </p>
-              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+              <Target className="h-8 w-8 text-ink-2 mx-auto mb-2" />
+              <p className="text-sm text-ink-3 ">No commitments this session</p>
+              <p className="text-xs text-ink-4 mt-1">
                 Add one above to get started
               </p>
             </div>
@@ -1365,7 +1339,7 @@ export function CommitmentPanel({
                 <div className="p-3 space-y-2">
                   {drafts.length > 0 && (
                     <>
-                      <div className="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                      <div className="flex items-center gap-1.5 text-xs font-medium text-ink-3 ">
                         <Sparkles className="h-3 w-3" />
                         AI Suggestions
                       </div>
@@ -1373,7 +1347,7 @@ export function CommitmentPanel({
                         <div key={c.id}>{renderCommitmentItem(c, false)}</div>
                       ))}
                       {nonDrafts.length > 0 && (
-                        <div className="border-t border-gray-200 dark:border-gray-600 my-2" />
+                        <div className="border-t border-line my-2" />
                       )}
                     </>
                   )}
@@ -1386,17 +1360,15 @@ export function CommitmentPanel({
           )
         ) : activeTab === 'active' ? (
           loadingActive ? (
-            <div className="p-4 flex items-center justify-center gap-2 text-gray-400">
+            <div className="p-4 flex items-center justify-center gap-2 text-ink-4">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span className="text-xs">Loading...</span>
             </div>
           ) : activeCommitments.length === 0 ? (
             <div className="p-6 text-center">
-              <Target className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                No active commitments
-              </p>
-              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+              <Target className="h-8 w-8 text-ink-2 mx-auto mb-2" />
+              <p className="text-sm text-ink-3 ">No active commitments</p>
+              <p className="text-xs text-ink-4 mt-1">
                 All commitments have been completed!
               </p>
             </div>

--- a/src/components/commitments/commitment-quick-complete.tsx
+++ b/src/components/commitments/commitment-quick-complete.tsx
@@ -56,7 +56,7 @@ export function CommitmentQuickComplete({
 
   if (updating) {
     return (
-      <Loader2 className={`${sizeClasses[size]} animate-spin text-gray-400`} />
+      <Loader2 className={`${sizeClasses[size]} animate-spin text-ink-4`} />
     )
   }
 
@@ -68,11 +68,11 @@ export function CommitmentQuickComplete({
     >
       {isComplete ? (
         <CheckCircle
-          className={`${sizeClasses[size]} text-green-600 fill-green-100`}
+          className={`${sizeClasses[size]} text-forest fill-forest`}
         />
       ) : (
         <div
-          className={`${sizeClasses[size]} rounded-full border-2 border-gray-300 hover:border-gray-400 transition-colors`}
+          className={`${sizeClasses[size]} rounded-full border-2 border-line-strong hover:border-line-strong transition-colors`}
         />
       )}
     </button>

--- a/src/components/commitments/commitments-widget.tsx
+++ b/src/components/commitments/commitments-widget.tsx
@@ -99,22 +99,22 @@ export function CommitmentsWidget({
     if (isOverdue) {
       return {
         text: 'Overdue',
-        className: 'text-red-600',
+        className: 'text-vermillion',
       }
     }
 
     return {
       text: `Due ${formatRelativeTime(commitment.target_date)}`,
-      className: 'text-zinc-400',
+      className: 'text-ink-4',
     }
   }
 
   if (loading) {
     return (
-      <Card className={cn('bg-white border-gray-200 shadow-sm', className)}>
+      <Card className={cn('bg-surface-1 border-line shadow-sm', className)}>
         <CardContent className="py-12">
           <div className="flex items-center justify-center">
-            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+            <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
           </div>
         </CardContent>
       </Card>
@@ -123,11 +123,11 @@ export function CommitmentsWidget({
 
   if (error) {
     return (
-      <Card className={cn('bg-white border-gray-200 shadow-sm', className)}>
+      <Card className={cn('bg-surface-1 border-line shadow-sm', className)}>
         <CardContent className="py-12">
           <div className="text-center">
-            <AlertCircle className="h-8 w-8 mx-auto mb-2 text-red-600" />
-            <p className="text-gray-600">{error}</p>
+            <AlertCircle className="h-8 w-8 mx-auto mb-2 text-vermillion" />
+            <p className="text-ink-3">{error}</p>
             <Button
               variant="outline"
               size="sm"
@@ -143,11 +143,11 @@ export function CommitmentsWidget({
   }
 
   return (
-    <Card className={cn('bg-white border-gray-200 shadow-sm', className)}>
+    <Card className={cn('bg-surface-1 border-line shadow-sm', className)}>
       {showHeader && (
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle className="text-gray-900 flex items-center gap-2">
+            <CardTitle className="text-ink flex items-center gap-2">
               <Target className="h-5 w-5" />
               My Active Commitments
             </CardTitle>
@@ -155,7 +155,7 @@ export function CommitmentsWidget({
               <Button
                 variant="ghost"
                 size="sm"
-                className="text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                className="text-ink-3 hover:text-ink hover:bg-surface-3"
               >
                 View All
                 <ArrowRight className="ml-2 h-4 w-4" />
@@ -168,9 +168,9 @@ export function CommitmentsWidget({
       <CardContent>
         {displayCommitments.length === 0 ? (
           <div className="text-center py-8">
-            <Target className="h-12 w-12 mx-auto mb-3 text-gray-300" />
-            <p className="text-gray-600">No active commitments</p>
-            <p className="text-sm text-gray-500 mt-1">
+            <Target className="h-12 w-12 mx-auto mb-3 text-ink-2" />
+            <p className="text-ink-3">No active commitments</p>
+            <p className="text-sm text-ink-3 mt-1">
               Commitments from your coaching sessions will appear here
             </p>
           </div>
@@ -181,7 +181,7 @@ export function CommitmentsWidget({
               return (
                 <div
                   key={commitment.id}
-                  className="flex items-start gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors group"
+                  className="flex items-start gap-3 p-3 border border-line rounded-lg hover:bg-paper transition-colors group"
                 >
                   {/* Quick Complete Checkbox */}
                   <div className="pt-0.5">
@@ -194,7 +194,7 @@ export function CommitmentsWidget({
 
                   {/* Content */}
                   <div className="flex-1 min-w-0">
-                    <h4 className="font-medium text-sm text-gray-900 line-clamp-1">
+                    <h4 className="font-medium text-sm text-ink line-clamp-1">
                       {commitment.title}
                     </h4>
 
@@ -204,13 +204,13 @@ export function CommitmentsWidget({
                         variant="secondary"
                         className={cn(
                           commitment.type === 'commitment' &&
-                            'bg-blue-100 text-blue-700',
+                            'bg-ds-accent-bg text-ds-accent',
                           commitment.type === 'habit' &&
-                            'bg-gray-100 text-gray-700',
+                            'bg-surface-3 text-ink-2',
                           commitment.type === 'mp_outcome' &&
-                            'bg-green-100 text-green-700',
+                            'bg-forest-bg text-forest',
                           commitment.type === 'sprint' &&
-                            'bg-indigo-100 text-indigo-700',
+                            'bg-indigo-bg text-indigo',
                         )}
                       >
                         {commitmentTypeLabels[commitment.type] ||
@@ -223,7 +223,7 @@ export function CommitmentsWidget({
                       )}
                       {commitment.progress_percentage > 0 &&
                         commitment.progress_percentage < 100 && (
-                          <span className="text-gray-600">
+                          <span className="text-ink-3">
                             {commitment.progress_percentage}%
                           </span>
                         )}
@@ -257,7 +257,7 @@ export function CommitmentsWidget({
             })}
 
             <Link href={viewAllLink}>
-              <Button className="w-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100 mt-2">
+              <Button className="w-full bg-ink text-ink-on-dark hover:bg-ink-2 mt-2">
                 View All Commitments
                 <ArrowRight className="h-4 w-4 ml-2" />
               </Button>

--- a/src/components/commitments/draft-commitments-review.tsx
+++ b/src/components/commitments/draft-commitments-review.tsx
@@ -225,10 +225,10 @@ export function DraftCommitmentsReview({
                         className={cn(
                           'ml-2',
                           draft.extraction_confidence >= 0.8
-                            ? 'bg-green-500/10 text-green-600'
+                            ? 'bg-forest/10 text-forest'
                             : draft.extraction_confidence >= 0.6
-                              ? 'bg-yellow-500/10 text-yellow-600'
-                              : 'bg-gray-500/10 text-gray-600',
+                              ? 'bg-amber-token/10 text-amber-token'
+                              : 'bg-ink-4/10 text-ink-3',
                         )}
                       >
                         {Math.round(draft.extraction_confidence * 100)}%
@@ -250,7 +250,7 @@ export function DraftCommitmentsReview({
                   {draft.transcript_context && (
                     <div className="mt-3 p-3 bg-accent/50 rounded-md border border-border/50">
                       <div className="flex items-start gap-2">
-                        <Sparkles className="size-4 text-purple-600 flex-shrink-0 mt-0.5" />
+                        <Sparkles className="size-4 text-indigo flex-shrink-0 mt-0.5" />
                         <div className="flex-1">
                           <p className="text-xs font-medium text-muted-foreground mb-1">
                             From transcript:

--- a/src/components/dashboard/upcoming-sessions.tsx
+++ b/src/components/dashboard/upcoming-sessions.tsx
@@ -81,11 +81,9 @@ export function UpcomingSessions() {
   return (
     <div className="mb-6">
       <div className="flex items-center gap-2 mb-3">
-        <CalendarClock className="h-4 w-4 text-gray-400" />
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-          Upcoming Sessions
-        </h3>
-        <span className="text-xs text-gray-400 font-medium">
+        <CalendarClock className="h-4 w-4 text-ink-4" />
+        <h3 className="text-sm font-semibold text-ink ">Upcoming Sessions</h3>
+        <span className="text-xs text-ink-4 font-medium">
           {sessions.length}
         </span>
       </div>
@@ -101,7 +99,7 @@ export function UpcomingSessions() {
             return (
               <div
                 key={session.id}
-                className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
+                className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-line bg-paper/50 hover:bg-paper transition-colors group"
               >
                 {/* Title (editable) */}
                 <div className="flex-1 min-w-0">
@@ -115,12 +113,12 @@ export function UpcomingSessions() {
                         if (e.key === 'Enter') handleTitleSave(session.id)
                         if (e.key === 'Escape') setEditingTitleId(null)
                       }}
-                      className="w-full text-sm font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-0.5 outline-none focus:border-gray-900 dark:focus:border-white"
+                      className="w-full text-sm font-medium bg-surface-1 border border-line-strong rounded px-2 py-0.5 outline-none focus:border-line "
                     />
                   ) : (
                     <button
                       onClick={() => startEditingTitle(session)}
-                      className="text-sm font-medium text-gray-900 dark:text-white truncate block text-left hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                      className="text-sm font-medium text-ink truncate block text-left hover:text-ink-3 transition-colors"
                       title="Click to edit title"
                     >
                       {session.client_name && session.title
@@ -132,7 +130,7 @@ export function UpcomingSessions() {
                       {session.google_calendar_event_id && (
                         <span
                           title="Synced from Google Calendar"
-                          className="ml-1.5 inline-flex items-center rounded-sm border border-gray-200 dark:border-gray-700 px-1 py-[1px] text-[10px] font-normal text-gray-500 dark:text-gray-400 align-middle"
+                          className="ml-1.5 inline-flex items-center rounded-sm border border-line px-1 py-[1px] text-[10px] font-normal text-ink-3 align-middle"
                         >
                           Calendar
                         </span>
@@ -151,9 +149,7 @@ export function UpcomingSessions() {
                   <PopoverTrigger asChild>
                     <button
                       className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
-                        isOverdue
-                          ? 'text-red-500'
-                          : 'text-gray-500 dark:text-gray-400'
+                        isOverdue ? 'text-vermillion' : 'text-ink-3 '
                       }`}
                       title="Click to reschedule"
                     >
@@ -180,7 +176,7 @@ export function UpcomingSessions() {
                   {session.questionnaire_completed ? (
                     <Badge
                       variant="secondary"
-                      className="bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 text-[10px] px-1.5 py-0 h-5"
+                      className="bg-forest-bg text-forest border-forest text-[10px] px-1.5 py-0 h-5"
                     >
                       <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
                       Answered
@@ -189,7 +185,7 @@ export function UpcomingSessions() {
                     <>
                       <Badge
                         variant="secondary"
-                        className="bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 text-[10px] px-1.5 py-0 h-5"
+                        className="bg-ds-accent-bg text-ds-accent border-ds-accent text-[10px] px-1.5 py-0 h-5"
                       >
                         <Mail className="h-2.5 w-2.5 mr-0.5" />
                         Sent
@@ -205,7 +201,7 @@ export function UpcomingSessions() {
                           }
                         }}
                         disabled={sendQuestionnaire.isPending}
-                        className="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                        className="text-[10px] text-ink-4 hover:text-ink-3 transition-colors disabled:opacity-50"
                         title="Resend questionnaire"
                       >
                         {sendQuestionnaire.isPending ? (
@@ -227,7 +223,7 @@ export function UpcomingSessions() {
                         }
                       }}
                       disabled={sendQuestionnaire.isPending}
-                      className="flex items-center gap-1 text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                      className="flex items-center gap-1 text-[10px] font-medium text-ink-3 hover:text-ink-2 transition-colors disabled:opacity-50"
                     >
                       <Send className="h-2.5 w-2.5" />
                       Send Q&A
@@ -239,7 +235,7 @@ export function UpcomingSessions() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-7 text-xs px-2 shrink-0 text-gray-500 hover:text-gray-900 dark:hover:text-white"
+                  className="h-7 text-xs px-2 shrink-0 text-ink-3 hover:text-ink "
                   onClick={() => router.push(`/sessions/${session.id}`)}
                 >
                   Open
@@ -254,7 +250,7 @@ export function UpcomingSessions() {
       {sessions.length > COLLAPSE_THRESHOLD && (
         <button
           onClick={() => setExpanded(v => !v)}
-          className="mt-2 flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
+          className="mt-2 flex items-center gap-1 text-xs font-medium text-ink-3 hover:text-ink transition-colors"
         >
           {expanded ? (
             <>

--- a/src/components/extraction/auto-extraction-modal.tsx
+++ b/src/components/extraction/auto-extraction-modal.tsx
@@ -298,11 +298,11 @@ export function AutoExtractionModal({
   const pendingCount = suggestions.filter(s => s.status === 'pending').length
 
   const getConfidenceColor = (confidence?: number) => {
-    if (!confidence) return 'bg-gray-100 text-gray-600'
-    if (confidence >= 0.85) return 'bg-green-100 text-green-700'
-    if (confidence >= 0.7) return 'bg-blue-100 text-blue-700'
-    if (confidence >= 0.5) return 'bg-yellow-100 text-yellow-700'
-    return 'bg-gray-100 text-gray-600'
+    if (!confidence) return 'bg-surface-3 text-ink-3'
+    if (confidence >= 0.85) return 'bg-forest-bg text-forest'
+    if (confidence >= 0.7) return 'bg-ds-accent-bg text-ds-accent'
+    if (confidence >= 0.5) return 'bg-amber-token-bg text-amber-token'
+    return 'bg-surface-3 text-ink-3'
   }
 
   return (
@@ -310,14 +310,14 @@ export function AutoExtractionModal({
       <DialogContent className="max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader>
           <div className="flex items-center gap-3">
-            <div className="p-2.5 bg-black rounded-xl">
-              <Sparkles className="h-5 w-5 text-white" />
+            <div className="p-2.5 bg-ink rounded-xl">
+              <Sparkles className="h-5 w-5 text-ink-on-dark" />
             </div>
             <div>
               <DialogTitle className="text-lg font-semibold">
                 Session Insights
               </DialogTitle>
-              <DialogDescription className="text-sm text-gray-500">
+              <DialogDescription className="text-sm text-ink-3">
                 {step === 'loading' && 'Analyzing session for key takeaways...'}
                 {step === 'review' && 'Review and confirm suggested items'}
                 {step === 'complete' && 'All done!'}
@@ -331,11 +331,11 @@ export function AutoExtractionModal({
           {step === 'loading' && (
             <div className="flex flex-col items-center justify-center py-12">
               <div className="relative">
-                <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center">
-                  <Loader2 className="h-6 w-6 text-gray-900 animate-spin" />
+                <div className="w-12 h-12 bg-surface-3 rounded-full flex items-center justify-center">
+                  <Loader2 className="h-6 w-6 text-ink animate-spin" />
                 </div>
               </div>
-              <p className="text-sm text-gray-600 mt-4">
+              <p className="text-sm text-ink-3 mt-4">
                 Extracting commitments and wins...
               </p>
             </div>
@@ -351,7 +351,7 @@ export function AutoExtractionModal({
                     size="sm"
                     variant="outline"
                     onClick={handleRejectAll}
-                    className="text-gray-600 hover:text-red-600 hover:border-red-200 hover:bg-red-50"
+                    className="text-ink-3 hover:text-vermillion hover:border-vermillion hover:bg-vermillion-bg"
                   >
                     <XCircle className="h-4 w-4 mr-1" />
                     Reject All
@@ -360,7 +360,7 @@ export function AutoExtractionModal({
                     size="sm"
                     variant="outline"
                     onClick={handleAcceptAll}
-                    className="text-gray-600 hover:text-green-600 hover:border-green-200 hover:bg-green-50"
+                    className="text-ink-3 hover:text-forest hover:border-forest hover:bg-forest-bg"
                   >
                     <CheckCheck className="h-4 w-4 mr-1" />
                     Accept All
@@ -373,10 +373,10 @@ export function AutoExtractionModal({
                   key={item.id}
                   className={`p-4 rounded-xl border transition-all ${
                     item.status === 'accepted'
-                      ? 'border-green-200 bg-green-50'
+                      ? 'border-forest bg-forest-bg'
                       : item.status === 'rejected'
-                        ? 'border-gray-200 bg-gray-50 opacity-50'
-                        : 'border-gray-200 bg-white hover:border-gray-300'
+                        ? 'border-line bg-paper opacity-50'
+                        : 'border-line bg-surface-1 hover:border-line-strong'
                   }`}
                 >
                   {editingItem === item.id ? (
@@ -386,21 +386,19 @@ export function AutoExtractionModal({
                         value={editTitle}
                         onChange={e => setEditTitle(e.target.value)}
                         placeholder="Title"
-                        className="border-gray-200"
+                        className="border-line"
                         autoFocus
                       />
                       <Textarea
                         value={editDescription}
                         onChange={e => setEditDescription(e.target.value)}
                         placeholder="Description (optional)"
-                        className="border-gray-200 resize-none min-h-[60px]"
+                        className="border-line resize-none min-h-[60px]"
                       />
                       {/* Date picker for commitments */}
                       {item.type === 'commitment' && (
                         <div className="flex items-center gap-2">
-                          <span className="text-sm text-gray-500">
-                            Due date:
-                          </span>
+                          <span className="text-sm text-ink-3">Due date:</span>
                           <Popover>
                             <PopoverTrigger asChild>
                               <Button
@@ -440,7 +438,7 @@ export function AutoExtractionModal({
                           size="sm"
                           onClick={() => handleSaveEdit(item.id)}
                           disabled={!editTitle.trim()}
-                          className="bg-green-600 hover:bg-green-700"
+                          className="bg-forest hover:bg-forest"
                         >
                           <Check className="h-4 w-4 mr-1" />
                           Save
@@ -454,21 +452,21 @@ export function AutoExtractionModal({
                       <div
                         className={`p-2 rounded-lg flex-shrink-0 ${
                           item.type === 'win'
-                            ? 'bg-amber-100'
-                            : 'bg-emerald-100'
+                            ? 'bg-amber-token-bg'
+                            : 'bg-forest-bg'
                         }`}
                       >
                         {item.type === 'win' ? (
-                          <Trophy className="h-4 w-4 text-amber-600" />
+                          <Trophy className="h-4 w-4 text-amber-token" />
                         ) : (
-                          <Target className="h-4 w-4 text-emerald-600" />
+                          <Target className="h-4 w-4 text-forest" />
                         )}
                       </div>
 
                       {/* Content */}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="text-xs font-medium text-gray-500 uppercase">
+                          <span className="text-xs font-medium text-ink-3 uppercase">
                             {item.type === 'win' ? 'Win' : 'Commitment'}
                           </span>
                           {item.confidence && (
@@ -480,16 +478,16 @@ export function AutoExtractionModal({
                             </Badge>
                           )}
                           {item.status === 'accepted' && (
-                            <Badge className="bg-green-600 text-white text-xs">
+                            <Badge className="bg-forest text-ink-on-dark text-xs">
                               Accepted
                             </Badge>
                           )}
                         </div>
-                        <h4 className="font-medium text-gray-900 text-sm">
+                        <h4 className="font-medium text-ink text-sm">
                           {item.title}
                         </h4>
                         {item.description && (
-                          <p className="text-sm text-gray-600 mt-1 line-clamp-2">
+                          <p className="text-sm text-ink-3 mt-1 line-clamp-2">
                             {item.description}
                           </p>
                         )}
@@ -502,7 +500,7 @@ export function AutoExtractionModal({
                                   <Button
                                     variant="outline"
                                     size="sm"
-                                    className="h-7 text-xs justify-start text-left font-normal border-gray-200 hover:border-gray-300"
+                                    className="h-7 text-xs justify-start text-left font-normal border-line hover:border-line-strong"
                                   >
                                     <CalendarIcon className="h-3 w-3 mr-1.5" />
                                     {item.target_date
@@ -534,7 +532,7 @@ export function AutoExtractionModal({
                           <Button
                             size="sm"
                             variant="ghost"
-                            className="h-8 w-8 p-0 text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+                            className="h-8 w-8 p-0 text-ink-3 hover:text-ink hover:bg-surface-3"
                             onClick={() => handleStartEdit(item)}
                             title="Edit"
                           >
@@ -543,7 +541,7 @@ export function AutoExtractionModal({
                           <Button
                             size="sm"
                             variant="ghost"
-                            className="h-8 w-8 p-0 text-gray-500 hover:text-red-600 hover:bg-red-50"
+                            className="h-8 w-8 p-0 text-ink-3 hover:text-vermillion hover:bg-vermillion-bg"
                             onClick={() => handleReject(item.id)}
                             title="Reject"
                           >
@@ -552,7 +550,7 @@ export function AutoExtractionModal({
                           <Button
                             size="sm"
                             variant="ghost"
-                            className="h-8 w-8 p-0 text-gray-500 hover:text-green-600 hover:bg-green-50"
+                            className="h-8 w-8 p-0 text-ink-3 hover:text-forest hover:bg-forest-bg"
                             onClick={() => handleAccept(item.id)}
                             title="Accept"
                           >
@@ -566,11 +564,11 @@ export function AutoExtractionModal({
               ))}
 
               {/* Summary and Actions */}
-              <div className="pt-4 border-t border-gray-100 flex items-center justify-between">
-                <p className="text-sm text-gray-500">
+              <div className="pt-4 border-t border-line flex items-center justify-between">
+                <p className="text-sm text-ink-3">
                   {acceptedCount > 0 ? (
                     <>
-                      <span className="font-medium text-green-600">
+                      <span className="font-medium text-forest">
                         {acceptedCount}
                       </span>{' '}
                       item{acceptedCount !== 1 ? 's' : ''} selected
@@ -594,7 +592,7 @@ export function AutoExtractionModal({
                     size="sm"
                     onClick={handleConfirmAll}
                     disabled={isSaving || acceptedCount === 0}
-                    className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+                    className="bg-ink hover:bg-ink-2 "
                   >
                     {isSaving ? (
                       <>
@@ -616,13 +614,13 @@ export function AutoExtractionModal({
           {/* Complete State */}
           {step === 'complete' && suggestions.length === 0 && (
             <div className="text-center py-10">
-              <div className="w-14 h-14 bg-gray-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                <Sparkles className="h-7 w-7 text-gray-400" />
+              <div className="w-14 h-14 bg-surface-3 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                <Sparkles className="h-7 w-7 text-ink-4" />
               </div>
-              <h3 className="font-semibold text-gray-900 mb-2">
+              <h3 className="font-semibold text-ink mb-2">
                 No suggestions found
               </h3>
-              <p className="text-sm text-gray-500 mb-6 max-w-xs mx-auto">
+              <p className="text-sm text-ink-3 mb-6 max-w-xs mx-auto">
                 We couldn&apos;t find any commitments or wins to extract from
                 this session.
               </p>
@@ -634,11 +632,11 @@ export function AutoExtractionModal({
 
           {step === 'complete' && suggestions.length > 0 && (
             <div className="text-center py-10">
-              <div className="w-14 h-14 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                <Check className="h-7 w-7 text-green-600" />
+              <div className="w-14 h-14 bg-forest-bg rounded-2xl flex items-center justify-center mx-auto mb-4">
+                <Check className="h-7 w-7 text-forest" />
               </div>
-              <h3 className="font-semibold text-gray-900 mb-2">Items Saved</h3>
-              <p className="text-sm text-gray-500">
+              <h3 className="font-semibold text-ink mb-2">Items Saved</h3>
+              <p className="text-sm text-ink-3">
                 Your session insights have been saved successfully.
               </p>
             </div>

--- a/src/components/extraction/enhanced-draft-review.tsx
+++ b/src/components/extraction/enhanced-draft-review.tsx
@@ -67,8 +67,8 @@ export function EnhancedDraftReview({
     return (
       <Card>
         <CardContent className="py-12 text-center">
-          <Sparkles className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-          <p className="text-gray-600">No drafts to review</p>
+          <Sparkles className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+          <p className="text-ink-3">No drafts to review</p>
         </CardContent>
       </Card>
     )
@@ -90,22 +90,22 @@ export function EnhancedDraftReview({
   }
 
   const getConfidenceBadge = (confidence: number) => {
-    if (confidence >= 0.85) return 'bg-green-100 text-green-800'
-    if (confidence >= 0.75) return 'bg-blue-100 text-blue-800'
-    if (confidence >= 0.6) return 'bg-yellow-100 text-yellow-800'
-    return 'bg-gray-100 text-gray-800'
+    if (confidence >= 0.85) return 'bg-forest-bg text-forest'
+    if (confidence >= 0.75) return 'bg-ds-accent-bg text-ds-accent'
+    if (confidence >= 0.6) return 'bg-amber-token-bg text-amber-token'
+    return 'bg-surface-3 text-ink-2'
   }
 
   return (
-    <Card className="border-gray-200">
+    <Card className="border-line">
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-gray-600" />
+            <Sparkles className="h-5 w-5 text-ink-3" />
             AI Extraction Results
           </CardTitle>
           <div className="flex items-center gap-2">
-            <Badge variant="outline" className="bg-gray-50">
+            <Badge variant="outline" className="bg-paper">
               {totalExtracted} items found
             </Badge>
           </div>
@@ -113,7 +113,7 @@ export function EnhancedDraftReview({
       </CardHeader>
       <CardContent>
         <Tabs defaultValue="all" className="space-y-4">
-          <TabsList className="bg-gray-50">
+          <TabsList className="bg-paper">
             <TabsTrigger value="all">All ({totalExtracted})</TabsTrigger>
             <TabsTrigger value="goals">
               Meta Performance Outcomes ({draftGoals.length})
@@ -129,15 +129,15 @@ export function EnhancedDraftReview({
           {/* All Tab */}
           <TabsContent value="all" className="space-y-6">
             {/* Summary & Action */}
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <div className="bg-paper border border-line rounded-lg p-4">
               <div className="flex items-center justify-between">
                 <div className="flex items-start gap-3 flex-1">
-                  <Sparkles className="h-5 w-5 text-gray-600 mt-0.5" />
+                  <Sparkles className="h-5 w-5 text-ink-3 mt-0.5" />
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-1">
+                    <h4 className="font-semibold text-ink mb-1">
                       Extraction Complete
                     </h4>
-                    <p className="text-sm text-gray-800">
+                    <p className="text-sm text-ink-2">
                       Found {draftGoals.length} meta performance outcomes,{' '}
                       {draftTargets.length} desired wins,{' '}
                       {draftCommitments.length} commitments. Review and confirm
@@ -149,7 +149,7 @@ export function EnhancedDraftReview({
                   onClick={handleConfirmAll}
                   disabled={confirming}
                   size="lg"
-                  className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 flex-shrink-0"
+                  className="bg-ink hover:bg-ink-2 text-ink-on-dark flex-shrink-0"
                 >
                   {confirming ? (
                     <>
@@ -170,23 +170,23 @@ export function EnhancedDraftReview({
             {draftGoals.length > 0 && (
               <div className="space-y-3">
                 <div className="flex items-center gap-2">
-                  <Trophy className="h-4 w-4 text-gray-600" />
-                  <h3 className="font-semibold text-gray-900">
+                  <Trophy className="h-4 w-4 text-ink-3" />
+                  <h3 className="font-semibold text-ink">
                     New Meta Performance Outcomes ({draftGoals.length})
                   </h3>
                 </div>
                 {draftGoals.map(goal => (
-                  <Card key={goal.id} className="border-gray-200">
+                  <Card key={goal.id} className="border-line">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
                         <div className="flex-1 space-y-2">
                           <div className="flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-gray-900">
+                              <h4 className="font-medium text-ink">
                                 {goal.title}
                               </h4>
                               {goal.description && (
-                                <p className="text-sm text-gray-600 mt-1">
+                                <p className="text-sm text-ink-3 mt-1">
                                   {goal.description}
                                 </p>
                               )}
@@ -201,7 +201,7 @@ export function EnhancedDraftReview({
                             <Badge variant="outline">{goal.category}</Badge>
                           </div>
                           {goal.transcript_context && (
-                            <div className="bg-gray-50 border border-gray-200 rounded p-2 text-sm italic text-gray-700">
+                            <div className="bg-paper border border-line rounded p-2 text-sm italic text-ink-2">
                               &quot;{goal.transcript_context}&quot;
                             </div>
                           )}
@@ -219,23 +219,23 @@ export function EnhancedDraftReview({
             {draftTargets.length > 0 && (
               <div className="space-y-3">
                 <div className="flex items-center gap-2">
-                  <Target className="h-4 w-4 text-blue-600" />
-                  <h3 className="font-semibold text-gray-900">
+                  <Target className="h-4 w-4 text-ds-accent" />
+                  <h3 className="font-semibold text-ink">
                     New Desired Wins ({draftTargets.length})
                   </h3>
                 </div>
                 {draftTargets.map(target => (
-                  <Card key={target.id} className="border-gray-200">
+                  <Card key={target.id} className="border-line">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
                         <div className="flex-1 space-y-2">
                           <div className="flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-gray-900">
+                              <h4 className="font-medium text-ink">
                                 {target.title}
                               </h4>
                               {target.description && (
-                                <p className="text-sm text-gray-600 mt-1">
+                                <p className="text-sm text-ink-3 mt-1">
                                   {target.description}
                                 </p>
                               )}
@@ -246,12 +246,12 @@ export function EnhancedDraftReview({
                               {Math.round(target.confidence * 100)}%
                             </Badge>
                           </div>
-                          <div className="flex items-center gap-2 text-sm text-gray-600">
+                          <div className="flex items-center gap-2 text-sm text-ink-3">
                             <Link2 className="h-3 w-3" />
                             <span>Links to outcome</span>
                           </div>
                           {target.transcript_context && (
-                            <div className="bg-gray-50 border border-gray-200 rounded p-2 text-sm italic text-gray-700">
+                            <div className="bg-paper border border-line rounded p-2 text-sm italic text-ink-2">
                               &quot;{target.transcript_context}&quot;
                             </div>
                           )}
@@ -270,23 +270,23 @@ export function EnhancedDraftReview({
             {draftCommitments.length > 0 && (
               <div className="space-y-3">
                 <div className="flex items-center gap-2">
-                  <Target className="h-4 w-4 text-green-600" />
-                  <h3 className="font-semibold text-gray-900">
+                  <Target className="h-4 w-4 text-forest" />
+                  <h3 className="font-semibold text-ink">
                     New Commitments ({draftCommitments.length})
                   </h3>
                 </div>
                 {draftCommitments.map(commitment => (
-                  <Card key={commitment.id} className="border-gray-200">
+                  <Card key={commitment.id} className="border-line">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
                         <div className="flex-1 space-y-2">
                           <div className="flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-gray-900">
+                              <h4 className="font-medium text-ink">
                                 {commitment.title}
                               </h4>
                               {commitment.description && (
-                                <p className="text-sm text-gray-600 mt-1">
+                                <p className="text-sm text-ink-3 mt-1">
                                   {commitment.description}
                                 </p>
                               )}
@@ -311,7 +311,7 @@ export function EnhancedDraftReview({
                           </div>
 
                           {commitment.transcript_context && (
-                            <div className="bg-gray-50 border border-gray-200 rounded p-2 text-sm italic text-gray-700">
+                            <div className="bg-paper border border-line rounded p-2 text-sm italic text-ink-2">
                               &quot;{commitment.transcript_context}&quot;
                             </div>
                           )}
@@ -329,23 +329,23 @@ export function EnhancedDraftReview({
           {/* Goals Tab */}
           <TabsContent value="goals" className="space-y-3">
             {draftGoals.length === 0 ? (
-              <p className="text-center text-gray-500 py-8">
+              <p className="text-center text-ink-3 py-8">
                 No meta performance outcomes extracted
               </p>
             ) : (
               <>
                 {draftGoals.map(goal => (
-                  <Card key={goal.id} className="border-gray-200">
+                  <Card key={goal.id} className="border-line">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
                         <div className="flex-1 space-y-2">
                           <div className="flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-gray-900">
+                              <h4 className="font-medium text-ink">
                                 {goal.title}
                               </h4>
                               {goal.description && (
-                                <p className="text-sm text-gray-600 mt-1">
+                                <p className="text-sm text-ink-3 mt-1">
                                   {goal.description}
                                 </p>
                               )}
@@ -358,11 +358,11 @@ export function EnhancedDraftReview({
                           </div>
                           <Badge variant="outline">{goal.category}</Badge>
                           {goal.transcript_context && (
-                            <div className="bg-gray-50 border border-gray-200 rounded p-3">
-                              <p className="text-xs font-medium text-gray-900 mb-1">
+                            <div className="bg-paper border border-line rounded p-3">
+                              <p className="text-xs font-medium text-ink mb-1">
                                 From transcript:
                               </p>
-                              <p className="text-sm italic text-gray-800">
+                              <p className="text-sm italic text-ink-2">
                                 &quot;{goal.transcript_context}&quot;
                               </p>
                             </div>
@@ -379,23 +379,23 @@ export function EnhancedDraftReview({
           {/* Targets Tab */}
           <TabsContent value="targets" className="space-y-3">
             {draftTargets.length === 0 ? (
-              <p className="text-center text-gray-500 py-8">
+              <p className="text-center text-ink-3 py-8">
                 No desired wins extracted
               </p>
             ) : (
               <>
                 {draftTargets.map(target => (
-                  <Card key={target.id} className="border-gray-200">
+                  <Card key={target.id} className="border-line">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
                         <div className="flex-1 space-y-2">
                           <div className="flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-gray-900">
+                              <h4 className="font-medium text-ink">
                                 {target.title}
                               </h4>
                               {target.description && (
-                                <p className="text-sm text-gray-600 mt-1">
+                                <p className="text-sm text-ink-3 mt-1">
                                   {target.description}
                                 </p>
                               )}
@@ -406,16 +406,16 @@ export function EnhancedDraftReview({
                               {Math.round(target.confidence * 100)}% confidence
                             </Badge>
                           </div>
-                          <div className="flex items-center gap-2 text-sm text-blue-600">
+                          <div className="flex items-center gap-2 text-sm text-ds-accent">
                             <Link2 className="h-3 w-3" />
                             <span>Linked to goal</span>
                           </div>
                           {target.transcript_context && (
-                            <div className="bg-blue-50 border border-blue-200 rounded p-3">
-                              <p className="text-xs font-medium text-blue-900 mb-1">
+                            <div className="bg-ds-accent-bg border border-ds-accent rounded p-3">
+                              <p className="text-xs font-medium text-ds-accent mb-1">
                                 From transcript:
                               </p>
-                              <p className="text-sm italic text-blue-800">
+                              <p className="text-sm italic text-ds-accent">
                                 &quot;{target.transcript_context}&quot;
                               </p>
                             </div>
@@ -432,23 +432,23 @@ export function EnhancedDraftReview({
           {/* Commitments Tab */}
           <TabsContent value="commitments" className="space-y-3">
             {draftCommitments.length === 0 ? (
-              <p className="text-center text-gray-500 py-8">
+              <p className="text-center text-ink-3 py-8">
                 No commitments extracted
               </p>
             ) : (
               <>
                 {draftCommitments.map(commitment => (
-                  <Card key={commitment.id} className="border-gray-200">
+                  <Card key={commitment.id} className="border-line">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
                         <div className="flex-1 space-y-2">
                           <div className="flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-gray-900">
+                              <h4 className="font-medium text-ink">
                                 {commitment.title}
                               </h4>
                               {commitment.description && (
-                                <p className="text-sm text-gray-600 mt-1">
+                                <p className="text-sm text-ink-3 mt-1">
                                   {commitment.description}
                                 </p>
                               )}
@@ -473,11 +473,11 @@ export function EnhancedDraftReview({
                             </div>
                           </div>
                           {commitment.transcript_context && (
-                            <div className="bg-green-50 border border-green-200 rounded p-3">
-                              <p className="text-xs font-medium text-green-900 mb-1">
+                            <div className="bg-forest-bg border border-forest rounded p-3">
+                              <p className="text-xs font-medium text-forest mb-1">
                                 From transcript:
                               </p>
-                              <p className="text-sm italic text-green-800">
+                              <p className="text-sm italic text-forest">
                                 &quot;{commitment.transcript_context}&quot;
                               </p>
                             </div>
@@ -498,7 +498,7 @@ export function EnhancedDraftReview({
             onClick={handleConfirmAll}
             disabled={confirming}
             size="lg"
-            className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 px-8"
+            className="bg-ink hover:bg-ink-2 text-ink-on-dark px-8"
           >
             {confirming ? (
               <>

--- a/src/components/goals/goal-form-modal.tsx
+++ b/src/components/goals/goal-form-modal.tsx
@@ -239,7 +239,7 @@ export function GoalFormModal({
                         'flex items-center space-x-2 border rounded-lg p-3 cursor-pointer transition-colors',
                         formData.category === option.value
                           ? 'border-primary bg-primary/5'
-                          : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500',
+                          : 'border-line hover:border-line-strong ',
                       )}
                       onClick={() =>
                         setFormData({ ...formData, category: option.value })

--- a/src/components/goals/goals-list.tsx
+++ b/src/components/goals/goals-list.tsx
@@ -56,42 +56,42 @@ export function GoalsList({
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'active':
-        return <Target className="h-4 w-4 text-green-600" />
+        return <Target className="h-4 w-4 text-forest" />
       case 'paused':
-        return <Pause className="h-4 w-4 text-yellow-600" />
+        return <Pause className="h-4 w-4 text-amber-token" />
       case 'achieved':
-        return <Trophy className="h-4 w-4 text-blue-600" />
+        return <Trophy className="h-4 w-4 text-ds-accent" />
       case 'abandoned':
-        return <X className="h-4 w-4 text-gray-400" />
+        return <X className="h-4 w-4 text-ink-4" />
       default:
-        return <Target className="h-4 w-4 text-gray-400" />
+        return <Target className="h-4 w-4 text-ink-4" />
     }
   }
 
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'active':
-        return 'bg-green-100 text-green-800 border-green-200'
+        return 'bg-forest-bg text-forest border-forest'
       case 'paused':
-        return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+        return 'bg-amber-token-bg text-amber-token border-amber-token'
       case 'achieved':
-        return 'bg-blue-100 text-blue-800 border-blue-200'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
       case 'abandoned':
-        return 'bg-gray-100 text-gray-800 border-gray-200'
+        return 'bg-surface-3 text-ink-2 border-line'
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200'
+        return 'bg-surface-3 text-ink-2 border-line'
     }
   }
 
   const getCategoryColor = (category: string) => {
     const colors: Record<string, string> = {
-      career: 'bg-gray-100 text-gray-800',
-      personal: 'bg-gray-200 text-gray-900',
-      health: 'bg-green-100 text-green-800',
-      financial: 'bg-yellow-100 text-yellow-800',
-      relationship: 'bg-red-100 text-red-800',
-      education: 'bg-blue-100 text-blue-800',
-      general: 'bg-gray-100 text-gray-800',
+      career: 'bg-surface-3 text-ink-2',
+      personal: 'bg-surface-3 text-ink',
+      health: 'bg-forest-bg text-forest',
+      financial: 'bg-amber-token-bg text-amber-token',
+      relationship: 'bg-vermillion-bg text-vermillion',
+      education: 'bg-ds-accent-bg text-ds-accent',
+      general: 'bg-surface-3 text-ink-2',
     }
     return colors[category.toLowerCase()] || colors.general
   }
@@ -100,7 +100,7 @@ export function GoalsList({
     return (
       <Card>
         <CardContent className="flex items-center justify-center py-8">
-          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
         </CardContent>
       </Card>
     )
@@ -108,7 +108,7 @@ export function GoalsList({
 
   return (
     <>
-      <Card className="border-gray-200 shadow-sm">
+      <Card className="border-line shadow-sm">
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2">
@@ -126,8 +126,8 @@ export function GoalsList({
         <CardContent>
           {goals.length === 0 ? (
             <div className="text-center py-8">
-              <Trophy className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-              <p className="text-gray-600 mb-4">No vision set yet</p>
+              <Trophy className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+              <p className="text-ink-3 mb-4">No vision set yet</p>
               {showCreateButton && (
                 <Button variant="outline" onClick={handleCreateClick}>
                   <Plus className="h-4 w-4 mr-2" />
@@ -140,21 +140,21 @@ export function GoalsList({
               {goals.map(goal => (
                 <div
                   key={goal.id}
-                  className="p-4 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+                  className="p-4 rounded-lg border border-line hover:bg-paper transition-colors"
                 >
                   <div className="flex items-start justify-between mb-3">
                     <div className="flex items-start gap-3 flex-1">
-                      <div className="p-2 bg-gray-100 rounded-lg mt-0.5">
+                      <div className="p-2 bg-surface-3 rounded-lg mt-0.5">
                         {getStatusIcon(goal.status)}
                       </div>
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <h4 className="font-semibold text-gray-900">
+                          <h4 className="font-semibold text-ink">
                             {goal.title}
                           </h4>
                         </div>
                         {goal.description && (
-                          <p className="text-sm text-gray-600 mb-2">
+                          <p className="text-sm text-ink-3 mb-2">
                             {goal.description}
                           </p>
                         )}
@@ -188,8 +188,8 @@ export function GoalsList({
                   {goal.status === 'active' && (
                     <div className="ml-14">
                       <div className="flex items-center justify-between text-sm mb-2">
-                        <span className="text-gray-600">Progress</span>
-                        <span className="font-semibold text-gray-900">
+                        <span className="text-ink-3">Progress</span>
+                        <span className="font-semibold text-ink">
                           {goal.progress}%
                         </span>
                       </div>

--- a/src/components/group-session/group-meeting-header.tsx
+++ b/src/components/group-session/group-meeting-header.tsx
@@ -17,10 +17,10 @@ export function GroupMeetingHeader({ session }: GroupMeetingHeaderProps) {
         {participants.slice(0, 5).map(p => (
           <div
             key={p.client_id}
-            className="w-7 h-7 rounded-full bg-gray-200 border-2 border-white flex items-center justify-center"
+            className="w-7 h-7 rounded-full bg-surface-3 border-2 border-paper flex items-center justify-center"
             title={p.client_name}
           >
-            <span className="text-xs font-medium text-gray-600">
+            <span className="text-xs font-medium text-ink-3">
               {p.client_name
                 .split(' ')
                 .map(n => n[0])
@@ -31,8 +31,8 @@ export function GroupMeetingHeader({ session }: GroupMeetingHeaderProps) {
           </div>
         ))}
         {participants.length > 5 && (
-          <div className="w-7 h-7 rounded-full bg-gray-300 border-2 border-white flex items-center justify-center">
-            <span className="text-xs font-medium text-gray-600">
+          <div className="w-7 h-7 rounded-full bg-line border-2 border-paper flex items-center justify-center">
+            <span className="text-xs font-medium text-ink-3">
               +{participants.length - 5}
             </span>
           </div>

--- a/src/components/group-session/group-session-badge.tsx
+++ b/src/components/group-session/group-session-badge.tsx
@@ -15,7 +15,7 @@ export function GroupSessionBadge({
   return (
     <Badge
       variant="outline"
-      className={`bg-teal-50 text-teal-700 border-teal-200 dark:bg-teal-900/30 dark:text-teal-400 dark:border-teal-800 text-xs ${className}`}
+      className={`bg-forest-bg text-forest border-forest text-xs ${className}`}
     >
       <Users className="h-3 w-3 mr-1" />
       {count != null ? `${count} participants` : 'Group'}

--- a/src/components/group-session/participant-card.tsx
+++ b/src/components/group-session/participant-card.tsx
@@ -25,8 +25,8 @@ export function ParticipantCard({
       <CardContent className="py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
-              <User className="h-5 w-5 text-gray-600" />
+            <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center">
+              <User className="h-5 w-5 text-ink-3" />
             </div>
             <div>
               <p className="font-medium text-sm">{participant.client_name}</p>

--- a/src/components/group-session/participant-selector.tsx
+++ b/src/components/group-session/participant-selector.tsx
@@ -35,16 +35,16 @@ export function ParticipantSelector({
             className={cn(
               'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border',
               isSelected
-                ? 'bg-gray-900 text-white border-gray-900 dark:bg-white dark:text-gray-900 dark:border-white shadow-sm'
-                : 'bg-white text-gray-600 border-gray-200 hover:border-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-700',
+                ? 'bg-ink text-ink-on-dark border-line shadow-sm'
+                : 'bg-surface-1 text-ink-3 border-line hover:border-line-strong hover:bg-paper ',
             )}
           >
             <span
               className={cn(
                 'w-4.5 h-4.5 rounded-full flex items-center justify-center text-[9px] font-semibold leading-none',
                 isSelected
-                  ? 'bg-white/20 text-white dark:bg-gray-900/20 dark:text-gray-900'
-                  : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+                  ? 'bg-surface-1/20 text-ink-on-dark '
+                  : 'bg-surface-3 text-ink-3 ',
               )}
             >
               {getInitials(p.client_name)}

--- a/src/components/group-session/start-standalone-group-session-modal.tsx
+++ b/src/components/group-session/start-standalone-group-session-modal.tsx
@@ -204,7 +204,7 @@ export function StartStandaloneGroupSessionModal({
             </ScrollArea>
 
             {selectedClientIds.size === 1 && (
-              <p className="text-xs text-amber-600 mt-1">
+              <p className="text-xs text-amber-token mt-1">
                 Select at least 2 clients for a group session
               </p>
             )}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -141,7 +141,7 @@ function TopNavShell({
   const pathname = usePathname() ?? ''
 
   return (
-    <div className="min-h-screen bg-bg flex flex-col">
+    <div className="min-h-screen bg-background flex flex-col">
       {banner}
       <header className="bg-paper border-b border-line sticky top-0 z-50">
         <div className="max-w-[1280px] mx-auto px-6 lg:px-8">
@@ -199,7 +199,7 @@ function SidebarShell({
   return (
     <>
       {banner}
-      <div className="flex h-screen bg-bg">
+      <div className="flex h-screen bg-background">
         <aside
           className={cn(
             'bg-sidebar text-sidebar-foreground flex flex-col transition-[width] duration-200 ease-in-out shrink-0',

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -21,13 +21,11 @@ import { Button } from '@/components/ui/button'
 export default function Navigation() {
   const router = useRouter()
   const pathname = usePathname()
-  const { isAuthenticated, hasAnyRole, roles } = useAuth() // NEW: Get roles
+  const { isAuthenticated, hasAnyRole, roles } = useAuth()
   const permissions = usePermissions()
 
-  // NEW: Check if user is client-only (no coach/admin/viewer roles)
   const isClientOnly = roles.length === 1 && roles.includes('client')
 
-  // Coach impersonation state
   const [impersonatedCoachName, setImpersonatedCoachName] = useState<
     string | null
   >(null)
@@ -48,7 +46,6 @@ export default function Navigation() {
     return false
   }
 
-  // Filter navigation items based on permissions
   const allNavItems = [
     { path: '/', label: 'Dashboard', icon: BarChart3, permission: null },
     {
@@ -71,7 +68,6 @@ export default function Navigation() {
     },
   ]
 
-  // NEW: Hide coach/admin nav items for client-only users
   const navItems = isClientOnly
     ? []
     : allNavItems.filter(item => {
@@ -82,9 +78,6 @@ export default function Navigation() {
         )
       })
 
-  // Removed auto-redirect - handled by CoachRoute instead to prevent loops
-
-  // NEW: Don't render navigation for client-only users (they have their own in client portal)
   if (isClientOnly) {
     return null
   }
@@ -92,8 +85,8 @@ export default function Navigation() {
   return (
     <>
       {impersonatedCoachName && (
-        <div className="bg-amber-500 text-white px-4 py-2 text-center text-sm font-medium flex items-center justify-center gap-3 sticky top-0 z-[60]">
-          <Eye className="h-4 w-4 shrink-0" />
+        <div className="bg-amber-token text-ink-on-dark px-4 py-2 text-center text-sm font-medium flex items-center justify-center gap-3 sticky top-0 z-[60]">
+          <Eye className="h-4 w-4 shrink-0" strokeWidth={1.75} />
           <span>Viewing as coach: {impersonatedCoachName}</span>
           <Button
             size="sm"
@@ -105,43 +98,32 @@ export default function Navigation() {
           </Button>
         </div>
       )}
-      <header className="bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 sticky top-0 z-50">
+      <header className="bg-paper border-b border-line sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            {/* Logo Section */}
             <div className="flex items-center gap-10">
               <button
                 onClick={() => router.push('/')}
                 className="flex items-center gap-3 group"
               >
-                <div className="relative">
-                  <div className="absolute inset-0 bg-gray-900 rounded-xl blur-sm opacity-20 group-hover:opacity-30 transition-opacity"></div>
-                  <div className="relative w-11 h-11 bg-gray-900 rounded-xl p-1.5 flex items-center justify-center group-hover:scale-105 transition-transform">
-                    <Image
-                      src="/novus-global-logo.webp"
-                      alt="Novus Global Logo"
-                      width={32}
-                      height={32}
-                      className="object-contain filter brightness-0 invert"
-                    />
-                  </div>
+                <div className="relative w-11 h-11 bg-brand-tile rounded-xl p-1.5 flex items-center justify-center group-hover:scale-105 transition-transform">
+                  <Image
+                    src="/novus-global-logo.webp"
+                    alt="Novus Global Logo"
+                    width={32}
+                    height={32}
+                    className="object-contain filter brightness-0 invert"
+                  />
                 </div>
                 <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <h1 className="text-xl font-bold text-gray-900 dark:text-white">
-                      Coach Sidekick
-                    </h1>
-                  </div>
+                  <h1 className="text-xl font-bold text-ink">Coach Sidekick</h1>
                 </div>
               </button>
 
-              {/* Navigation Links */}
               <nav className="hidden md:flex items-center">
-                <div className="flex items-center bg-gray-50 dark:bg-gray-800 rounded-lg p-1">
+                <div className="flex items-center bg-surface-2 rounded-lg p-1">
                   {navItems.map(item => {
                     const Icon = item.icon
-                    // Only the longest-matching nav item lights up — avoids
-                    // both /sessions and /sessions/shared appearing active at once.
                     const isActive =
                       isActivePath(item.path) &&
                       !navItems.some(
@@ -157,15 +139,15 @@ export default function Navigation() {
                         onClick={() => router.push(item.path)}
                         className={`
                         flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium
-                        transition-all duration-200 cursor-pointer
+                        transition-colors duration-200 cursor-pointer
                         ${
                           isActive
-                            ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm'
-                            : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-white dark:hover:bg-gray-700 hover:shadow-sm'
+                            ? 'bg-paper text-ink shadow-xs'
+                            : 'text-ink-3 hover:text-ink hover:bg-paper/60'
                         }
                       `}
                       >
-                        <Icon className="h-4 w-4" />
+                        <Icon className="h-4 w-4" strokeWidth={1.75} />
                         {item.label}
                       </button>
                     )
@@ -174,29 +156,25 @@ export default function Navigation() {
               </nav>
             </div>
 
-            {/* Right Section */}
             <div className="flex items-center gap-4">
               {isAuthenticated && (
                 <>
                   <div className="hidden lg:flex items-center">
-                    <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                    <div className="flex items-center gap-2 px-3 py-1.5 bg-surface-2 rounded-lg">
                       <div className="relative">
-                        <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                        <div className="absolute inset-0 w-2 h-2 bg-green-500 rounded-full animate-ping"></div>
+                        <div className="w-2 h-2 bg-forest rounded-full"></div>
+                        <div className="absolute inset-0 w-2 h-2 bg-forest rounded-full animate-ping"></div>
                       </div>
-                      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      <span className="text-sm font-medium text-ink-2">
                         Active
                       </span>
                     </div>
                   </div>
 
-                  {/* Theme Toggle */}
                   <ThemeToggle />
 
-                  {/* Role Switcher */}
                   <RoleSwitcher />
 
-                  {/* Admin Button - Only show for admin and super_admin roles, hide during coach impersonation */}
                   {hasAnyRole(['admin', 'super_admin']) &&
                     !impersonatedCoachName && (
                       <Button
@@ -207,7 +185,7 @@ export default function Navigation() {
                         size="sm"
                         className="flex items-center gap-2"
                       >
-                        <Shield className="h-4 w-4" />
+                        <Shield className="h-4 w-4" strokeWidth={1.75} />
                         <span className="hidden sm:inline">Admin</span>
                       </Button>
                     )}
@@ -216,8 +194,6 @@ export default function Navigation() {
 
               <UserNav />
             </div>
-
-            {/* Mobile Navigation Toggle - could be added if needed */}
           </div>
         </div>
       </header>

--- a/src/components/layout/page-layout.tsx
+++ b/src/components/layout/page-layout.tsx
@@ -13,9 +13,9 @@ export default function PageLayout({
   className = '',
 }: PageLayoutProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900">
+    <div className="min-h-screen bg-surface-2">
       <Navigation />
-      <main className={`${className}`}>{children}</main>
+      <main className={className}>{children}</main>
     </div>
   )
 }

--- a/src/components/meeting/analysis-conversations-card.tsx
+++ b/src/components/meeting/analysis-conversations-card.tsx
@@ -57,17 +57,15 @@ export function AnalysisConversationsCard({
             }
           >
             <MessageSquare
-              className={
-                compact ? 'h-3 w-3 text-gray-500' : 'h-4 w-4 text-gray-500'
-              }
+              className={compact ? 'h-3 w-3 text-ink-3' : 'h-4 w-4 text-ink-3'}
             />
             Analysis Context
           </h3>
         </CardHeader>
         <CardContent className={compact ? 'pt-0' : ''}>
           <div className="animate-pulse space-y-2">
-            <div className="h-3 bg-gray-200 rounded w-full"></div>
-            <div className="h-3 bg-gray-200 rounded w-3/4"></div>
+            <div className="h-3 bg-surface-3 rounded w-full"></div>
+            <div className="h-3 bg-surface-3 rounded w-3/4"></div>
           </div>
         </CardContent>
       </Card>
@@ -86,15 +84,13 @@ export function AnalysisConversationsCard({
             }
           >
             <MessageSquare
-              className={
-                compact ? 'h-3 w-3 text-gray-500' : 'h-4 w-4 text-gray-500'
-              }
+              className={compact ? 'h-3 w-3 text-ink-3' : 'h-4 w-4 text-ink-3'}
             />
             Analysis Context
           </h3>
         </CardHeader>
         <CardContent className={compact ? 'pt-0' : ''}>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-ink-3">
             No conversation context from recent analysis
           </p>
         </CardContent>
@@ -105,13 +101,13 @@ export function AnalysisConversationsCard({
   const getSpeakerIcon = (speaker: string) => {
     switch (speaker) {
       case 'coach':
-        return <User className="h-3 w-3 text-blue-500" />
+        return <User className="h-3 w-3 text-ds-accent" />
       case 'client':
-        return <User className="h-3 w-3 text-green-500" />
+        return <User className="h-3 w-3 text-forest" />
       case 'assistant':
-        return <Bot className="h-3 w-3 text-purple-500" />
+        return <Bot className="h-3 w-3 text-indigo" />
       default:
-        return <User className="h-3 w-3 text-gray-400" />
+        return <User className="h-3 w-3 text-ink-4" />
     }
   }
 
@@ -129,16 +125,16 @@ export function AnalysisConversationsCard({
   }
 
   const getRelevanceColor = (score?: number) => {
-    if (!score) return 'bg-gray-100 text-gray-700'
-    if (score > 0.8) return 'bg-green-100 text-green-700'
-    if (score > 0.6) return 'bg-yellow-100 text-yellow-700'
-    return 'bg-gray-100 text-gray-700'
+    if (!score) return 'bg-surface-3 text-ink-2'
+    if (score > 0.8) return 'bg-forest-bg text-forest'
+    if (score > 0.6) return 'bg-amber-token-bg text-amber-token'
+    return 'bg-surface-3 text-ink-2'
   }
 
   return (
     <Card className="h-auto">
       <CardHeader
-        className={`${compact ? 'pb-2 py-2' : 'pb-3'} cursor-pointer hover:bg-gray-50 transition-colors`}
+        className={`${compact ? 'pb-2 py-2' : 'pb-3'} cursor-pointer hover:bg-paper transition-colors`}
         onClick={() => setIsCardExpanded(!isCardExpanded)}
       >
         <div className="flex items-center justify-between">
@@ -151,7 +147,7 @@ export function AnalysisConversationsCard({
           >
             <Sparkles
               className={
-                compact ? 'h-3 w-3 text-purple-500' : 'h-4 w-4 text-purple-500'
+                compact ? 'h-3 w-3 text-indigo' : 'h-4 w-4 text-indigo'
               }
             />
             Analysis Context
@@ -162,9 +158,9 @@ export function AnalysisConversationsCard({
             )}
           </h3>
           {isCardExpanded ? (
-            <ChevronUp className="h-3 w-3 text-gray-400" />
+            <ChevronUp className="h-3 w-3 text-ink-4" />
           ) : (
-            <ChevronDown className="h-3 w-3 text-gray-400" />
+            <ChevronDown className="h-3 w-3 text-ink-4" />
           )}
         </div>
       </CardHeader>
@@ -179,7 +175,7 @@ export function AnalysisConversationsCard({
               return (
                 <div
                   key={conversation.id || index}
-                  className="border rounded-lg hover:bg-gray-50 transition-colors"
+                  className="border rounded-lg hover:bg-paper transition-colors"
                 >
                   <div
                     className="p-3 cursor-pointer"
@@ -189,7 +185,7 @@ export function AnalysisConversationsCard({
                     <div className="flex items-start justify-between mb-2">
                       <div className="flex-1">
                         {conversation.analysis_reason && (
-                          <p className="text-xs text-gray-600 mb-1">
+                          <p className="text-xs text-ink-3 mb-1">
                             {conversation.analysis_reason}
                           </p>
                         )}
@@ -204,22 +200,22 @@ export function AnalysisConversationsCard({
                       </div>
                       <div className="flex items-center gap-2">
                         {conversation.timestamp && (
-                          <div className="flex items-center gap-1 text-xs text-gray-400">
+                          <div className="flex items-center gap-1 text-xs text-ink-4">
                             <Clock className="h-3 w-3" />
                             {formatTime(conversation.timestamp)}
                           </div>
                         )}
                         {isExpanded ? (
-                          <ChevronUp className="h-3 w-3 text-gray-400" />
+                          <ChevronUp className="h-3 w-3 text-ink-4" />
                         ) : (
-                          <ChevronDown className="h-3 w-3 text-gray-400" />
+                          <ChevronDown className="h-3 w-3 text-ink-4" />
                         )}
                       </div>
                     </div>
 
                     {/* Summary or preview */}
                     {!isExpanded && conversation.summary && (
-                      <p className="text-xs text-gray-600 line-clamp-2">
+                      <p className="text-xs text-ink-3 line-clamp-2">
                         {conversation.summary}
                       </p>
                     )}
@@ -246,7 +242,7 @@ export function AnalysisConversationsCard({
 
                   {/* Expanded conversation segments */}
                   {isExpanded && (
-                    <div className="border-t px-3 py-2 space-y-2 bg-gray-50">
+                    <div className="border-t px-3 py-2 space-y-2 bg-paper">
                       {conversation.segments.map((segment, segIndex) => (
                         <div key={segIndex} className="flex items-start gap-2">
                           <div className="mt-0.5">
@@ -254,18 +250,16 @@ export function AnalysisConversationsCard({
                           </div>
                           <div className="flex-1">
                             <div className="flex items-center gap-2 mb-0.5">
-                              <span className="text-xs font-medium text-gray-700">
+                              <span className="text-xs font-medium text-ink-2">
                                 {getSpeakerLabel(segment.speaker)}
                               </span>
                               {segment.timestamp && (
-                                <span className="text-xs text-gray-400">
+                                <span className="text-xs text-ink-4">
                                   {segment.timestamp}
                                 </span>
                               )}
                             </div>
-                            <p className="text-xs text-gray-600">
-                              {segment.text}
-                            </p>
+                            <p className="text-xs text-ink-3">{segment.text}</p>
                           </div>
                         </div>
                       ))}
@@ -274,7 +268,7 @@ export function AnalysisConversationsCard({
                       {conversation.key_moments &&
                         conversation.key_moments.length > 0 && (
                           <div className="mt-3 pt-2 border-t">
-                            <h4 className="text-xs font-medium text-gray-700 mb-1">
+                            <h4 className="text-xs font-medium text-ink-2 mb-1">
                               Key Moments:
                             </h4>
                             <div className="flex flex-wrap gap-1">
@@ -297,7 +291,7 @@ export function AnalysisConversationsCard({
             })}
 
           {conversations.length > (compact ? 2 : 5) && (
-            <p className="text-xs text-gray-500 text-center">
+            <p className="text-xs text-ink-3 text-center">
               +{conversations.length - (compact ? 2 : 5)} more conversation
               segments
             </p>

--- a/src/components/meeting/batch-save-status.tsx
+++ b/src/components/meeting/batch-save-status.tsx
@@ -131,16 +131,16 @@ export function BatchSaveStatus({
     if (minimal) {
       return (
         <div className="flex items-center gap-2">
-          <Loader2 className="h-3 w-3 animate-spin text-gray-400" />
-          <span className="text-xs text-gray-500">Loading...</span>
+          <Loader2 className="h-3 w-3 animate-spin text-ink-4" />
+          <span className="text-xs text-ink-3">Loading...</span>
         </div>
       )
     }
     return (
-      <Card className="border-gray-200">
+      <Card className="border-line">
         <CardContent className="flex items-center gap-2 p-3">
-          <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
-          <span className="text-xs text-gray-600">Checking save status...</span>
+          <Loader2 className="h-4 w-4 animate-spin text-ink-4" />
+          <span className="text-xs text-ink-3">Checking save status...</span>
         </CardContent>
       </Card>
     )
@@ -150,16 +150,18 @@ export function BatchSaveStatus({
     if (minimal) {
       return (
         <div className="flex items-center gap-2">
-          <CloudOff className="h-3 w-3 text-red-500" />
-          <span className="text-xs text-red-600">Save error</span>
+          <CloudOff className="h-3 w-3 text-vermillion" />
+          <span className="text-xs text-vermillion">Save error</span>
         </div>
       )
     }
     return (
-      <Card className="border-red-200 bg-red-50">
+      <Card className="border-vermillion bg-vermillion-bg">
         <CardContent className="flex items-center gap-2 p-3">
-          <CloudOff className="h-4 w-4 text-red-600" />
-          <span className="text-xs text-red-700">Save status unavailable</span>
+          <CloudOff className="h-4 w-4 text-vermillion" />
+          <span className="text-xs text-vermillion">
+            Save status unavailable
+          </span>
         </CardContent>
       </Card>
     )
@@ -170,18 +172,18 @@ export function BatchSaveStatus({
   const getSaveStatusIcon = () => {
     const size = minimal ? 'h-3 w-3' : 'h-4 w-4'
     if (saveStatus.batchSaveInProgress) {
-      return <Loader2 className={`${size} animate-spin text-blue-600`} />
+      return <Loader2 className={`${size} animate-spin text-ds-accent`} />
     }
 
     if (saveStatus.unsavedEntries === 0) {
-      return <CheckCircle2 className={`${size} text-green-600`} />
+      return <CheckCircle2 className={`${size} text-forest`} />
     }
 
     if (saveStatus.unsavedEntries > 20) {
-      return <AlertTriangle className={`${size} text-yellow-600`} />
+      return <AlertTriangle className={`${size} text-amber-token`} />
     }
 
-    return <Cloud className={`${size} text-blue-600`} />
+    return <Cloud className={`${size} text-ds-accent`} />
   }
 
   const getSaveStatusText = () => {
@@ -198,18 +200,18 @@ export function BatchSaveStatus({
 
   const getSaveStatusColor = () => {
     if (saveStatus.batchSaveInProgress) {
-      return 'bg-blue-100 text-blue-800 border-blue-200'
+      return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
     }
 
     if (saveStatus.unsavedEntries === 0) {
-      return 'bg-green-100 text-green-800 border-green-200'
+      return 'bg-forest-bg text-forest border-forest'
     }
 
     if (saveStatus.unsavedEntries > 20) {
-      return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+      return 'bg-amber-token-bg text-amber-token border-amber-token'
     }
 
-    return 'bg-blue-100 text-blue-800 border-blue-200'
+    return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
   }
 
   const formatLastSave = (dateString: string | null) => {
@@ -230,10 +232,10 @@ export function BatchSaveStatus({
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
           {getSaveStatusIcon()}
-          <span className="text-xs text-gray-600">{getSaveStatusText()}</span>
+          <span className="text-xs text-ink-3">{getSaveStatusText()}</span>
         </div>
         {saveStatus.lastBatchSave && (
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-ink-4">
             Last save: {formatLastSave(saveStatus.lastBatchSave)}
           </span>
         )}
@@ -247,7 +249,7 @@ export function BatchSaveStatus({
   }
 
   return (
-    <Card className="border-gray-200">
+    <Card className="border-line">
       <CardContent className="p-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -257,11 +259,11 @@ export function BatchSaveStatus({
                 <Badge className={getSaveStatusColor()}>
                   {getSaveStatusText()}
                 </Badge>
-                <span className="text-xs text-gray-600">
+                <span className="text-xs text-ink-3">
                   {saveStatus.savedEntries}/{saveStatus.totalEntries} saved
                 </span>
               </div>
-              <span className="text-xs text-gray-500 mt-1">
+              <span className="text-xs text-ink-3 mt-1">
                 Last save: {formatLastSave(saveStatus.lastBatchSave)}
               </span>
             </div>

--- a/src/components/meeting/bot-status.tsx
+++ b/src/components/meeting/bot-status.tsx
@@ -85,14 +85,14 @@ export function BotStatus({ bot, onStop, compact = false }: BotStatusProps) {
         <Circle
           className={`w-2 h-2 ${
             statusColor === 'green'
-              ? 'text-green-500 fill-green-500'
+              ? 'text-forest fill-forest'
               : statusColor === 'yellow'
-              ? 'text-yellow-500 fill-yellow-500'
-              : statusColor === 'red'
-              ? 'text-red-500 fill-red-500'
-              : statusColor === 'gray'
-              ? 'text-gray-400 fill-gray-400'
-              : 'text-blue-500 fill-blue-500'
+                ? 'text-amber-token fill-amber-token'
+                : statusColor === 'red'
+                  ? 'text-vermillion fill-vermillion'
+                  : statusColor === 'gray'
+                    ? 'text-ink-4 fill-ink-4'
+                    : 'text-ds-accent fill-ds-accent'
           } ${isActive ? 'animate-pulse' : ''}`}
         />
         <Badge variant={getStatusVariant(bot.status)} className="text-xs">
@@ -112,14 +112,14 @@ export function BotStatus({ bot, onStop, compact = false }: BotStatusProps) {
             <Circle
               className={`w-3 h-3 ${
                 statusColor === 'green'
-                  ? 'text-green-500 fill-green-500'
+                  ? 'text-forest fill-forest'
                   : statusColor === 'yellow'
-                  ? 'text-yellow-500 fill-yellow-500'
-                  : statusColor === 'red'
-                  ? 'text-red-500 fill-red-500'
-                  : statusColor === 'gray'
-                  ? 'text-gray-400 fill-gray-400'
-                  : 'text-blue-500 fill-blue-500'
+                    ? 'text-amber-token fill-amber-token'
+                    : statusColor === 'red'
+                      ? 'text-vermillion fill-vermillion'
+                      : statusColor === 'gray'
+                        ? 'text-ink-4 fill-ink-4'
+                        : 'text-ds-accent fill-ds-accent'
               } ${isActive ? 'animate-pulse' : ''}`}
             />
           </div>

--- a/src/components/meeting/client-meeting-link.tsx
+++ b/src/components/meeting/client-meeting-link.tsx
@@ -82,12 +82,7 @@ export function ClientMeetingLink({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled
-              className="text-gray-400"
-            >
+            <Button variant="outline" size="sm" disabled className="text-ink-4">
               <UserPlus className="h-4 w-4 mr-2" />
               Share with Client
             </Button>
@@ -119,7 +114,7 @@ export function ClientMeetingLink({
             <Button
               variant="outline"
               size="sm"
-              className="text-red-500 border-red-200"
+              className="text-vermillion border-vermillion"
             >
               <Link2 className="h-4 w-4 mr-2" />
               Link Error
@@ -149,7 +144,7 @@ export function ClientMeetingLink({
             variant="outline"
             size="sm"
             onClick={handleCopy}
-            className={hasCopied ? 'border-green-300 text-green-600' : ''}
+            className={hasCopied ? 'border-forest text-forest' : ''}
           >
             {hasCopied ? (
               <>

--- a/src/components/meeting/client-profile-card.tsx
+++ b/src/components/meeting/client-profile-card.tsx
@@ -79,7 +79,7 @@ export function ClientProfileCard({
     return (
       <Card className={compact ? 'h-auto border-0 shadow-none' : 'h-full'}>
         <CardContent className={compact ? 'p-0' : 'pt-4'}>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-ink-3 ">
             Profile will build as sessions are analyzed.
           </p>
         </CardContent>
@@ -106,17 +106,16 @@ export function ClientProfileCard({
   }
 
   const getBreakthroughColor = (potential: string) => {
-    if (potential?.includes('High'))
-      return 'text-green-600 bg-green-50 dark:text-green-400 dark:bg-green-900/30'
+    if (potential?.includes('High')) return 'text-forest bg-forest-bg '
     if (potential?.includes('Emerging'))
-      return 'text-yellow-600 bg-yellow-50 dark:text-yellow-400 dark:bg-yellow-900/30'
-    return 'text-gray-600 bg-gray-50 dark:text-gray-400 dark:bg-gray-800'
+      return 'text-amber-token bg-amber-token-bg '
+    return 'text-ink-3 bg-paper '
   }
 
   return (
     <Card className="h-auto">
       <CardHeader
-        className={`${compact ? 'pb-2 py-2' : 'pb-3'} cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors`}
+        className={`${compact ? 'pb-2 py-2' : 'pb-3'} cursor-pointer hover:bg-paper transition-colors`}
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <div className="flex items-center justify-between">
@@ -129,9 +128,7 @@ export function ClientProfileCard({
           >
             <User
               className={
-                compact
-                  ? 'h-3 w-3 text-gray-500 dark:text-gray-400'
-                  : 'h-4 w-4 text-gray-500 dark:text-gray-400'
+                compact ? 'h-3 w-3 text-ink-3 ' : 'h-4 w-4 text-ink-3 '
               }
             />
             Client Profile
@@ -143,9 +140,9 @@ export function ClientProfileCard({
           </h3>
           <div className="flex items-center gap-2">
             {isExpanded ? (
-              <ChevronUp className="h-3 w-3 text-gray-400 dark:text-gray-500" />
+              <ChevronUp className="h-3 w-3 text-ink-4 " />
             ) : (
-              <ChevronDown className="h-3 w-3 text-gray-400 dark:text-gray-500" />
+              <ChevronDown className="h-3 w-3 text-ink-4 " />
             )}
           </div>
         </div>
@@ -155,7 +152,7 @@ export function ClientProfileCard({
             {summaryItems.map((item, i) => (
               <span
                 key={i}
-                className="text-xs text-gray-500 truncate max-w-[150px]"
+                className="text-xs text-ink-3 truncate max-w-[150px]"
               >
                 {i > 0 && ' • '}
                 {item}
@@ -164,7 +161,7 @@ export function ClientProfileCard({
           </div>
         )}
         {!isExpanded && summaryItems.length === 0 && (
-          <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
+          <p className="mt-1.5 text-xs text-ink-4 ">
             Expand to see profile details
           </p>
         )}
@@ -175,17 +172,15 @@ export function ClientProfileCard({
           {insights?.client_journey && !compact && (
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                <span className="text-xs font-medium text-ink-2 ">
                   Journey Stage
                 </span>
-                <span className="text-xs text-gray-500 dark:text-gray-400">
+                <span className="text-xs text-ink-3 ">
                   {getJourneyProgress()}%
                 </span>
               </div>
               <Progress value={getJourneyProgress()} className="h-1.5" />
-              <p className="text-xs text-gray-600 dark:text-gray-400">
-                {insights.client_journey}
-              </p>
+              <p className="text-xs text-ink-3 ">{insights.client_journey}</p>
             </div>
           )}
 
@@ -194,8 +189,8 @@ export function ClientProfileCard({
             {profile.communication_style && (
               <div className="space-y-1">
                 <div className="flex items-center gap-1">
-                  <MessageSquare className="h-3 w-3 text-gray-400 dark:text-gray-500" />
-                  <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                  <MessageSquare className="h-3 w-3 text-ink-4 " />
+                  <span className="text-xs font-medium text-ink-2 ">
                     Communication
                   </span>
                 </div>
@@ -210,8 +205,8 @@ export function ClientProfileCard({
             {profile.learning_style && (
               <div className="space-y-1">
                 <div className="flex items-center gap-1">
-                  <Brain className="h-3 w-3 text-gray-400 dark:text-gray-500" />
-                  <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                  <Brain className="h-3 w-3 text-ink-4 " />
+                  <span className="text-xs font-medium text-ink-2 ">
                     Learning
                   </span>
                 </div>
@@ -231,32 +226,27 @@ export function ClientProfileCard({
             (profile.long_term_goals?.length ?? 0) > 0) && (
             <div className="space-y-2">
               <div className="flex items-center gap-1">
-                <Target className="h-3 w-3 text-green-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
-                  Vision
-                </span>
+                <Target className="h-3 w-3 text-forest" />
+                <span className="text-xs font-medium text-ink-2 ">Vision</span>
               </div>
               <div className="space-y-1">
                 {profile.primary_goals?.slice(0, 2).map((goal, i) => (
                   <div
                     key={i}
-                    className="text-xs text-gray-600 flex items-start gap-1"
+                    className="text-xs text-ink-3 flex items-start gap-1"
                   >
-                    <span className="text-green-500 mt-0.5">•</span>
+                    <span className="text-forest mt-0.5">•</span>
                     <span>{goal}</span>
                   </div>
                 ))}
                 {profile.short_term_goals?.slice(0, 1).map((goal, i) => (
                   <div
                     key={`st-${i}`}
-                    className="text-xs text-gray-600 flex items-start gap-1"
+                    className="text-xs text-ink-3 flex items-start gap-1"
                   >
-                    <span className="text-blue-500 mt-0.5">•</span>
+                    <span className="text-ds-accent mt-0.5">•</span>
                     <span>
-                      {goal}{' '}
-                      <span className="text-gray-400 dark:text-gray-500">
-                        (short-term)
-                      </span>
+                      {goal} <span className="text-ink-4 ">(short-term)</span>
                     </span>
                   </div>
                 ))}
@@ -269,8 +259,8 @@ export function ClientProfileCard({
             (profile.obstacles?.length ?? 0) > 0) && (
             <div className="space-y-2">
               <div className="flex items-center gap-1">
-                <AlertCircle className="h-3 w-3 text-orange-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                <AlertCircle className="h-3 w-3 text-amber-token" />
+                <span className="text-xs font-medium text-ink-2 ">
                   Current Challenges
                 </span>
               </div>
@@ -283,9 +273,9 @@ export function ClientProfileCard({
                   .map((challenge, i) => (
                     <div
                       key={i}
-                      className="text-xs text-gray-600 flex items-start gap-1"
+                      className="text-xs text-ink-3 flex items-start gap-1"
                     >
-                      <span className="text-orange-500 mt-0.5">•</span>
+                      <span className="text-amber-token mt-0.5">•</span>
                       <span>{challenge}</span>
                     </div>
                   ))}
@@ -297,8 +287,8 @@ export function ClientProfileCard({
           {(profile.strengths?.length ?? 0) > 0 && (
             <div className="space-y-2">
               <div className="flex items-center gap-1">
-                <Award className="h-3 w-3 text-purple-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                <Award className="h-3 w-3 text-indigo" />
+                <span className="text-xs font-medium text-ink-2 ">
                   Strengths
                 </span>
               </div>
@@ -306,7 +296,7 @@ export function ClientProfileCard({
                 {profile.strengths?.slice(0, 4).map((strength, i) => (
                   <Badge
                     key={i}
-                    className="text-xs bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800"
+                    className="text-xs bg-indigo-bg text-indigo border-indigo "
                   >
                     {strength}
                   </Badge>
@@ -320,8 +310,8 @@ export function ClientProfileCard({
             (insights?.suggested_focus?.length ?? 0) > 0) && (
             <div className="space-y-2">
               <div className="flex items-center gap-1">
-                <TrendingUp className="h-3 w-3 text-blue-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                <TrendingUp className="h-3 w-3 text-ds-accent" />
+                <span className="text-xs font-medium text-ink-2 ">
                   Focus Areas
                 </span>
               </div>
@@ -341,8 +331,8 @@ export function ClientProfileCard({
           {insights?.breakthrough_potential && (
             <div className="space-y-1">
               <div className="flex items-center gap-1">
-                <Sparkles className="h-3 w-3 text-yellow-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                <Sparkles className="h-3 w-3 text-amber-token" />
+                <span className="text-xs font-medium text-ink-2 ">
                   Breakthrough Potential
                 </span>
               </div>
@@ -357,7 +347,7 @@ export function ClientProfileCard({
           {/* Recurring Themes */}
           {(profile.recurring_themes?.length ?? 0) > 0 && (
             <div className="space-y-2">
-              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              <span className="text-xs font-medium text-ink-2 ">
                 Recurring Themes
               </span>
               <div className="flex flex-wrap gap-1">
@@ -375,7 +365,7 @@ export function ClientProfileCard({
             <div className="space-y-2 border-t pt-2">
               <div className="flex items-center gap-1">
                 <Award className="h-3 w-3 text-gold-500" />
-                <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                <span className="text-xs font-medium text-ink-2 ">
                   Recent Achievements
                 </span>
               </div>
@@ -383,9 +373,9 @@ export function ClientProfileCard({
                 {profile.achievements?.slice(0, 2).map((achievement, i) => (
                   <div
                     key={i}
-                    className="text-xs text-gray-600 flex items-start gap-1"
+                    className="text-xs text-ink-3 flex items-start gap-1"
                   >
-                    <span className="text-yellow-500">★</span>
+                    <span className="text-amber-token">★</span>
                     <span>{achievement}</span>
                   </div>
                 ))}

--- a/src/components/meeting/coaching-panel.tsx
+++ b/src/components/meeting/coaching-panel.tsx
@@ -164,13 +164,13 @@ export function CoachingPanel({
 
   if (error && error.includes('OpenAI API key')) {
     return (
-      <Card className={cn(className, 'dark:bg-gray-800 dark:border-gray-700')}>
+      <Card className={cn(className, '')}>
         <CardContent className="p-6 text-center">
-          <AlertCircle className="h-8 w-8 text-yellow-500 mx-auto mb-4" />
-          <h3 className="text-lg font-semibold mb-2 dark:text-white">
+          <AlertCircle className="h-8 w-8 text-amber-token mx-auto mb-4" />
+          <h3 className="text-lg font-semibold mb-2 ">
             OpenAI Configuration Required
           </h3>
-          <p className="text-gray-600 dark:text-gray-400 text-sm">
+          <p className="text-ink-3 text-sm">
             Add your OPENAI_API_KEY to the .env.local file to enable coaching
             analysis.
           </p>
@@ -183,42 +183,41 @@ export function CoachingPanel({
     switch (priority) {
       case 'high':
         return {
-          bg: 'bg-white dark:bg-gray-800',
-          border: 'border-gray-200 dark:border-gray-700',
-          accentBg: 'bg-gray-800 dark:bg-gray-200',
-          accentText: 'text-gray-800 dark:text-gray-200',
-          badge: 'bg-gray-900 text-white dark:bg-gray-200 dark:text-gray-900',
+          bg: 'bg-surface-1 ',
+          border: 'border-line ',
+          accentBg: 'bg-ink-2 ',
+          accentText: 'text-ink-2 ',
+          badge: 'bg-ink text-ink-on-dark ',
           icon: Zap,
           label: 'Act Now',
         }
       case 'medium':
         return {
-          bg: 'bg-white dark:bg-gray-800',
-          border: 'border-gray-200 dark:border-gray-700',
-          accentBg: 'bg-gray-600 dark:bg-gray-400',
-          accentText: 'text-gray-700 dark:text-gray-300',
-          badge:
-            'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+          bg: 'bg-surface-1 ',
+          border: 'border-line ',
+          accentBg: 'bg-ink-3 ',
+          accentText: 'text-ink-2 ',
+          badge: 'bg-surface-3 text-ink-2 ',
           icon: MessageCircle,
           label: 'Consider',
         }
       case 'low':
         return {
-          bg: 'bg-white dark:bg-gray-800',
-          border: 'border-gray-200 dark:border-gray-700',
-          accentBg: 'bg-gray-400 dark:bg-gray-500',
-          accentText: 'text-gray-600 dark:text-gray-400',
-          badge: 'bg-gray-50 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+          bg: 'bg-surface-1 ',
+          border: 'border-line ',
+          accentBg: 'bg-line ',
+          accentText: 'text-ink-3 ',
+          badge: 'bg-paper text-ink-3 ',
           icon: Lightbulb,
           label: 'Idea',
         }
       default:
         return {
-          bg: 'bg-white dark:bg-gray-800',
-          border: 'border-gray-200 dark:border-gray-700',
-          accentBg: 'bg-gray-400 dark:bg-gray-500',
-          accentText: 'text-gray-600 dark:text-gray-400',
-          badge: 'bg-gray-50 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+          bg: 'bg-surface-1 ',
+          border: 'border-line ',
+          accentBg: 'bg-line ',
+          accentText: 'text-ink-3 ',
+          badge: 'bg-paper text-ink-3 ',
           icon: Lightbulb,
           label: 'Tip',
         }
@@ -231,31 +230,27 @@ export function CoachingPanel({
       case 'immediate':
         return {
           label: 'Use now',
-          color:
-            'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+          color: 'bg-surface-3 text-ink-2 ',
         }
       case 'next_pause':
         return {
           label: 'Next pause',
-          color:
-            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+          color: 'bg-surface-3 text-ink-3 ',
         }
       case 'next_exchange':
         return {
           label: 'Next exchange',
-          color:
-            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+          color: 'bg-surface-3 text-ink-3 ',
         }
       case 'end_of_call':
         return {
           label: 'End of call',
-          color:
-            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+          color: 'bg-surface-3 text-ink-3 ',
         }
       case 'wait':
         return {
           label: 'When ready',
-          color: 'bg-gray-50 text-gray-500 dark:bg-gray-700 dark:text-gray-500',
+          color: 'bg-paper text-ink-3 ',
         }
       default:
         return null
@@ -266,25 +261,23 @@ export function CoachingPanel({
 
   return (
     <div className={cn('flex flex-col h-full', className)}>
-      <Card className="h-full flex flex-col bg-white dark:bg-gray-800 border-0 shadow-sm overflow-hidden">
+      <Card className="h-full flex flex-col bg-surface-1 border-0 shadow-sm overflow-hidden">
         {/* Header */}
-        <div className="px-4 py-3 flex-shrink-0 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+        <div className="px-4 py-3 flex-shrink-0 border-b border-line flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-            <span className="text-sm font-semibold text-gray-900 dark:text-white">
-              AI Coach
-            </span>
+            <Sparkles className="h-4 w-4 text-ink-2 " />
+            <span className="text-sm font-semibold text-ink ">AI Coach</span>
           </div>
           {isConnected ? (
-            <span className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+            <span className="flex items-center gap-1.5 text-xs text-ink-3 ">
               <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-green-500"></span>
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-forest opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-forest"></span>
               </span>
               Live
             </span>
           ) : (
-            <span className="text-xs text-gray-400">Connecting...</span>
+            <span className="text-xs text-ink-4">Connecting...</span>
           )}
         </div>
 
@@ -295,13 +288,13 @@ export function CoachingPanel({
               {loading && (
                 <div className="flex flex-col items-center justify-center py-12">
                   <div className="relative">
-                    <div className="w-16 h-16 border-4 border-gray-200 dark:border-gray-600 rounded-full" />
-                    <div className="absolute inset-0 w-16 h-16 border-4 border-gray-800 dark:border-gray-200 border-t-transparent rounded-full animate-spin" />
+                    <div className="w-16 h-16 border-4 border-line rounded-full" />
+                    <div className="absolute inset-0 w-16 h-16 border-4 border-line border-t-transparent rounded-full animate-spin" />
                   </div>
-                  <p className="mt-4 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  <p className="mt-4 text-sm font-semibold text-ink-2 ">
                     Analyzing conversation...
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-xs text-ink-3 mt-1">
                     This takes about 30 seconds
                   </p>
                 </div>
@@ -309,16 +302,14 @@ export function CoachingPanel({
 
               {/* Error State */}
               {error && (
-                <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-xl p-4">
+                <div className="bg-vermillion-bg border border-vermillion rounded-xl p-4">
                   <div className="flex items-start gap-3">
-                    <AlertCircle className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5" />
+                    <AlertCircle className="h-5 w-5 text-vermillion flex-shrink-0 mt-0.5" />
                     <div>
-                      <p className="text-sm font-semibold text-red-800 dark:text-red-300">
+                      <p className="text-sm font-semibold text-vermillion ">
                         Analysis Error
                       </p>
-                      <p className="text-sm text-red-600 dark:text-red-400 mt-1">
-                        {error}
-                      </p>
+                      <p className="text-sm text-vermillion mt-1">{error}</p>
                     </div>
                   </div>
                 </div>
@@ -327,21 +318,21 @@ export function CoachingPanel({
               {/* Empty State */}
               {allSuggestions.length === 0 && !loading && !error && (
                 <div className="flex flex-col items-center justify-center py-12 px-6">
-                  <div className="w-20 h-20 bg-gray-100 dark:bg-gray-700 rounded-3xl flex items-center justify-center mb-5">
-                    <Lightbulb className="h-10 w-10 text-gray-600 dark:text-gray-400" />
+                  <div className="w-20 h-20 bg-surface-3 rounded-3xl flex items-center justify-center mb-5">
+                    <Lightbulb className="h-10 w-10 text-ink-3 " />
                   </div>
-                  <h3 className="text-base font-bold text-gray-900 dark:text-white mb-2">
+                  <h3 className="text-base font-bold text-ink mb-2">
                     {waitingForSuggestions
                       ? 'Listening...'
                       : 'Ready for insights'}
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 text-center max-w-[240px] leading-relaxed">
+                  <p className="text-sm text-ink-3 text-center max-w-[240px] leading-relaxed">
                     {waitingForSuggestions
                       ? 'AI-powered coaching suggestions will appear as the conversation unfolds'
                       : 'Continue the conversation to receive personalized coaching tips'}
                   </p>
                   {waitingForSuggestions && (
-                    <div className="flex items-center gap-2 mt-5 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 px-4 py-2 rounded-full font-medium">
+                    <div className="flex items-center gap-2 mt-5 text-sm text-ink-2 bg-surface-3 px-4 py-2 rounded-full font-medium">
                       <Clock className="h-4 w-4" />
                       Updates every 30-60s
                     </div>
@@ -354,11 +345,11 @@ export function CoachingPanel({
                 <div className="mb-4">
                   <button
                     onClick={() => setPinnedSectionOpen(!pinnedSectionOpen)}
-                    className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
+                    className="w-full flex items-center justify-between px-3 py-2 bg-paper border border-line rounded-lg hover:bg-surface-3 transition-colors"
                   >
                     <div className="flex items-center gap-2">
-                      <Pin className="h-3.5 w-3.5 text-gray-600 dark:text-gray-400" />
-                      <span className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                      <Pin className="h-3.5 w-3.5 text-ink-3 " />
+                      <span className="text-sm font-semibold text-ink-2 ">
                         Pinned ({pinnedCount})
                       </span>
                     </div>
@@ -370,14 +361,14 @@ export function CoachingPanel({
                           e.stopPropagation()
                           clearAllPinned()
                         }}
-                        className="h-6 px-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        className="h-6 px-2 text-xs text-ink-3 hover:text-ink-2 hover:bg-surface-3 "
                       >
                         Clear all
                       </Button>
                       {pinnedSectionOpen ? (
-                        <ChevronUp className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                        <ChevronUp className="h-4 w-4 text-ink-3 " />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                        <ChevronDown className="h-4 w-4 text-ink-3 " />
                       )}
                     </div>
                   </button>
@@ -387,7 +378,7 @@ export function CoachingPanel({
                       {pinnedSuggestions.map(pinned => (
                         <div
                           key={pinned.id}
-                          className="relative flex items-start gap-2 p-3 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl group"
+                          className="relative flex items-start gap-2 p-3 bg-paper border border-line rounded-xl group"
                         >
                           {pinned.go_live_emoji && (
                             <span className="text-lg flex-shrink-0">
@@ -395,11 +386,11 @@ export function CoachingPanel({
                             </span>
                           )}
                           <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium text-gray-800 dark:text-gray-200 leading-relaxed">
+                            <p className="text-sm font-medium text-ink-2 leading-relaxed">
                               {pinned.suggestion}
                             </p>
                             {pinned.go_live_value && (
-                              <span className="inline-block mt-1 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded">
+                              <span className="inline-block mt-1 px-2 py-0.5 text-xs font-medium bg-surface-3 text-ink-2 rounded">
                                 {pinned.go_live_value}
                               </span>
                             )}
@@ -408,7 +399,7 @@ export function CoachingPanel({
                             variant="ghost"
                             size="sm"
                             onClick={() => unpinSuggestion(pinned.id)}
-                            className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 flex-shrink-0"
+                            className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity text-ink-4 hover:text-vermillion hover:bg-vermillion-bg flex-shrink-0"
                           >
                             <X className="h-3.5 w-3.5" />
                           </Button>
@@ -464,7 +455,7 @@ export function CoachingPanel({
                               </span>
                               {'go_live_value' in suggestion &&
                                 suggestion.go_live_value && (
-                                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-white/80 dark:bg-gray-700/80 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600">
+                                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-surface-1/80 text-ink-2 border border-line ">
                                     {suggestion.go_live_value}
                                   </span>
                                 )}
@@ -494,8 +485,8 @@ export function CoachingPanel({
                                 className={cn(
                                   'h-7 w-7 p-0 rounded-full transition-all',
                                   isPinned(suggestion.id)
-                                    ? 'text-gray-700 bg-gray-200 hover:bg-gray-300'
-                                    : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100',
+                                    ? 'text-ink-2 bg-surface-3 hover:bg-line'
+                                    : 'text-ink-4 hover:text-ink-3 hover:bg-surface-3',
                                 )}
                                 title={
                                   isPinned(suggestion.id)
@@ -526,12 +517,12 @@ export function CoachingPanel({
                                   config.accentBg,
                                 )}
                               >
-                                <ArrowRight className="h-5 w-5 text-white" />
+                                <ArrowRight className="h-5 w-5 text-ink-on-dark" />
                               </div>
                             )}
 
                             <div className="flex-1 min-w-0">
-                              <p className="text-base font-semibold text-gray-900 dark:text-white leading-relaxed">
+                              <p className="text-base font-semibold text-ink leading-relaxed">
                                 {suggestion.suggestion ||
                                   ('content' in suggestion
                                     ? (suggestion as any).content
@@ -542,7 +533,7 @@ export function CoachingPanel({
                               {!simplified &&
                                 'rationale' in suggestion &&
                                 suggestion.rationale && (
-                                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-2 leading-relaxed">
+                                  <p className="text-sm text-ink-3 mt-2 leading-relaxed">
                                     {suggestion.rationale}
                                   </p>
                                 )}
@@ -551,12 +542,12 @@ export function CoachingPanel({
 
                           {/* Confidence indicator */}
                           {!simplified && suggestion.confidence && (
-                            <div className="mt-4 pt-3 border-t border-gray-200/50 dark:border-gray-600/50">
+                            <div className="mt-4 pt-3 border-t border-line/50 ">
                               <div className="flex items-center gap-3">
-                                <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                                <span className="text-xs font-medium text-ink-3 ">
                                   Confidence
                                 </span>
-                                <div className="flex-1 h-2 bg-white/80 dark:bg-gray-700/80 rounded-full overflow-hidden">
+                                <div className="flex-1 h-2 bg-surface-1/80 rounded-full overflow-hidden">
                                   <div
                                     className={cn(
                                       'h-full rounded-full transition-all duration-500',
@@ -567,7 +558,7 @@ export function CoachingPanel({
                                     }}
                                   />
                                 </div>
-                                <span className="text-xs font-bold text-gray-700 dark:text-gray-300">
+                                <span className="text-xs font-bold text-ink-2 ">
                                   {Math.round(suggestion.confidence * 100)}%
                                 </span>
                               </div>

--- a/src/components/meeting/meeting-error.tsx
+++ b/src/components/meeting/meeting-error.tsx
@@ -10,14 +10,14 @@ export function MeetingError({ error }: MeetingErrorProps) {
   const router = useRouter()
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="max-w-md mx-auto bg-white rounded-lg shadow-lg p-6">
+    <div className="min-h-screen bg-paper flex items-center justify-center">
+      <div className="max-w-md mx-auto bg-surface-1 rounded-lg shadow-lg p-6">
         <div className="text-center">
-          <div className="text-red-600 text-6xl mb-4">⚠️</div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          <div className="text-vermillion text-6xl mb-4">⚠️</div>
+          <h2 className="text-xl font-semibold text-ink mb-2">
             Configuration Error
           </h2>
-          <p className="text-gray-600 mb-4">{error}</p>
+          <p className="text-ink-3 mb-4">{error}</p>
           <Button onClick={() => router.push('/')} className="w-full">
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back to Dashboard

--- a/src/components/meeting/meeting-form-simple.tsx
+++ b/src/components/meeting/meeting-form-simple.tsx
@@ -67,14 +67,14 @@ export function MeetingFormSimple({
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           {preselectedClientId && !showClientSelector ? (
-            <div className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-md bg-neutral-50 dark:bg-neutral-800 flex items-center justify-between">
-              <span className="font-medium text-neutral-900 dark:text-white">
+            <div className="w-full px-3 py-2 border border-line rounded-md bg-paper flex items-center justify-between">
+              <span className="font-medium text-ink ">
                 {preselectedClientName || 'Selected client'}
               </span>
               <button
                 type="button"
                 onClick={() => setShowClientSelector(true)}
-                className="text-xs text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300 underline"
+                className="text-xs text-ink-3 hover:text-ink-2 underline"
               >
                 Change
               </button>
@@ -91,7 +91,7 @@ export function MeetingFormSimple({
         </div>
 
         <div className="relative">
-          <Link className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Link className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-4" />
           <Input
             type="url"
             value={meetingUrl}
@@ -107,7 +107,7 @@ export function MeetingFormSimple({
           disabled={
             loading || !meetingUrl.trim() || !validateUrl(meetingUrl.trim())
           }
-          className="w-full bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+          className="w-full bg-ink hover:bg-ink-2 text-ink-on-dark "
         >
           {loading ? (
             <>
@@ -119,7 +119,7 @@ export function MeetingFormSimple({
           )}
         </Button>
 
-        <p className="text-xs text-center text-gray-500">
+        <p className="text-xs text-center text-ink-3">
           Works with Zoom, Google Meet, and Teams
         </p>
       </form>

--- a/src/components/meeting/meeting-loading.tsx
+++ b/src/components/meeting/meeting-loading.tsx
@@ -1,9 +1,9 @@
 export function MeetingLoading() {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+    <div className="min-h-screen bg-paper flex items-center justify-center">
       <div className="text-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto"></div>
-        <p className="mt-4 text-gray-600">Loading meeting data...</p>
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-ds-accent mx-auto"></div>
+        <p className="mt-4 text-ink-3">Loading meeting data...</p>
       </div>
     </div>
   )

--- a/src/components/meeting/pattern-insights-card.tsx
+++ b/src/components/meeting/pattern-insights-card.tsx
@@ -45,27 +45,27 @@ export function PatternInsightsCard({
   const getPatternIcon = (pattern: string) => {
     const patternLower = pattern.toLowerCase()
     if (patternLower.includes('breakthrough'))
-      return <Zap className="h-3 w-3 text-green-500" />
+      return <Zap className="h-3 w-3 text-forest" />
     if (patternLower.includes('resistance'))
-      return <AlertTriangle className="h-3 w-3 text-orange-500" />
+      return <AlertTriangle className="h-3 w-3 text-amber-token" />
     if (patternLower.includes('engagement') || patternLower.includes('engaged'))
-      return <CheckCircle className="h-3 w-3 text-blue-500" />
+      return <CheckCircle className="h-3 w-3 text-ds-accent" />
     if (patternLower.includes('avoidance'))
-      return <TrendingDown className="h-3 w-3 text-red-500" />
-    return <Activity className="h-3 w-3 text-gray-500" />
+      return <TrendingDown className="h-3 w-3 text-vermillion" />
+    return <Activity className="h-3 w-3 text-ink-3" />
   }
 
   const getPatternColor = (pattern: string) => {
     const patternLower = pattern.toLowerCase()
     if (patternLower.includes('breakthrough'))
-      return 'bg-green-50 text-green-700 border-green-200'
+      return 'bg-forest-bg text-forest border-forest'
     if (patternLower.includes('resistance'))
-      return 'bg-orange-50 text-orange-700 border-orange-200'
+      return 'bg-amber-token-bg text-amber-token border-amber-token'
     if (patternLower.includes('engagement') || patternLower.includes('engaged'))
-      return 'bg-blue-50 text-blue-700 border-blue-200'
+      return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
     if (patternLower.includes('avoidance'))
-      return 'bg-red-50 text-red-700 border-red-200'
-    return 'bg-gray-50 text-gray-700 border-gray-200'
+      return 'bg-vermillion-bg text-vermillion border-vermillion'
+    return 'bg-paper text-ink-2 border-line'
   }
 
   const getThemeSize = (count: number) => {
@@ -87,7 +87,7 @@ export function PatternInsightsCard({
     return (
       <Card className={compact ? 'h-auto border-0 shadow-none' : 'h-full'}>
         <CardContent className={compact ? 'p-0' : 'pt-4'}>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-ink-3">
             Patterns will emerge as the conversation develops.
           </p>
         </CardContent>
@@ -111,7 +111,7 @@ export function PatternInsightsCard({
         {/* Active Patterns */}
         {hasPatterns && (
           <div className="space-y-1.5">
-            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <span className="text-xs font-medium text-ink-3 uppercase tracking-wider">
               Active
             </span>
             <div className="flex flex-wrap gap-1.5">
@@ -131,21 +131,21 @@ export function PatternInsightsCard({
         {/* Pattern Timeline (non-compact only) */}
         {hasHistory && !compact && (
           <div className="space-y-2">
-            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <span className="text-xs font-medium text-ink-3 uppercase tracking-wider">
               History
             </span>
             <div className="space-y-1.5">
               {(patternHistory || []).slice(0, 3).map((history, i) => (
                 <div key={i} className="flex items-center gap-2 text-xs">
-                  <span className="text-gray-400 w-16 flex-shrink-0 text-right">
+                  <span className="text-ink-4 w-16 flex-shrink-0 text-right">
                     {getTimeAgo(new Date(history.date))}
                   </span>
-                  <div className="w-px h-4 bg-gray-200 dark:bg-gray-600" />
+                  <div className="w-px h-4 bg-surface-3 " />
                   <div className="flex flex-wrap gap-1">
                     {history.patterns.slice(0, 3).map((pattern, j) => (
                       <span
                         key={j}
-                        className="flex items-center gap-1 text-gray-600 dark:text-gray-400"
+                        className="flex items-center gap-1 text-ink-3 "
                       >
                         {getPatternIcon(pattern)}
                         {formatPatternName(pattern)}
@@ -161,20 +161,18 @@ export function PatternInsightsCard({
         {/* Recurring Themes */}
         {hasThemes && (
           <div className="space-y-1.5">
-            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <span className="text-xs font-medium text-ink-3 uppercase tracking-wider">
               Recurring Themes
             </span>
             <div className="flex flex-wrap gap-1.5">
               {(recurringThemes || []).map((theme, i) => (
                 <span
                   key={i}
-                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 ${getThemeSize(theme.count)}`}
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-surface-3 text-ink-2 ${getThemeSize(theme.count)}`}
                 >
                   {theme.theme}
                   {theme.count > 1 && (
-                    <span className="text-gray-400 dark:text-gray-500">
-                      x{theme.count}
-                    </span>
+                    <span className="text-ink-4 ">x{theme.count}</span>
                   )}
                 </span>
               ))}
@@ -184,17 +182,17 @@ export function PatternInsightsCard({
 
         {/* Pattern Summary (non-compact, 3+ history entries) */}
         {(patternHistory?.length ?? 0) > 2 && !compact && (
-          <div className="border-t dark:border-gray-700 pt-3">
+          <div className="border-t pt-3">
             <div className="grid grid-cols-2 gap-2">
-              <div className="text-center p-2 bg-gray-50 dark:bg-gray-700 rounded-lg">
-                <TrendingUp className="h-4 w-4 text-green-500 mx-auto mb-1" />
-                <p className="text-xs text-gray-600 dark:text-gray-400">
+              <div className="text-center p-2 bg-paper rounded-lg">
+                <TrendingUp className="h-4 w-4 text-forest mx-auto mb-1" />
+                <p className="text-xs text-ink-3 ">
                   {countPositivePatterns(patternHistory || [])} positive shifts
                 </p>
               </div>
-              <div className="text-center p-2 bg-gray-50 dark:bg-gray-700 rounded-lg">
-                <Activity className="h-4 w-4 text-blue-500 mx-auto mb-1" />
-                <p className="text-xs text-gray-600 dark:text-gray-400">
+              <div className="text-center p-2 bg-paper rounded-lg">
+                <Activity className="h-4 w-4 text-ds-accent mx-auto mb-1" />
+                <p className="text-xs text-ink-3 ">
                   {countUniquePatterns(patternHistory || [])} unique patterns
                 </p>
               </div>

--- a/src/components/meeting/pre-session-responses-compact.tsx
+++ b/src/components/meeting/pre-session-responses-compact.tsx
@@ -32,8 +32,8 @@ export function PreSessionResponsesCompact({
       <div className="p-4 space-y-3">
         {[0, 1, 2].map(i => (
           <div key={i} className="animate-pulse space-y-1.5">
-            <div className="h-2.5 bg-gray-200 dark:bg-gray-600 rounded w-3/4" />
-            <div className="h-2.5 bg-gray-200 dark:bg-gray-600 rounded w-1/2" />
+            <div className="h-2.5 bg-surface-3 rounded w-3/4" />
+            <div className="h-2.5 bg-surface-3 rounded w-1/2" />
           </div>
         ))}
       </div>
@@ -43,10 +43,10 @@ export function PreSessionResponsesCompact({
   if (!responses || responses.length === 0) {
     return (
       <div className="p-6 text-center">
-        <div className="w-10 h-10 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center mx-auto mb-3">
-          <ClipboardList className="h-5 w-5 text-gray-400" />
+        <div className="w-10 h-10 bg-surface-3 rounded-lg flex items-center justify-center mx-auto mb-3">
+          <ClipboardList className="h-5 w-5 text-ink-4" />
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        <p className="text-xs text-ink-3 mb-3">
           No pre-session responses for this session
         </p>
         {sessionId && clientId && (
@@ -58,7 +58,7 @@ export function PreSessionResponsesCompact({
               })
             }
             disabled={sendQuestionnaire.isPending}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 disabled:opacity-50 transition-colors"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-ink text-ink-on-dark hover:bg-ink-2 disabled:opacity-50 transition-colors"
           >
             {sendQuestionnaire.isPending ? (
               <>
@@ -94,20 +94,17 @@ export function PreSessionResponsesCompact({
             : qa.question_text
 
         return (
-          <div
-            key={idx}
-            className="p-2.5 rounded-lg bg-gray-50 dark:bg-gray-700/50"
-          >
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">
+          <div key={idx} className="p-2.5 rounded-lg bg-paper ">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-4 mb-1">
               {shortQuestion}
             </p>
-            <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed">
+            <p className="text-xs text-ink-2 leading-relaxed">
               {displayAnswer}
             </p>
             {isLong && (
               <button
                 onClick={() => setExpandedIndex(isExpanded ? null : idx)}
-                className="flex items-center gap-0.5 text-[10px] text-gray-400 hover:text-gray-600 mt-1 transition-colors"
+                className="flex items-center gap-0.5 text-[10px] text-ink-4 hover:text-ink-3 mt-1 transition-colors"
               >
                 {isExpanded ? (
                   <>

--- a/src/components/meeting/similar-sessions-card.tsx
+++ b/src/components/meeting/similar-sessions-card.tsx
@@ -65,15 +65,15 @@ export function SimilarSessionsCard({
   } | null>(null)
 
   const getMatchColor = (certainty: number) => {
-    if (certainty >= 0.85) return 'from-emerald-500 to-green-600'
-    if (certainty >= 0.75) return 'from-amber-500 to-yellow-600'
-    return 'from-gray-400 to-gray-500'
+    if (certainty >= 0.85) return ''
+    if (certainty >= 0.75) return ''
+    return ''
   }
 
   const getMatchBgColor = (certainty: number) => {
-    if (certainty >= 0.85) return 'bg-emerald-50 border-emerald-200'
-    if (certainty >= 0.75) return 'bg-amber-50 border-amber-200'
-    return 'bg-gray-50 border-gray-200'
+    if (certainty >= 0.85) return 'bg-forest-bg border-forest'
+    if (certainty >= 0.75) return 'bg-amber-token-bg border-amber-token'
+    return 'bg-paper border-line'
   }
 
   const getSentimentEmoji = (sentiment?: string) => {
@@ -121,20 +121,20 @@ export function SimilarSessionsCard({
         {!compact && (
           <CardHeader className="pb-3">
             <h3 className="text-sm font-medium flex items-center gap-2">
-              <Clock className="h-4 w-4 text-gray-500" />
+              <Clock className="h-4 w-4 text-ink-3" />
               Similar Past Sessions
             </h3>
           </CardHeader>
         )}
         <CardContent className={compact ? 'p-0' : ''}>
           <div className="text-center py-6">
-            <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-3">
-              <Clock className="h-6 w-6 text-gray-400" />
+            <div className="w-12 h-12 rounded-full bg-surface-3 flex items-center justify-center mx-auto mb-3">
+              <Clock className="h-6 w-6 text-ink-4" />
             </div>
-            <p className="text-sm text-gray-500 font-medium">
+            <p className="text-sm text-ink-3 font-medium">
               No similar sessions yet
             </p>
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="text-xs text-ink-4 mt-1">
               Continue the conversation to build history
             </p>
           </div>
@@ -151,7 +151,7 @@ export function SimilarSessionsCard({
         {!compact && (
           <CardHeader className="pb-3">
             <h3 className="text-sm font-medium flex items-center gap-2">
-              <Clock className="h-4 w-4 text-gray-500" />
+              <Clock className="h-4 w-4 text-ink-3" />
               Similar Past Sessions
               <Badge variant="secondary" className="ml-auto text-xs">
                 {sessions.length} found
@@ -172,27 +172,27 @@ export function SimilarSessionsCard({
                 onClick={() => setSelectedSession({ session, summary })}
                 className={`
                   group relative cursor-pointer rounded-xl border transition-all duration-200
-                  hover:shadow-md hover:border-blue-200 hover:bg-blue-50/30
+                  hover:shadow-md hover:border-ds-accent hover:bg-ds-accent-bg/30
                   ${getMatchBgColor(session.certainty)}
                 `}
               >
                 {/* Match indicator bar */}
                 <div
-                  className={`absolute left-0 top-0 bottom-0 w-1 rounded-l-xl bg-gradient-to-b ${getMatchColor(session.certainty)}`}
+                  className={`absolute left-0 top-0 bottom-0 w-1 rounded-l-xl  ${getMatchColor(session.certainty)}`}
                 />
 
                 <div className="p-3 pl-4">
                   {/* Header row */}
                   <div className="flex items-start justify-between mb-2">
                     <div className="flex items-center gap-2">
-                      <div className="flex items-center gap-1.5 text-gray-600">
+                      <div className="flex items-center gap-1.5 text-ink-3">
                         <Calendar className="h-3.5 w-3.5" />
                         <span className="text-xs font-medium">
                           {formatDate(session.session_date)}
                         </span>
                       </div>
                       {session.duration_minutes && (
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-ink-4">
                           • {session.duration_minutes}m
                         </span>
                       )}
@@ -200,13 +200,13 @@ export function SimilarSessionsCard({
                     <div className="flex items-center gap-1.5">
                       <div
                         className={`
-                          px-2 py-0.5 rounded-full text-xs font-semibold text-white
-                          bg-gradient-to-r ${getMatchColor(session.certainty)}
+                          px-2 py-0.5 rounded-full text-xs font-semibold text-ink-on-dark
+                           ${getMatchColor(session.certainty)}
                         `}
                       >
                         {matchPercent}% match
                       </div>
-                      <ChevronRight className="h-4 w-4 text-gray-400 group-hover:text-blue-500 transition-colors" />
+                      <ChevronRight className="h-4 w-4 text-ink-4 group-hover:text-ds-accent transition-colors" />
                     </div>
                   </div>
 
@@ -219,13 +219,13 @@ export function SimilarSessionsCard({
                         .map((topic, i) => (
                           <span
                             key={i}
-                            className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-white/80 text-gray-700 border border-gray-200"
+                            className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-surface-1/80 text-ink-2 border border-line"
                           >
                             {topic}
                           </span>
                         ))}
                       {(session.key_topics || session.topics).length > 3 && (
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-ink-4">
                           +{(session.key_topics || session.topics).length - 3}{' '}
                           more
                         </span>
@@ -234,8 +234,8 @@ export function SimilarSessionsCard({
                   )}
 
                   {/* Relevance reason */}
-                  <p className="text-xs text-gray-600 line-clamp-2 leading-relaxed">
-                    <Sparkles className="h-3 w-3 inline mr-1 text-amber-500" />
+                  <p className="text-xs text-ink-3 line-clamp-2 leading-relaxed">
+                    <Sparkles className="h-3 w-3 inline mr-1 text-amber-token" />
                     {summary?.relevance_reason ||
                       session.relevance_reason ||
                       session.summary ||
@@ -243,23 +243,23 @@ export function SimilarSessionsCard({
                   </p>
 
                   {/* Quick stats row */}
-                  <div className="flex items-center gap-3 mt-2 pt-2 border-t border-gray-200/50">
+                  <div className="flex items-center gap-3 mt-2 pt-2 border-t border-line/50">
                     {session.action_items &&
                       session.action_items.length > 0 && (
-                        <span className="flex items-center gap-1 text-xs text-gray-500">
-                          <Target className="h-3 w-3 text-blue-500" />
+                        <span className="flex items-center gap-1 text-xs text-ink-3">
+                          <Target className="h-3 w-3 text-ds-accent" />
                           {session.action_items.length} commitments
                         </span>
                       )}
                     {session.sentiment && (
-                      <span className="flex items-center gap-1 text-xs text-gray-500">
+                      <span className="flex items-center gap-1 text-xs text-ink-3">
                         {getSentimentEmoji(session.sentiment)}{' '}
                         {session.sentiment}
                       </span>
                     )}
                     {summary?.key_points && summary.key_points.length > 0 && (
-                      <span className="flex items-center gap-1 text-xs text-gray-500">
-                        <Lightbulb className="h-3 w-3 text-amber-500" />
+                      <span className="flex items-center gap-1 text-xs text-ink-3">
+                        <Lightbulb className="h-3 w-3 text-amber-token" />
                         {summary.key_points.length} insights
                       </span>
                     )}
@@ -272,7 +272,7 @@ export function SimilarSessionsCard({
           {/* Show more indicator */}
           {compact && sessions.length > 3 && (
             <div className="text-center pt-1">
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-ink-4">
                 +{sessions.length - 3} more sessions
               </span>
             </div>
@@ -291,10 +291,10 @@ export function SimilarSessionsCard({
               <div
                 className={`
                   w-10 h-10 rounded-lg flex items-center justify-center
-                  bg-gradient-to-br ${selectedSession ? getMatchColor(selectedSession.session.certainty) : ''}
+                   ${selectedSession ? getMatchColor(selectedSession.session.certainty) : ''}
                 `}
               >
-                <Clock className="h-5 w-5 text-white" />
+                <Clock className="h-5 w-5 text-ink-on-dark" />
               </div>
               <div>
                 <div className="text-lg font-semibold">
@@ -303,7 +303,7 @@ export function SimilarSessionsCard({
                     ? formatFullDate(selectedSession.session.session_date)
                     : ''}
                 </div>
-                <div className="text-sm text-gray-500 font-normal flex items-center gap-2">
+                <div className="text-sm text-ink-3 font-normal flex items-center gap-2">
                   {selectedSession?.session.duration_minutes && (
                     <span>
                       {selectedSession.session.duration_minutes} minutes
@@ -311,7 +311,7 @@ export function SimilarSessionsCard({
                   )}
                   {selectedSession && (
                     <Badge
-                      className={`bg-gradient-to-r ${getMatchColor(selectedSession.session.certainty)} text-white border-0`}
+                      className={` ${getMatchColor(selectedSession.session.certainty)} text-ink-on-dark border-0`}
                     >
                       {Math.round(selectedSession.session.certainty * 100)}%
                       match
@@ -328,12 +328,12 @@ export function SimilarSessionsCard({
                 {/* Why this is relevant */}
                 {(selectedSession.summary?.relevance_reason ||
                   selectedSession.session.relevance_reason) && (
-                  <div className="bg-gradient-to-r from-amber-50 to-yellow-50 border border-amber-200 rounded-xl p-4">
-                    <h4 className="text-sm font-semibold text-amber-800 mb-2 flex items-center gap-2">
+                  <div className=" border border-amber-token rounded-xl p-4">
+                    <h4 className="text-sm font-semibold text-amber-token mb-2 flex items-center gap-2">
                       <Sparkles className="h-4 w-4" />
                       Why This Session is Relevant
                     </h4>
-                    <p className="text-sm text-amber-900">
+                    <p className="text-sm text-amber-token">
                       {selectedSession.summary?.relevance_reason ||
                         selectedSession.session.relevance_reason}
                     </p>
@@ -344,8 +344,8 @@ export function SimilarSessionsCard({
                 {((selectedSession.session.topics?.length ?? 0) > 0 ||
                   (selectedSession.session.key_topics?.length ?? 0) > 0) && (
                   <div>
-                    <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
-                      <MessageCircle className="h-4 w-4 text-gray-500" />
+                    <h4 className="text-sm font-semibold text-ink-2 mb-2 flex items-center gap-2">
+                      <MessageCircle className="h-4 w-4 text-ink-3" />
                       Topics Discussed
                     </h4>
                     <div className="flex flex-wrap gap-2">
@@ -369,22 +369,22 @@ export function SimilarSessionsCard({
                 {selectedSession.summary?.key_points &&
                   selectedSession.summary.key_points.length > 0 && (
                     <div>
-                      <h4 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-                        <Lightbulb className="h-4 w-4 text-amber-500" />
+                      <h4 className="text-sm font-semibold text-ink-2 mb-3 flex items-center gap-2">
+                        <Lightbulb className="h-4 w-4 text-amber-token" />
                         Key Insights
                       </h4>
                       <div className="space-y-2">
                         {selectedSession.summary.key_points.map((point, i) => (
                           <div
                             key={i}
-                            className="flex items-start gap-3 p-3 bg-gray-50 rounded-lg"
+                            className="flex items-start gap-3 p-3 bg-paper rounded-lg"
                           >
-                            <div className="w-6 h-6 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
-                              <span className="text-xs font-semibold text-amber-700">
+                            <div className="w-6 h-6 rounded-full bg-amber-token-bg flex items-center justify-center flex-shrink-0">
+                              <span className="text-xs font-semibold text-amber-token">
                                 {i + 1}
                               </span>
                             </div>
-                            <p className="text-sm text-gray-700">{point}</p>
+                            <p className="text-sm text-ink-2">{point}</p>
                           </div>
                         ))}
                       </div>
@@ -395,18 +395,18 @@ export function SimilarSessionsCard({
                 {selectedSession.session.action_items &&
                   selectedSession.session.action_items.length > 0 && (
                     <div>
-                      <h4 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-                        <Target className="h-4 w-4 text-blue-500" />
+                      <h4 className="text-sm font-semibold text-ink-2 mb-3 flex items-center gap-2">
+                        <Target className="h-4 w-4 text-ds-accent" />
                         Commitments from This Session
                       </h4>
                       <div className="space-y-2">
                         {selectedSession.session.action_items.map((item, i) => (
                           <div
                             key={i}
-                            className="flex items-start gap-3 p-3 bg-blue-50 border border-blue-100 rounded-lg"
+                            className="flex items-start gap-3 p-3 bg-ds-accent-bg border border-ds-accent rounded-lg"
                           >
-                            <TrendingUp className="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
-                            <p className="text-sm text-blue-900">
+                            <TrendingUp className="h-4 w-4 text-ds-accent mt-0.5 flex-shrink-0" />
+                            <p className="text-sm text-ds-accent">
                               {typeof item === 'string'
                                 ? item
                                 : (item as any).item ||
@@ -423,11 +423,11 @@ export function SimilarSessionsCard({
                 {(selectedSession.summary?.summary ||
                   selectedSession.session.summary) && (
                   <div>
-                    <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
-                      <MessageCircle className="h-4 w-4 text-gray-500" />
+                    <h4 className="text-sm font-semibold text-ink-2 mb-2 flex items-center gap-2">
+                      <MessageCircle className="h-4 w-4 text-ink-3" />
                       Session Summary
                     </h4>
-                    <p className="text-sm text-gray-600 bg-gray-50 p-4 rounded-lg leading-relaxed">
+                    <p className="text-sm text-ink-3 bg-paper p-4 rounded-lg leading-relaxed">
                       {selectedSession.summary?.summary ||
                         selectedSession.session.summary}
                     </p>
@@ -437,12 +437,12 @@ export function SimilarSessionsCard({
                 {/* Conversation Preview */}
                 {selectedSession.session.content_preview && (
                   <div>
-                    <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
-                      <MessageCircle className="h-4 w-4 text-gray-500" />
+                    <h4 className="text-sm font-semibold text-ink-2 mb-2 flex items-center gap-2">
+                      <MessageCircle className="h-4 w-4 text-ink-3" />
                       Conversation Preview
                     </h4>
-                    <div className="bg-gray-50 p-4 rounded-lg border border-gray-200">
-                      <p className="text-sm text-gray-600 italic leading-relaxed">
+                    <div className="bg-paper p-4 rounded-lg border border-line">
+                      <p className="text-sm text-ink-3 italic leading-relaxed">
                         &ldquo;{selectedSession.session.content_preview}&rdquo;
                       </p>
                     </div>
@@ -451,15 +451,15 @@ export function SimilarSessionsCard({
 
                 {/* Sentiment */}
                 {selectedSession.session.sentiment && (
-                  <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
+                  <div className="flex items-center gap-3 p-3 bg-paper rounded-lg">
                     <span className="text-2xl">
                       {getSentimentEmoji(selectedSession.session.sentiment)}
                     </span>
                     <div>
-                      <p className="text-sm font-medium text-gray-700">
+                      <p className="text-sm font-medium text-ink-2">
                         Session Sentiment
                       </p>
-                      <p className="text-sm text-gray-500">
+                      <p className="text-sm text-ink-3">
                         {selectedSession.session.sentiment}
                       </p>
                     </div>
@@ -472,7 +472,7 @@ export function SimilarSessionsCard({
                     href={`/sessions/${selectedSession.session.session_id}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center justify-center gap-2 w-full p-3 bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900 rounded-lg transition-colors"
+                    className="flex items-center justify-center gap-2 w-full p-3 bg-ink hover:bg-ink-2 text-ink-on-dark rounded-lg transition-colors"
                   >
                     <ExternalLink className="h-4 w-4" />
                     View Full Session Details

--- a/src/components/meeting/transcript-viewer.tsx
+++ b/src/components/meeting/transcript-viewer.tsx
@@ -58,20 +58,20 @@ export function TranscriptViewer({
     return (
       <>
         <div
-          className="h-full flex items-center gap-3 px-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
+          className="h-full flex items-center gap-3 px-4 bg-paper rounded-lg cursor-pointer hover:bg-surface-3 transition-colors"
           onClick={() => setShowFullTranscript(true)}
         >
           <div className="flex items-center gap-2 flex-shrink-0">
-            <MessageSquare className="h-4 w-4 text-gray-400" />
-            <span className="text-xs font-medium text-gray-500">
+            <MessageSquare className="h-4 w-4 text-ink-4" />
+            <span className="text-xs font-medium text-ink-3">
               {transcript.length} entries
             </span>
           </div>
 
-          <div className="h-4 w-px bg-gray-300" />
+          <div className="h-4 w-px bg-line" />
 
           {recentEntries.length === 0 ? (
-            <span className="text-xs text-gray-400 italic">
+            <span className="text-xs text-ink-4 italic">
               Waiting for conversation...
             </span>
           ) : (
@@ -80,19 +80,19 @@ export function TranscriptViewer({
                 <div
                   key={i}
                   className={`flex-shrink-0 max-w-[200px] px-2 py-1 rounded text-xs ${
-                    entry.is_final ? 'bg-white' : 'bg-blue-50'
+                    entry.is_final ? 'bg-surface-1' : 'bg-ds-accent-bg'
                   }`}
                 >
-                  <span className="font-medium text-gray-700">
+                  <span className="font-medium text-ink-2">
                     {entry.speaker}:
                   </span>{' '}
-                  <span className="text-gray-600 truncate">{entry.text}</span>
+                  <span className="text-ink-3 truncate">{entry.text}</span>
                 </div>
               ))}
             </div>
           )}
 
-          <ChevronRight className="h-4 w-4 text-gray-400 flex-shrink-0" />
+          <ChevronRight className="h-4 w-4 text-ink-4 flex-shrink-0" />
         </div>
 
         {/* Full Transcript Modal */}
@@ -110,11 +110,11 @@ export function TranscriptViewer({
                   <div
                     key={index}
                     className={`p-3 rounded-lg ${
-                      entry.is_final ? 'bg-gray-50' : 'bg-blue-50'
+                      entry.is_final ? 'bg-paper' : 'bg-ds-accent-bg'
                     }`}
                   >
                     <div className="flex items-center gap-2 mb-1">
-                      <span className="font-medium text-sm text-gray-700">
+                      <span className="font-medium text-sm text-ink-2">
                         {entry.speaker}
                       </span>
                       {!entry.is_final && (
@@ -125,11 +125,11 @@ export function TranscriptViewer({
                           Live
                         </Badge>
                       )}
-                      <span className="text-xs text-gray-400 ml-auto">
+                      <span className="text-xs text-ink-4 ml-auto">
                         {formatTime(entry.timestamp)}
                       </span>
                     </div>
-                    <p className="text-sm text-gray-700">{entry.text}</p>
+                    <p className="text-sm text-ink-2">{entry.text}</p>
                   </div>
                 ))}
               </div>
@@ -147,10 +147,8 @@ export function TranscriptViewer({
         <div ref={containerRef} className="p-3 space-y-2">
           {transcript.length === 0 ? (
             <div className="text-center py-8">
-              <div className="text-gray-400 text-lg mb-2">🎤</div>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">
-                Waiting for conversation...
-              </p>
+              <div className="text-ink-4 text-lg mb-2">🎤</div>
+              <p className="text-ink-3 text-sm">Waiting for conversation...</p>
             </div>
           ) : (
             transcript.map((entry, index) => (
@@ -158,12 +156,12 @@ export function TranscriptViewer({
                 key={index}
                 className={`p-2.5 rounded-lg transition-all duration-300 ${
                   entry.is_final
-                    ? 'bg-gray-50 dark:bg-gray-700 border border-gray-100 dark:border-gray-600'
-                    : 'bg-blue-50 dark:bg-blue-900/30 border border-blue-100 dark:border-blue-800'
+                    ? 'bg-paper border border-line '
+                    : 'bg-ds-accent-bg border border-ds-accent '
                 }`}
               >
                 <div className="flex items-center gap-2 mb-1">
-                  <span className="font-medium text-xs text-gray-700 dark:text-gray-300">
+                  <span className="font-medium text-xs text-ink-2 ">
                     {entry.speaker}
                   </span>
                   {!entry.is_final && (
@@ -174,11 +172,11 @@ export function TranscriptViewer({
                       Live
                     </Badge>
                   )}
-                  <span className="text-xs text-gray-400 ml-auto">
+                  <span className="text-xs text-ink-4 ml-auto">
                     {formatTime(entry.timestamp)}
                   </span>
                 </div>
-                <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed">
+                <p className="text-xs text-ink-2 leading-relaxed">
                   {entry.text}
                 </p>
               </div>
@@ -200,18 +198,14 @@ export function TranscriptViewer({
         <div
           className={
             mode === 'compact'
-              ? 'text-gray-400 text-base mb-1'
-              : 'text-gray-400 text-lg mb-2'
+              ? 'text-ink-4 text-base mb-1'
+              : 'text-ink-4 text-lg mb-2'
           }
         >
           🎤
         </div>
         <p
-          className={
-            mode === 'compact'
-              ? 'text-gray-500 dark:text-gray-400 text-xs'
-              : 'text-gray-500 dark:text-gray-400'
-          }
+          className={mode === 'compact' ? 'text-ink-3 text-xs' : 'text-ink-3 '}
         >
           {mode === 'compact'
             ? 'Waiting for conversation...'
@@ -228,13 +222,11 @@ export function TranscriptViewer({
           <div
             key={index}
             className={`p-2 rounded-lg transition-all duration-300 ${
-              entry.is_final
-                ? 'bg-gray-50 dark:bg-gray-700'
-                : 'bg-blue-50 dark:bg-blue-900/30 opacity-80'
+              entry.is_final ? 'bg-paper ' : 'bg-ds-accent-bg opacity-80'
             }`}
           >
             <div className="flex items-center gap-2 mb-1">
-              <span className="font-medium text-xs text-gray-700 dark:text-gray-300">
+              <span className="font-medium text-xs text-ink-2 ">
                 {entry.speaker}
               </span>
               {!entry.is_final && (
@@ -242,13 +234,11 @@ export function TranscriptViewer({
                   Live
                 </Badge>
               )}
-              <span className="text-xs text-gray-400 ml-auto">
+              <span className="text-xs text-ink-4 ml-auto">
                 {formatTime(entry.timestamp)}
               </span>
             </div>
-            <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed">
-              {entry.text}
-            </p>
+            <p className="text-xs text-ink-2 leading-relaxed">{entry.text}</p>
           </div>
         ))}
         {autoScroll && <div ref={bottomRef} className="h-1" />}
@@ -263,16 +253,14 @@ export function TranscriptViewer({
           key={index}
           className={`transition-all duration-300 ${
             entry.is_final
-              ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
-              : 'bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-800 border-dashed'
+              ? 'bg-surface-1 border-line '
+              : 'bg-ds-accent-bg border-ds-accent border-dashed'
           }`}
         >
           <CardContent className="pt-4">
             <div className="flex items-start justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="font-medium text-gray-900 dark:text-white">
-                  {entry.speaker}
-                </span>
+                <span className="font-medium text-ink ">{entry.speaker}</span>
                 <Badge
                   variant={entry.is_final ? 'default' : 'secondary'}
                   className="text-xs"
@@ -283,13 +271,11 @@ export function TranscriptViewer({
                   {Math.round(entry.confidence * 100)}% confidence
                 </Badge>
               </div>
-              <span className="text-xs text-gray-500 dark:text-gray-400">
+              <span className="text-xs text-ink-3 ">
                 {formatTime(entry.timestamp)}
               </span>
             </div>
-            <p className="text-gray-800 dark:text-gray-200 leading-relaxed">
-              {entry.text}
-            </p>
+            <p className="text-ink-2 leading-relaxed">{entry.text}</p>
           </CardContent>
         </Card>
       ))}

--- a/src/components/meeting/websocket-status.tsx
+++ b/src/components/meeting/websocket-status.tsx
@@ -13,36 +13,36 @@ export function WebSocketStatus() {
         return {
           icon: <Loader2 className="h-3 w-3 animate-spin" />,
           label: 'Connecting...',
-          color: 'bg-yellow-100 text-yellow-800 border-yellow-300',
-          showReconnect: false
+          color: 'bg-amber-token-bg text-amber-token border-amber-token',
+          showReconnect: false,
         }
       case 'connected':
         return {
           icon: <Wifi className="h-3 w-3" />,
           label: 'Live',
-          color: 'bg-green-100 text-green-800 border-green-300',
-          showReconnect: false
+          color: 'bg-forest-bg text-forest border-forest',
+          showReconnect: false,
         }
       case 'disconnected':
         return {
           icon: <WifiOff className="h-3 w-3" />,
           label: 'Offline',
-          color: 'bg-gray-100 text-gray-800 border-gray-300',
-          showReconnect: true
+          color: 'bg-surface-3 text-ink-2 border-line-strong',
+          showReconnect: true,
         }
       case 'error':
         return {
           icon: <AlertCircle className="h-3 w-3" />,
           label: 'Error',
-          color: 'bg-red-100 text-red-800 border-red-300',
-          showReconnect: true
+          color: 'bg-vermillion-bg text-vermillion border-vermillion',
+          showReconnect: true,
         }
       default:
         return {
           icon: <WifiOff className="h-3 w-3" />,
           label: 'Unknown',
-          color: 'bg-gray-100 text-gray-800 border-gray-300',
-          showReconnect: false
+          color: 'bg-surface-3 text-ink-2 border-line-strong',
+          showReconnect: false,
         }
     }
   }
@@ -51,8 +51,8 @@ export function WebSocketStatus() {
 
   return (
     <div className="flex items-center gap-2">
-      <Badge 
-        variant="outline" 
+      <Badge
+        variant="outline"
         className={`text-xs font-medium border ${config.color} px-2 py-0.5`}
       >
         <div className="flex items-center gap-1.5">
@@ -60,11 +60,11 @@ export function WebSocketStatus() {
           <span>{config.label}</span>
         </div>
       </Badge>
-      
+
       {config.showReconnect && (
         <button
           onClick={connect}
-          className="text-xs text-blue-600 hover:text-blue-800 underline"
+          className="text-xs text-ds-accent hover:text-ds-accent underline"
         >
           Reconnect
         </button>

--- a/src/components/persona/persona-evolution-timeline.tsx
+++ b/src/components/persona/persona-evolution-timeline.tsx
@@ -77,34 +77,34 @@ const CATEGORY_COLORS: Record<
   { bg: string; text: string; border: string }
 > = {
   Demographics: {
-    bg: 'bg-blue-50',
-    text: 'text-blue-700',
-    border: 'border-blue-200',
+    bg: 'bg-ds-accent-bg',
+    text: 'text-ds-accent',
+    border: 'border-ds-accent',
   },
   Vision: {
-    bg: 'bg-purple-50',
-    text: 'text-purple-700',
-    border: 'border-purple-200',
+    bg: 'bg-indigo-bg',
+    text: 'text-indigo',
+    border: 'border-indigo',
   },
   Challenges: {
-    bg: 'bg-orange-50',
-    text: 'text-orange-700',
-    border: 'border-orange-200',
+    bg: 'bg-amber-token-bg',
+    text: 'text-amber-token',
+    border: 'border-amber-token',
   },
   Personality: {
-    bg: 'bg-pink-50',
-    text: 'text-pink-700',
-    border: 'border-pink-200',
+    bg: 'bg-vermillion-bg',
+    text: 'text-vermillion',
+    border: 'border-vermillion',
   },
   Patterns: {
-    bg: 'bg-green-50',
-    text: 'text-green-700',
-    border: 'border-green-200',
+    bg: 'bg-forest-bg',
+    text: 'text-forest',
+    border: 'border-forest',
   },
   Progress: {
-    bg: 'bg-yellow-50',
-    text: 'text-yellow-700',
-    border: 'border-yellow-200',
+    bg: 'bg-amber-token-bg',
+    text: 'text-amber-token',
+    border: 'border-amber-token',
   },
 }
 
@@ -201,12 +201,12 @@ export function PersonaEvolutionTimeline({
     return (
       <div className="text-center py-16">
         <div className="max-w-md mx-auto">
-          <div className="p-6 bg-gradient-to-br from-gray-50 to-gray-100 rounded-2xl border border-gray-200">
-            <Calendar className="h-16 w-16 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">
+          <div className="p-6  rounded-2xl border border-line">
+            <Calendar className="h-16 w-16 text-ink-4 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold text-ink mb-2">
               No Timeline Yet
             </h3>
-            <p className="text-gray-600">
+            <p className="text-ink-3">
               The persona evolution timeline will appear here as your client
               progresses through coaching sessions.
             </p>
@@ -262,39 +262,39 @@ export function PersonaEvolutionTimeline({
   return (
     <div className="space-y-8">
       {/* Stats Header */}
-      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-8 text-white">
-        <div className="absolute top-0 right-0 w-64 h-64 bg-white opacity-5 rounded-full -mr-32 -mt-32" />
-        <div className="absolute bottom-0 left-0 w-48 h-48 bg-white opacity-5 rounded-full -ml-24 -mb-24" />
+      <div className="relative overflow-hidden rounded-2xl bg-ink p-8 text-ink-on-dark">
+        <div className="absolute top-0 right-0 w-64 h-64 bg-surface-1 opacity-5 rounded-full -mr-32 -mt-32" />
+        <div className="absolute bottom-0 left-0 w-48 h-48 bg-surface-1 opacity-5 rounded-full -ml-24 -mb-24" />
 
         <div className="relative">
           <div className="flex items-center gap-3 mb-6">
-            <div className="p-3 bg-white/10 rounded-xl backdrop-blur-sm">
+            <div className="p-3 bg-surface-1/10 rounded-xl backdrop-blur-sm">
               <Sparkles className="h-6 w-6" />
             </div>
             <div>
               <h2 className="text-2xl font-bold">Persona Evolution</h2>
-              <p className="text-gray-300 text-sm">
+              <p className="text-ink-2 text-sm">
                 Journey of growth and discovery
               </p>
             </div>
           </div>
 
           <div className="grid grid-cols-3 gap-6">
-            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4">
+            <div className="bg-surface-1/10 backdrop-blur-sm rounded-xl p-4">
               <div className="text-3xl font-bold mb-1">{totalChanges}</div>
-              <div className="text-sm text-gray-300">Total Changes</div>
+              <div className="text-sm text-ink-2">Total Changes</div>
             </div>
-            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4">
+            <div className="bg-surface-1/10 backdrop-blur-sm rounded-xl p-4">
               <div className="text-3xl font-bold mb-1">
                 {(avgConfidence * 100).toFixed(0)}%
               </div>
-              <div className="text-sm text-gray-300">Avg Confidence</div>
+              <div className="text-sm text-ink-2">Avg Confidence</div>
             </div>
-            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4">
+            <div className="bg-surface-1/10 backdrop-blur-sm rounded-xl p-4">
               <div className="text-3xl font-bold mb-1">
                 {sortedEvents.length}
               </div>
-              <div className="text-sm text-gray-300">Months Active</div>
+              <div className="text-sm text-ink-2">Months Active</div>
             </div>
           </div>
         </div>
@@ -317,14 +317,14 @@ export function PersonaEvolutionTimeline({
                   className={cn(
                     'relative z-10 rounded-full flex items-center justify-center',
                     event.isImportant
-                      ? 'w-12 h-12 bg-gradient-to-br from-gray-900 to-gray-700 shadow-lg'
-                      : 'w-8 h-8 bg-white border-2 border-gray-300',
+                      ? 'w-12 h-12  shadow-lg'
+                      : 'w-8 h-8 bg-surface-1 border-2 border-line-strong',
                   )}
                 >
                   {event.isImportant ? (
-                    <Sparkles className="h-5 w-5 text-white" />
+                    <Sparkles className="h-5 w-5 text-ink-on-dark" />
                   ) : (
-                    <Circle className="h-3 w-3 text-gray-400 fill-gray-400" />
+                    <Circle className="h-3 w-3 text-ink-4 fill-ink-4" />
                   )}
                 </div>
 
@@ -333,9 +333,7 @@ export function PersonaEvolutionTimeline({
                   <div
                     className={cn(
                       'w-0.5 flex-1 absolute top-12',
-                      event.isImportant
-                        ? 'bg-gradient-to-b from-gray-900 to-gray-300'
-                        : 'bg-gray-200',
+                      event.isImportant ? ' ' : 'bg-surface-3',
                     )}
                     style={{ height: 'calc(100% + 2rem)' }}
                   />
@@ -347,16 +345,16 @@ export function PersonaEvolutionTimeline({
                 {/* Month Header */}
                 <div className="mb-4">
                   <div className="flex items-center gap-3 mb-1">
-                    <h3 className="text-lg font-bold text-gray-900">
+                    <h3 className="text-lg font-bold text-ink">
                       {event.month}
                     </h3>
                     {event.isImportant && (
-                      <Badge className="bg-gradient-to-r from-gray-900 to-gray-700 text-white border-0">
+                      <Badge className=" text-ink-on-dark border-0">
                         Key Milestone
                       </Badge>
                     )}
                   </div>
-                  <div className="flex items-center gap-3 text-sm text-gray-500">
+                  <div className="flex items-center gap-3 text-sm text-ink-3">
                     <span>{event.updates.length} changes</span>
                     <span>•</span>
                     <span>{categoryCount} categories</span>
@@ -387,7 +385,7 @@ export function PersonaEvolutionTimeline({
                         <div className="flex items-start gap-3">
                           <div
                             className={cn(
-                              'p-1.5 rounded-lg bg-white',
+                              'p-1.5 rounded-lg bg-surface-1',
                               colors.border,
                               'border',
                             )}
@@ -396,7 +394,7 @@ export function PersonaEvolutionTimeline({
                           </div>
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 mb-1">
-                              <span className="text-sm font-semibold text-gray-900">
+                              <span className="text-sm font-semibold text-ink">
                                 {label}
                               </span>
                               <Badge variant="outline" className="text-xs">
@@ -406,16 +404,16 @@ export function PersonaEvolutionTimeline({
                                 className={cn(
                                   'text-xs font-medium px-1.5 py-0.5 rounded ml-auto',
                                   update.confidence >= 0.8
-                                    ? 'bg-blue-100 text-blue-700'
+                                    ? 'bg-ds-accent-bg text-ds-accent'
                                     : update.confidence >= 0.6
-                                      ? 'bg-blue-50 text-blue-600'
-                                      : 'bg-gray-100 text-gray-600',
+                                      ? 'bg-ds-accent-bg text-ds-accent'
+                                      : 'bg-surface-3 text-ink-3',
                                 )}
                               >
                                 {(update.confidence * 100).toFixed(0)}%
                               </div>
                             </div>
-                            <div className="text-sm text-gray-700">
+                            <div className="text-sm text-ink-2">
                               {isArrayField ? (
                                 <div className="flex flex-wrap gap-1 mt-1">
                                   {Array.isArray(update.new_value) &&
@@ -431,7 +429,7 @@ export function PersonaEvolutionTimeline({
                                         <Badge
                                           key={idx}
                                           variant="secondary"
-                                          className="text-xs bg-white/50"
+                                          className="text-xs bg-surface-1/50"
                                         >
                                           {item}
                                         </Badge>
@@ -445,7 +443,7 @@ export function PersonaEvolutionTimeline({
                                     ).length > 3 && (
                                       <Badge
                                         variant="secondary"
-                                        className="text-xs bg-white/50"
+                                        className="text-xs bg-surface-1/50"
                                       >
                                         +
                                         {update.new_value.filter(
@@ -485,24 +483,24 @@ export function PersonaEvolutionTimeline({
         {/* Start Marker */}
         <div className="flex gap-6">
           <div className="flex flex-col items-center">
-            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shadow-lg">
-              <CheckCircle2 className="h-4 w-4 text-white" />
+            <div className="w-8 h-8 rounded-full bg-surface-3 flex items-center justify-center shadow-lg">
+              <CheckCircle2 className="h-4 w-4 text-ink-on-dark" />
             </div>
           </div>
           <div className="flex-1 pb-4">
-            <div className="bg-gradient-to-r from-blue-50 to-white border border-blue-200 rounded-lg p-4">
+            <div className=" border border-ds-accent rounded-lg p-4">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-blue-900">
+                <span className="text-sm font-semibold text-ds-accent">
                   Journey Started
                 </span>
-                <Badge className="bg-blue-100 text-blue-700 border-0 text-xs">
+                <Badge className="bg-ds-accent-bg text-ds-accent border-0 text-xs">
                   {formatDate(
                     history[history.length - 1].created_at,
                     'MMMM d, yyyy',
                   )}
                 </Badge>
               </div>
-              <p className="text-sm text-blue-700 mt-1">
+              <p className="text-sm text-ds-accent mt-1">
                 The beginning of persona development
               </p>
             </div>

--- a/src/components/persona/persona-history-timeline.tsx
+++ b/src/components/persona/persona-history-timeline.tsx
@@ -175,7 +175,7 @@ export function PersonaHistoryTimeline({
         {[1, 2, 3, 4, 5].map(i => (
           <div
             key={i}
-            className="border border-gray-200 rounded-lg p-4 bg-white"
+            className="border border-line rounded-lg p-4 bg-surface-1"
           >
             <div className="flex items-center gap-3 mb-3">
               <Skeleton className="h-10 w-10 rounded-lg" />
@@ -193,12 +193,10 @@ export function PersonaHistoryTimeline({
 
   if (history.length === 0) {
     return (
-      <div className="text-center py-12 border border-gray-200 rounded-lg bg-gray-50">
-        <Clock className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-gray-900 mb-2">
-          No History Yet
-        </h3>
-        <p className="text-gray-500">
+      <div className="text-center py-12 border border-line rounded-lg bg-paper">
+        <Clock className="h-12 w-12 text-ink-4 mx-auto mb-4" />
+        <h3 className="text-lg font-medium text-ink mb-2">No History Yet</h3>
+        <p className="text-ink-3">
           Persona updates will appear here as sessions are analyzed
         </p>
       </div>
@@ -259,32 +257,32 @@ export function PersonaHistoryTimeline({
         const categories = Object.keys(categorizedUpdates)
 
         return (
-          <Card key={sessionKey} className="border-gray-200 overflow-hidden">
+          <Card key={sessionKey} className="border-line overflow-hidden">
             {/* Session Header - Clickable */}
             <button
               onClick={() => toggleSession(sessionKey)}
               className={cn(
                 'w-full p-4 flex items-center gap-4 transition-colors',
-                'hover:bg-gray-50 text-left',
-                isExpanded && 'bg-gray-50',
+                'hover:bg-paper text-left',
+                isExpanded && 'bg-paper',
               )}
             >
               {/* Icon */}
-              <div className="flex-shrink-0 p-2.5 bg-gradient-to-br from-gray-900 to-gray-700 rounded-lg">
-                <Sparkles className="h-5 w-5 text-white" />
+              <div className="flex-shrink-0 p-2.5  rounded-lg">
+                <Sparkles className="h-5 w-5 text-ink-on-dark" />
               </div>
 
               {/* Info */}
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
-                  <h3 className="text-sm font-semibold text-gray-900">
+                  <h3 className="text-sm font-semibold text-ink">
                     Session Analysis
                   </h3>
                   <Badge variant="secondary" className="text-xs">
                     {group.updates.length} changes
                   </Badge>
                 </div>
-                <div className="flex items-center gap-3 text-xs text-gray-500">
+                <div className="flex items-center gap-3 text-xs text-ink-3">
                   <span className="flex items-center gap-1">
                     <Calendar className="h-3 w-3" />
                     {formatDate(group.sessionDateStr, 'MMM d, yyyy')}
@@ -305,38 +303,38 @@ export function PersonaHistoryTimeline({
                   className={cn(
                     'text-xs font-medium px-2.5 py-1 rounded-md',
                     group.avgConfidence >= 0.8
-                      ? 'bg-blue-100 text-blue-700'
+                      ? 'bg-ds-accent-bg text-ds-accent'
                       : group.avgConfidence >= 0.6
-                        ? 'bg-blue-50 text-blue-600'
-                        : 'bg-gray-100 text-gray-600',
+                        ? 'bg-ds-accent-bg text-ds-accent'
+                        : 'bg-surface-3 text-ink-3',
                   )}
                 >
                   {(group.avgConfidence * 100).toFixed(0)}% avg
                 </div>
                 {isExpanded ? (
-                  <ChevronDown className="h-5 w-5 text-gray-400" />
+                  <ChevronDown className="h-5 w-5 text-ink-4" />
                 ) : (
-                  <ChevronRight className="h-5 w-5 text-gray-400" />
+                  <ChevronRight className="h-5 w-5 text-ink-4" />
                 )}
               </div>
             </button>
 
             {/* Expanded Content */}
             {isExpanded && (
-              <div className="border-t border-gray-200 bg-white">
+              <div className="border-t border-line bg-surface-1">
                 <div className="p-4 space-y-4">
                   {/* Session Link */}
                   {group.sessionId && (
-                    <div className="flex items-center justify-between p-3 bg-blue-50 rounded-lg border border-blue-200">
+                    <div className="flex items-center justify-between p-3 bg-ds-accent-bg rounded-lg border border-ds-accent">
                       <div className="flex items-center gap-2">
-                        <FileText className="h-4 w-4 text-blue-600" />
-                        <span className="text-sm text-blue-900 font-medium">
+                        <FileText className="h-4 w-4 text-ds-accent" />
+                        <span className="text-sm text-ds-accent font-medium">
                           View session transcript
                         </span>
                       </div>
                       <Link
                         href={`/sessions/${group.sessionId}`}
-                        className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 font-medium"
+                        className="inline-flex items-center gap-1 text-sm text-ds-accent hover:text-ds-accent font-medium"
                         onClick={e => e.stopPropagation()}
                       >
                         Open
@@ -355,9 +353,9 @@ export function PersonaHistoryTimeline({
                         return (
                           <div key={category} className="space-y-2">
                             {/* Category Header */}
-                            <div className="flex items-center gap-2 pb-2 border-b border-gray-200">
-                              <CategoryIcon className="h-4 w-4 text-gray-600" />
-                              <h4 className="text-sm font-semibold text-gray-900">
+                            <div className="flex items-center gap-2 pb-2 border-b border-line">
+                              <CategoryIcon className="h-4 w-4 text-ink-3" />
+                              <h4 className="text-sm font-semibold text-ink">
                                 {category}
                               </h4>
                               <Badge
@@ -387,23 +385,23 @@ export function PersonaHistoryTimeline({
                                     className="flex items-start gap-2 py-1.5"
                                   >
                                     {/* Icon */}
-                                    <Icon className="h-3.5 w-3.5 text-gray-400 flex-shrink-0 mt-0.5" />
+                                    <Icon className="h-3.5 w-3.5 text-ink-4 flex-shrink-0 mt-0.5" />
 
                                     {/* Content */}
                                     <div className="flex-1 min-w-0">
                                       {/* Label and Confidence on same line */}
                                       <div className="flex items-center gap-2 mb-1">
-                                        <span className="text-sm font-medium text-gray-700">
+                                        <span className="text-sm font-medium text-ink-2">
                                           {label}
                                         </span>
                                         <div
                                           className={cn(
                                             'text-xs font-medium px-1.5 py-0.5 rounded',
                                             update.confidence >= 0.8
-                                              ? 'bg-blue-100 text-blue-700'
+                                              ? 'bg-ds-accent-bg text-ds-accent'
                                               : update.confidence >= 0.6
-                                                ? 'bg-blue-50 text-blue-600'
-                                                : 'bg-gray-100 text-gray-600',
+                                                ? 'bg-ds-accent-bg text-ds-accent'
+                                                : 'bg-surface-3 text-ink-3',
                                           )}
                                         >
                                           {(update.confidence * 100).toFixed(0)}
@@ -419,7 +417,7 @@ export function PersonaHistoryTimeline({
                                             Array.isArray(update.old_value) &&
                                             update.old_value.length > 0 && (
                                               <div className="flex flex-wrap gap-1 items-center">
-                                                <span className="text-xs text-gray-500 font-medium mr-1">
+                                                <span className="text-xs text-ink-3 font-medium mr-1">
                                                   Previous:
                                                 </span>
                                                 {update.old_value.map(
@@ -430,7 +428,7 @@ export function PersonaHistoryTimeline({
                                                     <Badge
                                                       key={idx}
                                                       variant="secondary"
-                                                      className="text-xs bg-gray-100 text-gray-600 border-gray-300 line-through opacity-75"
+                                                      className="text-xs bg-surface-3 text-ink-3 border-line-strong line-through opacity-75"
                                                     >
                                                       {item}
                                                     </Badge>
@@ -441,7 +439,7 @@ export function PersonaHistoryTimeline({
 
                                           {/* Added items inline */}
                                           <div className="flex flex-wrap gap-1 items-center">
-                                            <span className="text-xs text-gray-700 font-medium mr-1">
+                                            <span className="text-xs text-ink-2 font-medium mr-1">
                                               {update.old_value &&
                                               Array.isArray(update.old_value) &&
                                               update.old_value.length > 0
@@ -468,7 +466,7 @@ export function PersonaHistoryTimeline({
                                                     <Badge
                                                       key={idx}
                                                       variant="secondary"
-                                                      className="text-xs bg-blue-50 text-blue-700 border-blue-200"
+                                                      className="text-xs bg-ds-accent-bg text-ds-accent border-ds-accent"
                                                     >
                                                       {item}
                                                     </Badge>
@@ -480,11 +478,11 @@ export function PersonaHistoryTimeline({
                                         <div className="text-sm">
                                           {formatValue(update.old_value) !==
                                             'Not set' && (
-                                            <span className="text-gray-500 line-through mr-2">
+                                            <span className="text-ink-3 line-through mr-2">
                                               {formatValue(update.old_value)}
                                             </span>
                                           )}
-                                          <span className="font-medium text-gray-900">
+                                          <span className="font-medium text-ink">
                                             {formatValue(update.new_value)}
                                           </span>
                                         </div>

--- a/src/components/programs/program-action-items.tsx
+++ b/src/components/programs/program-action-items.tsx
@@ -104,7 +104,7 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
     return (
       <Card>
         <CardContent className="flex items-center justify-center py-12">
-          <p className="text-gray-600">No action items available</p>
+          <p className="text-ink-3">No action items available</p>
         </CardContent>
       </Card>
     )
@@ -113,11 +113,11 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'bg-green-50 text-green-700 border-green-200'
+        return 'bg-forest-bg text-forest border-forest'
       case 'overdue':
-        return 'bg-red-50 text-red-700 border-red-200'
+        return 'bg-vermillion-bg text-vermillion border-vermillion'
       default:
-        return 'bg-blue-50 text-blue-700 border-blue-200'
+        return 'bg-ds-accent-bg text-ds-accent border-ds-accent'
     }
   }
 
@@ -137,8 +137,8 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">Action Items</h2>
-          <p className="text-gray-600 mt-1">
+          <h2 className="text-2xl font-bold text-ink">Action Items</h2>
+          <p className="text-ink-3 mt-1">
             Track commitments and follow-ups across all clients
           </p>
         </div>
@@ -164,13 +164,13 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               Total Items
             </CardTitle>
-            <ListTodo className="h-5 w-5 text-gray-500" />
+            <ListTodo className="h-5 w-5 text-ink-3" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {actionItems.total_action_items}
             </div>
           </CardContent>
@@ -178,13 +178,13 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               Pending
             </CardTitle>
-            <Clock className="h-5 w-5 text-blue-500" />
+            <Clock className="h-5 w-5 text-ds-accent" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {actionItems.pending_count}
             </div>
           </CardContent>
@@ -192,13 +192,13 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               Completed
             </CardTitle>
-            <CheckCircle2 className="h-5 w-5 text-green-500" />
+            <CheckCircle2 className="h-5 w-5 text-forest" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {actionItems.completed_count}
             </div>
           </CardContent>
@@ -206,16 +206,16 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               Overdue
             </CardTitle>
-            <AlertCircle className="h-5 w-5 text-red-500" />
+            <AlertCircle className="h-5 w-5 text-vermillion" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {actionItems.overdue_count}
             </div>
-            <p className="text-xs text-red-600 mt-1">
+            <p className="text-xs text-vermillion mt-1">
               {actionItems.completion_rate.toFixed(0)}% completion rate
             </p>
           </CardContent>
@@ -234,7 +234,7 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
           {/* Client Filters */}
           {uniqueClients.length > 0 && (
             <div>
-              <p className="text-sm font-medium text-gray-700 mb-2">Clients</p>
+              <p className="text-sm font-medium text-ink-2 mb-2">Clients</p>
               <div className="flex flex-wrap gap-2">
                 {uniqueClients.map(client => (
                   <button
@@ -242,8 +242,8 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
                     onClick={() => toggleClientFilter(client.id)}
                     className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
                       selectedClients.includes(client.id)
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-gray-900'
+                        ? 'bg-ink text-ink-on-dark border-line '
+                        : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line'
                     }`}
                   >
                     {client.name}
@@ -252,7 +252,7 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
                 {selectedClients.length > 0 && (
                   <button
                     onClick={() => setSelectedClients([])}
-                    className="px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                    className="px-3 py-1.5 text-sm rounded-md border border-line-strong text-ink-2 hover:bg-paper"
                   >
                     Clear
                   </button>
@@ -264,7 +264,7 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
           {/* Coach Filters */}
           {uniqueCoaches.length > 0 && (
             <div>
-              <p className="text-sm font-medium text-gray-700 mb-2">Coaches</p>
+              <p className="text-sm font-medium text-ink-2 mb-2">Coaches</p>
               <div className="flex flex-wrap gap-2">
                 {uniqueCoaches.map(coach => (
                   <button
@@ -272,8 +272,8 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
                     onClick={() => toggleCoachFilter(coach.id)}
                     className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
                       selectedCoaches.includes(coach.id)
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-gray-900'
+                        ? 'bg-ink text-ink-on-dark border-line '
+                        : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line'
                     }`}
                   >
                     {coach.name}
@@ -282,7 +282,7 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
                 {selectedCoaches.length > 0 && (
                   <button
                     onClick={() => setSelectedCoaches([])}
-                    className="px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                    className="px-3 py-1.5 text-sm rounded-md border border-line-strong text-ink-2 hover:bg-paper"
                   >
                     Clear
                   </button>
@@ -305,12 +305,12 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
         <CardContent>
           {filteredActionItems.length === 0 ? (
             <div className="text-center py-12">
-              <ListTodo className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-              <p className="text-gray-600">No action items found</p>
+              <ListTodo className="h-12 w-12 text-ink-4 mx-auto mb-4" />
+              <p className="text-ink-3">No action items found</p>
               {(statusFilter ||
                 selectedClients.length > 0 ||
                 selectedCoaches.length > 0) && (
-                <p className="text-sm text-gray-500 mt-2">
+                <p className="text-sm text-ink-3 mt-2">
                   Try changing the filters
                 </p>
               )}
@@ -333,15 +333,13 @@ export function ProgramActionItems({ programId }: ProgramActionItemsProps) {
                           {item.status}
                         </Badge>
                         {item.due_date && (
-                          <span className="text-xs text-gray-500">
+                          <span className="text-xs text-ink-3">
                             Due {formatRelativeTime(item.due_date)}
                           </span>
                         )}
                       </div>
-                      <p className="text-gray-900 font-medium">
-                        {item.description}
-                      </p>
-                      <div className="flex items-center gap-4 mt-2 text-sm text-gray-600">
+                      <p className="text-ink font-medium">{item.description}</p>
+                      <div className="flex items-center gap-4 mt-2 text-sm text-ink-3">
                         <span>Client: {item.client_name}</span>
                         <span>•</span>
                         <span>Coach: {item.coach_name || 'Unknown'}</span>

--- a/src/components/programs/program-calendar.tsx
+++ b/src/components/programs/program-calendar.tsx
@@ -148,7 +148,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
     return (
       <Card>
         <CardContent className="flex items-center justify-center py-12">
-          <p className="text-gray-600">No calendar data available</p>
+          <p className="text-ink-3">No calendar data available</p>
         </CardContent>
       </Card>
     )
@@ -164,8 +164,8 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">Sandbox Calendar</h2>
-          <p className="text-gray-600 mt-1">
+          <h2 className="text-2xl font-bold text-ink">Sandbox Calendar</h2>
+          <p className="text-ink-3 mt-1">
             Upcoming sessions and coach workload
           </p>
         </div>
@@ -190,48 +190,46 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               This Week
             </CardTitle>
-            <Calendar className="h-5 w-5 text-blue-500" />
+            <Calendar className="h-5 w-5 text-ds-accent" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {calendar.sessions_this_week}
             </div>
-            <p className="text-xs text-gray-600 mt-1">sessions scheduled</p>
+            <p className="text-xs text-ink-3 mt-1">sessions scheduled</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               Next Week
             </CardTitle>
-            <TrendingUp className="h-5 w-5 text-purple-500" />
+            <TrendingUp className="h-5 w-5 text-indigo" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {calendar.sessions_next_week}
             </div>
-            <p className="text-xs text-gray-600 mt-1">sessions scheduled</p>
+            <p className="text-xs text-ink-3 mt-1">sessions scheduled</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
+            <CardTitle className="text-sm font-medium text-ink-3">
               Total Upcoming
             </CardTitle>
-            <Clock className="h-5 w-5 text-green-500" />
+            <Clock className="h-5 w-5 text-forest" />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-gray-900">
+            <div className="text-3xl font-bold text-ink">
               {filteredSessions.length}
             </div>
-            <p className="text-xs text-gray-600 mt-1">
-              in next {daysAhead} days
-            </p>
+            <p className="text-xs text-ink-3 mt-1">in next {daysAhead} days</p>
           </CardContent>
         </Card>
       </div>
@@ -246,7 +244,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
           {/* Client Filters */}
           {uniqueClients.length > 0 && (
             <div>
-              <p className="text-sm font-medium text-gray-700 mb-2">Clients</p>
+              <p className="text-sm font-medium text-ink-2 mb-2">Clients</p>
               <div className="flex flex-wrap gap-2">
                 {uniqueClients.map(client => (
                   <button
@@ -254,8 +252,8 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                     onClick={() => toggleClientFilter(client.id)}
                     className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
                       selectedClients.includes(client.id)
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-gray-900'
+                        ? 'bg-ink text-ink-on-dark border-line '
+                        : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line'
                     }`}
                   >
                     {client.name}
@@ -264,7 +262,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                 {selectedClients.length > 0 && (
                   <button
                     onClick={() => setSelectedClients([])}
-                    className="px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                    className="px-3 py-1.5 text-sm rounded-md border border-line-strong text-ink-2 hover:bg-paper"
                   >
                     Clear
                   </button>
@@ -276,7 +274,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
           {/* Coach Filters */}
           {uniqueCoaches.length > 0 && (
             <div>
-              <p className="text-sm font-medium text-gray-700 mb-2">Coaches</p>
+              <p className="text-sm font-medium text-ink-2 mb-2">Coaches</p>
               <div className="flex flex-wrap gap-2">
                 {uniqueCoaches.map(coach => (
                   <button
@@ -284,8 +282,8 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                     onClick={() => toggleCoachFilter(coach.id)}
                     className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
                       selectedCoaches.includes(coach.id)
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-gray-900'
+                        ? 'bg-ink text-ink-on-dark border-line '
+                        : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line'
                     }`}
                   >
                     {coach.name}
@@ -294,7 +292,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                 {selectedCoaches.length > 0 && (
                   <button
                     onClick={() => setSelectedCoaches([])}
-                    className="px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                    className="px-3 py-1.5 text-sm rounded-md border border-line-strong text-ink-2 hover:bg-paper"
                   >
                     Clear
                   </button>
@@ -332,12 +330,12 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-7 gap-px bg-gray-200 border border-gray-200 rounded-lg overflow-hidden">
+          <div className="grid grid-cols-7 gap-px bg-surface-3 border border-line rounded-lg overflow-hidden">
             {/* Day headers */}
             {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
               <div
                 key={day}
-                className="bg-gray-50 p-2 text-center text-xs font-semibold text-gray-700"
+                className="bg-paper p-2 text-center text-xs font-semibold text-ink-2"
               >
                 {day}
               </div>
@@ -352,9 +350,9 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
               return (
                 <div
                   key={day.toISOString()}
-                  className={`bg-white p-2 min-h-[100px] ${
-                    !isCurrentMonth ? 'text-gray-400' : ''
-                  } ${isCurrentDay ? 'ring-2 ring-gray-900 ring-inset' : ''}`}
+                  className={`bg-surface-1 p-2 min-h-[100px] ${
+                    !isCurrentMonth ? 'text-ink-4' : ''
+                  } ${isCurrentDay ? 'ring-2 ring-line ring-inset' : ''}`}
                 >
                   <div className="text-sm font-medium mb-1">
                     {format(day, 'd')}
@@ -363,7 +361,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                     {daySessionsCount.slice(0, 3).map(session => (
                       <div
                         key={session.session_id}
-                        className="text-xs p-1 rounded bg-gray-50 border border-gray-300 cursor-pointer hover:bg-gray-100 truncate"
+                        className="text-xs p-1 rounded bg-paper border border-line-strong cursor-pointer hover:bg-surface-3 truncate"
                         onClick={() =>
                           router.push(`/clients/${session.client_id}`)
                         }
@@ -372,13 +370,13 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                         <div className="font-medium truncate">
                           {formatDate(session.scheduled_date, 'h:mm a')}
                         </div>
-                        <div className="truncate text-gray-600">
+                        <div className="truncate text-ink-3">
                           {session.client_name}
                         </div>
                       </div>
                     ))}
                     {daySessionsCount.length > 3 && (
-                      <div className="text-xs text-gray-500 font-medium">
+                      <div className="text-xs text-ink-3 font-medium">
                         +{daySessionsCount.length - 3} more
                       </div>
                     )}
@@ -395,7 +393,7 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <Users className="h-5 w-5 text-blue-600" />
+              <Users className="h-5 w-5 text-ds-accent" />
               <CardTitle>Coach Workload</CardTitle>
             </div>
             <CardDescription>
@@ -408,11 +406,11 @@ export function ProgramCalendar({ programId }: ProgramCalendarProps) {
                 .sort(([, a], [, b]) => b - a)
                 .map(([coach, count]) => (
                   <div key={coach} className="p-4 border rounded-lg">
-                    <p className="text-sm text-gray-600 truncate" title={coach}>
+                    <p className="text-sm text-ink-3 truncate" title={coach}>
                       {coach}
                     </p>
-                    <p className="text-2xl font-bold text-gray-900">{count}</p>
-                    <p className="text-xs text-gray-500">sessions</p>
+                    <p className="text-2xl font-bold text-ink">{count}</p>
+                    <p className="text-xs text-ink-3">sessions</p>
                   </div>
                 ))}
             </div>

--- a/src/components/programs/program-form.tsx
+++ b/src/components/programs/program-form.tsx
@@ -32,15 +32,17 @@ interface ProgramFormProps {
   mode: 'create' | 'edit'
 }
 
+// Program-color picker — user choice that persists to the database.
+// Values retargeted to DS token literals so the visual stays in the system.
 const DEFAULT_COLORS = [
-  { name: 'Blue', value: '#3B82F6' },
-  { name: 'Green', value: '#10B981' },
-  { name: 'Purple', value: '#8B5CF6' },
-  { name: 'Red', value: '#EF4444' },
-  { name: 'Yellow', value: '#F59E0B' },
-  { name: 'Pink', value: '#EC4899' },
-  { name: 'Indigo', value: '#6366F1' },
-  { name: 'Teal', value: '#14B8A6' },
+  { name: 'Blue', value: '#2563EB' }, // ds-accent
+  { name: 'Green', value: '#15803D' }, // forest
+  { name: 'Indigo', value: '#4338CA' }, // indigo
+  { name: 'Red', value: '#B91C1C' }, // vermillion
+  { name: 'Amber', value: '#B45309' }, // amber-token
+  { name: 'Ink', value: '#0A0A0A' }, // ink
+  { name: 'Slate', value: '#404040' }, // ink-2
+  { name: 'Stone', value: '#737373' }, // ink-3
 ]
 
 export function ProgramForm({ program, mode }: ProgramFormProps) {
@@ -58,7 +60,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
     defaultValues: {
       name: program?.name || '',
       description: program?.description || '',
-      color: program?.color || '#3B82F6',
+      color: program?.color || '#2563EB',
       metadata: program?.metadata || {},
       client_ids: [],
     },
@@ -179,7 +181,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
           {/* Program Name */}
           <div className="space-y-2">
             <Label htmlFor="name">
-              Sandbox Name <span className="text-red-500">*</span>
+              Sandbox Name <span className="text-vermillion">*</span>
             </Label>
             <Input
               id="name"
@@ -187,7 +189,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
               placeholder="e.g., Executive Leadership Cohort 2025"
             />
             {errors.name && (
-              <p className="text-sm text-red-600">{errors.name.message}</p>
+              <p className="text-sm text-vermillion">{errors.name.message}</p>
             )}
           </div>
 
@@ -214,8 +216,8 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                     onClick={() => setValue('color', color.value)}
                     className={`w-10 h-10 rounded-full border-2 transition-all ${
                       selectedColor === color.value
-                        ? 'border-gray-900 dark:border-white scale-110'
-                        : 'border-gray-300 dark:border-gray-600 hover:scale-105'
+                        ? 'border-line scale-110'
+                        : 'border-line-strong hover:scale-105'
                     }`}
                     style={{ backgroundColor: color.value }}
                     title={color.name}
@@ -224,7 +226,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
               </div>
               <div className="flex items-center gap-2">
                 <div
-                  className="w-10 h-10 rounded-full border-2 border-gray-300 dark:border-gray-600"
+                  className="w-10 h-10 rounded-full border-2 border-line-strong "
                   style={{ backgroundColor: selectedColor }}
                 />
                 <Input
@@ -252,7 +254,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           {clients.length === 0 ? (
-            <p className="text-sm text-gray-600 dark:text-gray-400">
+            <p className="text-sm text-ink-3 ">
               No clients available. Create clients first before assigning them
               to sandboxes.
             </p>
@@ -270,14 +272,14 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                       <Badge
                         key={clientId}
                         variant="secondary"
-                        className={`pl-3 pr-1 ${isNew ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800' : ''}`}
+                        className={`pl-3 pr-1 ${isNew ? 'bg-forest-bg text-forest border-forest ' : ''}`}
                       >
                         {isNew && <Plus className="h-3 w-3 mr-1" />}
                         {client.name}
                         <button
                           type="button"
                           onClick={() => toggleClient(clientId)}
-                          className="ml-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded p-1"
+                          className="ml-2 hover:bg-surface-3 rounded p-1"
                         >
                           <X className="h-3 w-3" />
                         </button>
@@ -291,7 +293,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
               {mode === 'edit' &&
                 initialClients.some(id => !selectedClients.includes(id)) && (
                   <div className="flex flex-wrap gap-2 pb-4 border-b">
-                    <p className="text-sm text-gray-600 dark:text-gray-400 w-full mb-2">
+                    <p className="text-sm text-ink-3 w-full mb-2">
                       Clients to be removed:
                     </p>
                     {initialClients
@@ -303,14 +305,14 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                           <Badge
                             key={clientId}
                             variant="secondary"
-                            className="pl-3 pr-1 bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800"
+                            className="pl-3 pr-1 bg-vermillion-bg text-vermillion border-vermillion "
                           >
                             <X className="h-3 w-3 mr-1" />
                             {client.name}
                             <button
                               type="button"
                               onClick={() => toggleClient(clientId)}
-                              className="ml-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded p-1"
+                              className="ml-2 hover:bg-surface-3 rounded p-1"
                               title="Undo removal"
                             >
                               <Plus className="h-3 w-3" />
@@ -322,7 +324,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                 )}
 
               {/* Client List */}
-              <div className="max-h-96 overflow-y-auto space-y-1 border rounded-lg p-2 bg-gray-50 dark:bg-gray-800">
+              <div className="max-h-96 overflow-y-auto space-y-1 border rounded-lg p-2 bg-paper ">
                 {clients.map(client => {
                   const isSelected = selectedClients.includes(client.id)
                   const isNew =
@@ -340,11 +342,11 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                       className={`flex items-center space-x-3 p-3 rounded-lg transition-all cursor-pointer ${
                         isSelected
                           ? isNew
-                            ? 'bg-green-50 border-2 border-green-300 hover:bg-green-100 dark:bg-green-900/30 dark:border-green-700 dark:hover:bg-green-900/50'
-                            : 'bg-white border-2 border-blue-300 hover:bg-blue-50 dark:bg-gray-900 dark:border-blue-700 dark:hover:bg-blue-900/30'
+                            ? 'bg-forest-bg border-2 border-forest hover:bg-forest-bg '
+                            : 'bg-surface-1 border-2 border-ds-accent hover:bg-ds-accent-bg '
                           : isRemoved
-                            ? 'bg-red-50 border-2 border-red-200 opacity-60 hover:bg-red-100 dark:bg-red-900/30 dark:border-red-800 dark:hover:bg-red-900/50'
-                            : 'bg-white border-2 border-gray-200 hover:bg-gray-50 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800'
+                            ? 'bg-vermillion-bg border-2 border-vermillion opacity-60 hover:bg-vermillion-bg '
+                            : 'bg-surface-1 border-2 border-line hover:bg-paper '
                       }`}
                       onClick={() => toggleClient(client.id)}
                     >
@@ -352,13 +354,13 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                       <div
                         className={`flex items-center justify-center w-5 h-5 rounded border-2 transition-colors ${
                           isSelected
-                            ? 'bg-blue-600 border-blue-600'
-                            : 'bg-white border-gray-300 dark:bg-gray-900 dark:border-gray-600'
+                            ? 'bg-ds-accent border-ds-accent'
+                            : 'bg-surface-1 border-line-strong '
                         }`}
                       >
                         {isSelected && (
                           <svg
-                            className="w-3 h-3 text-white"
+                            className="w-3 h-3 text-ink-on-dark"
                             fill="none"
                             strokeLinecap="round"
                             strokeLinejoin="round"
@@ -376,7 +378,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                           {isNew && (
                             <Badge
                               variant="outline"
-                              className="text-xs bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800"
+                              className="text-xs bg-forest-bg text-forest border-forest "
                             >
                               New
                             </Badge>
@@ -384,7 +386,7 @@ export function ProgramForm({ program, mode }: ProgramFormProps) {
                           {isRemoved && (
                             <Badge
                               variant="outline"
-                              className="text-xs bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800"
+                              className="text-xs bg-vermillion-bg text-vermillion border-vermillion "
                             >
                               Will Remove
                             </Badge>

--- a/src/components/programs/program-outcomes.tsx
+++ b/src/components/programs/program-outcomes.tsx
@@ -121,11 +121,11 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
     return (
       <Card>
         <CardContent className="flex flex-col items-center justify-center py-12">
-          <AlertCircle className="h-12 w-12 text-gray-400 mb-4" />
-          <h3 className="text-lg font-semibold text-gray-900 mb-2">
+          <AlertCircle className="h-12 w-12 text-ink-4 mb-4" />
+          <h3 className="text-lg font-semibold text-ink mb-2">
             Unable to Load Outcomes
           </h3>
-          <p className="text-gray-600 text-center">
+          <p className="text-ink-3 text-center">
             There was an error loading the sandbox outcomes.
           </p>
         </CardContent>
@@ -140,14 +140,14 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Target className="h-5 w-5 text-gray-600" />
+              <div className="p-2 bg-surface-3 rounded-lg">
+                <Target className="h-5 w-5 text-ink-3" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {outcomes.total_outcomes}
                 </p>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-ink-3">
                   Total Meta Performance Outcomes
                 </p>
               </div>
@@ -158,14 +158,14 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Clock className="h-5 w-5 text-gray-600" />
+              <div className="p-2 bg-surface-3 rounded-lg">
+                <Clock className="h-5 w-5 text-ink-3" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {outcomes.active_outcomes}
                 </p>
-                <p className="text-sm text-gray-500">Active</p>
+                <p className="text-sm text-ink-3">Active</p>
               </div>
             </div>
           </CardContent>
@@ -174,14 +174,14 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <CheckCircle2 className="h-5 w-5 text-gray-600" />
+              <div className="p-2 bg-surface-3 rounded-lg">
+                <CheckCircle2 className="h-5 w-5 text-ink-3" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {outcomes.completed_outcomes}
                 </p>
-                <p className="text-sm text-gray-500">Completed</p>
+                <p className="text-sm text-ink-3">Completed</p>
               </div>
             </div>
           </CardContent>
@@ -190,14 +190,14 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <TrendingUp className="h-5 w-5 text-gray-600" />
+              <div className="p-2 bg-surface-3 rounded-lg">
+                <TrendingUp className="h-5 w-5 text-ink-3" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-2xl font-bold text-ink">
                   {Math.round(outcomes.overall_progress)}%
                 </p>
-                <p className="text-sm text-gray-500">Overall Progress</p>
+                <p className="text-sm text-ink-3">Overall Progress</p>
               </div>
             </div>
           </CardContent>
@@ -208,15 +208,15 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
       <Card>
         <CardContent className="pt-6">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-gray-700">
+            <span className="text-sm font-medium text-ink-2">
               Sandbox Progress
             </span>
-            <span className="text-sm font-semibold text-gray-900">
+            <span className="text-sm font-semibold text-ink">
               {Math.round(outcomes.overall_progress)}%
             </span>
           </div>
           <Progress value={outcomes.overall_progress} className="h-3" />
-          <div className="flex items-center justify-between mt-2 text-xs text-gray-500">
+          <div className="flex items-center justify-between mt-2 text-xs text-ink-3">
             <span>
               {outcomes.completed_outcomes} of {outcomes.total_outcomes} meta
               performance outcomes completed
@@ -233,8 +233,8 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
             onClick={() => setStatusFilter('all')}
             className={`inline-flex items-center px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
               statusFilter === 'all'
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400 hover:bg-gray-50'
+                ? 'bg-ink text-ink-on-dark border-line '
+                : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper'
             }`}
           >
             All ({statusCounts.all})
@@ -243,33 +243,33 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
             onClick={() => setStatusFilter('active')}
             className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
               statusFilter === 'active'
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400 hover:bg-gray-50'
+                ? 'bg-ink text-ink-on-dark border-line '
+                : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper'
             }`}
           >
-            <span className="w-2 h-2 rounded-full bg-blue-500" />
+            <span className="w-2 h-2 rounded-full bg-ds-accent" />
             Active ({statusCounts.active})
           </button>
           <button
             onClick={() => setStatusFilter('completed')}
             className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
               statusFilter === 'completed'
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400 hover:bg-gray-50'
+                ? 'bg-ink text-ink-on-dark border-line '
+                : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper'
             }`}
           >
-            <span className="w-2 h-2 rounded-full bg-green-500" />
+            <span className="w-2 h-2 rounded-full bg-forest" />
             Completed ({statusCounts.completed})
           </button>
           <button
             onClick={() => setStatusFilter('deferred')}
             className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
               statusFilter === 'deferred'
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
-                : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400 hover:bg-gray-50'
+                ? 'bg-ink text-ink-on-dark border-line '
+                : 'bg-surface-1 text-ink-2 border-line-strong hover:border-line-strong hover:bg-paper'
             }`}
           >
-            <span className="w-2 h-2 rounded-full bg-yellow-500" />
+            <span className="w-2 h-2 rounded-full bg-amber-token" />
             Deferred ({statusCounts.deferred})
           </button>
         </div>
@@ -278,7 +278,7 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
           {/* Client Filter */}
           <Select value={selectedClient} onValueChange={setSelectedClient}>
             <SelectTrigger className="w-[180px]">
-              <User className="h-4 w-4 mr-2 text-gray-500" />
+              <User className="h-4 w-4 mr-2 text-ink-3" />
               <SelectValue placeholder="All Clients" />
             </SelectTrigger>
             <SelectContent>
@@ -311,11 +311,11 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
       {filteredOutcomes.length === 0 && (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
-            <Target className="h-12 w-12 text-gray-400 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+            <Target className="h-12 w-12 text-ink-4 mb-4" />
+            <h3 className="text-lg font-semibold text-ink mb-2">
               No meta performance outcomes found
             </h3>
-            <p className="text-gray-600 text-center">
+            <p className="text-ink-3 text-center">
               {statusFilter !== 'all'
                 ? 'Try changing the filter to see more meta performance outcomes'
                 : 'Meta performance outcomes will appear here as clients set them'}
@@ -346,8 +346,8 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
                 <CardHeader className="pb-3">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      <div className="p-2 bg-gray-100 rounded-full">
-                        <User className="h-4 w-4 text-gray-600" />
+                      <div className="p-2 bg-surface-3 rounded-full">
+                        <User className="h-4 w-4 text-ink-3" />
                       </div>
                       <div>
                         <CardTitle className="text-lg">{clientName}</CardTitle>
@@ -362,7 +362,7 @@ export function ProgramOutcomes({ programId }: ProgramOutcomesProps) {
                         const clientId = clientOutcomes[0]?.client_id
                         if (clientId) router.push(`/clients/${clientId}`)
                       }}
-                      className="text-sm font-medium text-gray-600 hover:text-gray-900 flex items-center gap-1"
+                      className="text-sm font-medium text-ink-3 hover:text-ink flex items-center gap-1"
                     >
                       View Client <ChevronRight className="h-4 w-4" />
                     </button>
@@ -400,15 +400,15 @@ function OutcomeCard({
   const getStatusStyles = (status: string) => {
     switch (status) {
       case 'completed':
-        return { dot: 'bg-green-500', badge: 'bg-gray-100 text-gray-700' }
+        return { dot: 'bg-forest', badge: 'bg-surface-3 text-ink-2' }
       case 'active':
-        return { dot: 'bg-blue-500', badge: 'bg-gray-100 text-gray-700' }
+        return { dot: 'bg-ds-accent', badge: 'bg-surface-3 text-ink-2' }
       case 'deferred':
-        return { dot: 'bg-yellow-500', badge: 'bg-gray-100 text-gray-700' }
+        return { dot: 'bg-amber-token', badge: 'bg-surface-3 text-ink-2' }
       case 'abandoned':
-        return { dot: 'bg-red-500', badge: 'bg-gray-100 text-gray-700' }
+        return { dot: 'bg-vermillion', badge: 'bg-surface-3 text-ink-2' }
       default:
-        return { dot: 'bg-gray-400', badge: 'bg-gray-100 text-gray-700' }
+        return { dot: 'bg-line', badge: 'bg-surface-3 text-ink-2' }
     }
   }
 
@@ -423,12 +423,12 @@ function OutcomeCard({
         <div className="flex items-start justify-between mb-3">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <Target className="h-4 w-4 text-gray-400 shrink-0" />
-              <h3 className="font-semibold text-gray-900 truncate">
+              <Target className="h-4 w-4 text-ink-4 shrink-0" />
+              <h3 className="font-semibold text-ink truncate">
                 {outcome.title}
               </h3>
             </div>
-            <p className="text-sm text-gray-500 flex items-center gap-1">
+            <p className="text-sm text-ink-3 flex items-center gap-1">
               <User className="h-3 w-3" />
               {outcome.client_name}
             </p>
@@ -440,7 +440,7 @@ function OutcomeCard({
         </div>
 
         {outcome.description && (
-          <p className="text-sm text-gray-600 line-clamp-2 mb-3">
+          <p className="text-sm text-ink-3 line-clamp-2 mb-3">
             {outcome.description}
           </p>
         )}
@@ -448,15 +448,15 @@ function OutcomeCard({
         {/* Progress */}
         <div className="mb-3">
           <div className="flex items-center justify-between mb-1">
-            <span className="text-xs text-gray-500">Progress</span>
-            <span className="text-xs font-semibold text-gray-700">
+            <span className="text-xs text-ink-3">Progress</span>
+            <span className="text-xs font-semibold text-ink-2">
               {outcome.progress_percentage}%
             </span>
           </div>
-          <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
+          <div className="h-2 w-full bg-surface-3 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all ${
-                outcome.status === 'completed' ? 'bg-green-500' : 'bg-gray-400'
+                outcome.status === 'completed' ? 'bg-forest' : 'bg-line'
               }`}
               style={{
                 width: `${Math.min(100, outcome.progress_percentage)}%`,
@@ -467,8 +467,8 @@ function OutcomeCard({
 
         {/* Commitments */}
         <div className="flex items-center justify-between text-sm border-t pt-3">
-          <span className="text-gray-500">Commitments</span>
-          <span className="font-medium text-gray-900">
+          <span className="text-ink-3">Commitments</span>
+          <span className="font-medium text-ink">
             {outcome.completed_commitment_count} / {outcome.commitment_count}
           </span>
         </div>
@@ -504,22 +504,22 @@ function OutcomeRow({
   const getStatusStyles = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'bg-green-500'
+        return 'bg-forest'
       case 'active':
-        return 'bg-blue-500'
+        return 'bg-ds-accent'
       case 'deferred':
-        return 'bg-yellow-500'
+        return 'bg-amber-token'
       case 'abandoned':
-        return 'bg-red-500'
+        return 'bg-vermillion'
       default:
-        return 'bg-gray-400'
+        return 'bg-line'
     }
   }
 
   return (
     <div
       onClick={onClick}
-      className="flex items-center gap-4 p-3 rounded-lg border border-gray-200 hover:bg-gray-50 cursor-pointer transition-colors"
+      className="flex items-center gap-4 p-3 rounded-lg border border-line hover:bg-paper cursor-pointer transition-colors"
     >
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
@@ -528,12 +528,10 @@ function OutcomeRow({
               outcome.status,
             )}`}
           />
-          <h4 className="font-medium text-gray-900 truncate">
-            {outcome.title}
-          </h4>
+          <h4 className="font-medium text-ink truncate">{outcome.title}</h4>
         </div>
         {outcome.vision_titles.length > 0 && (
-          <p className="text-xs text-gray-500 mt-1 ml-4 truncate">
+          <p className="text-xs text-ink-3 mt-1 ml-4 truncate">
             Vision: {outcome.vision_titles.join(', ')}
           </p>
         )}
@@ -542,10 +540,10 @@ function OutcomeRow({
       {/* Progress */}
       <div className="flex items-center gap-3 shrink-0">
         <div className="w-24">
-          <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
+          <div className="h-2 w-full bg-surface-3 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full ${
-                outcome.status === 'completed' ? 'bg-green-500' : 'bg-gray-400'
+                outcome.status === 'completed' ? 'bg-forest' : 'bg-line'
               }`}
               style={{
                 width: `${Math.min(100, outcome.progress_percentage)}%`,
@@ -553,12 +551,12 @@ function OutcomeRow({
             />
           </div>
         </div>
-        <span className="text-sm font-medium text-gray-700 w-10 text-right">
+        <span className="text-sm font-medium text-ink-2 w-10 text-right">
           {outcome.progress_percentage}%
         </span>
       </div>
 
-      <ChevronRight className="h-4 w-4 text-gray-400 shrink-0" />
+      <ChevronRight className="h-4 w-4 text-ink-4 shrink-0" />
     </div>
   )
 }

--- a/src/components/programs/program-theme-analysis.tsx
+++ b/src/components/programs/program-theme-analysis.tsx
@@ -54,7 +54,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
     return (
       <Card>
         <CardContent className="flex items-center justify-center py-12">
-          <p className="text-gray-600">No theme data available</p>
+          <p className="text-ink-3">No theme data available</p>
         </CardContent>
       </Card>
     )
@@ -65,8 +65,8 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">Theme Analysis</h2>
-          <p className="text-gray-600 mt-1">
+          <h2 className="text-2xl font-bold text-ink">Theme Analysis</h2>
+          <p className="text-ink-3 mt-1">
             Track conversation topics and patterns over time
           </p>
         </div>
@@ -92,7 +92,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <Sparkles className="h-5 w-5 text-yellow-600" />
+              <Sparkles className="h-5 w-5 text-amber-token" />
               <CardTitle>Emerging Themes</CardTitle>
             </div>
             <CardDescription>
@@ -105,7 +105,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
                 <Badge
                   key={theme}
                   variant="secondary"
-                  className="bg-yellow-50 text-yellow-700 border-yellow-200"
+                  className="bg-amber-token-bg text-amber-token border-amber-token"
                 >
                   <Sparkles className="h-3 w-3 mr-1" />
                   {theme}
@@ -122,14 +122,14 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <TrendingUp className="h-5 w-5 text-green-600" />
+              <TrendingUp className="h-5 w-5 text-forest" />
               <CardTitle>Trending Topics</CardTitle>
             </div>
             <CardDescription>Themes becoming more frequent</CardDescription>
           </CardHeader>
           <CardContent>
             {themes.trending_themes.length === 0 ? (
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-ink-3">
                 No trending themes identified
               </p>
             ) : (
@@ -137,17 +137,17 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
                 {themes.trending_themes.map(theme => (
                   <div key={theme.theme} className="p-3 border rounded-lg">
                     <div className="flex items-center justify-between mb-2">
-                      <span className="font-medium text-gray-900">
+                      <span className="font-medium text-ink">
                         {theme.theme}
                       </span>
                       <Badge
                         variant="outline"
-                        className="bg-green-50 text-green-700 border-green-200"
+                        className="bg-forest-bg text-forest border-forest"
                       >
                         {theme.total_count} mentions
                       </Badge>
                     </div>
-                    <div className="text-xs text-gray-600">
+                    <div className="text-xs text-ink-3">
                       <span>
                         First seen {formatRelativeTime(theme.first_seen)}
                       </span>
@@ -167,14 +167,14 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <TrendingDown className="h-5 w-5 text-orange-600" />
+              <TrendingDown className="h-5 w-5 text-amber-token" />
               <CardTitle>Declining Topics</CardTitle>
             </div>
             <CardDescription>Themes becoming less frequent</CardDescription>
           </CardHeader>
           <CardContent>
             {themes.declining_themes.length === 0 ? (
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-ink-3">
                 No declining themes identified
               </p>
             ) : (
@@ -182,17 +182,17 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
                 {themes.declining_themes.map(theme => (
                   <div key={theme.theme} className="p-3 border rounded-lg">
                     <div className="flex items-center justify-between mb-2">
-                      <span className="font-medium text-gray-900">
+                      <span className="font-medium text-ink">
                         {theme.theme}
                       </span>
                       <Badge
                         variant="outline"
-                        className="bg-orange-50 text-orange-700 border-orange-200"
+                        className="bg-amber-token-bg text-amber-token border-amber-token"
                       >
                         {theme.total_count} mentions
                       </Badge>
                     </div>
-                    <div className="text-xs text-gray-600">
+                    <div className="text-xs text-ink-3">
                       <span>
                         First seen {formatRelativeTime(theme.first_seen)}
                       </span>
@@ -228,7 +228,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
 
                 return (
                   <div key={theme.theme}>
-                    <h4 className="text-sm font-medium text-gray-900 mb-3">
+                    <h4 className="text-sm font-medium text-ink mb-3">
                       {theme.theme}
                     </h4>
                     <ResponsiveContainer width="100%" height={150}>
@@ -240,7 +240,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
                         <Line
                           type="monotone"
                           dataKey="count"
-                          stroke="#10B981"
+                          stroke="var(--forest)"
                           strokeWidth={2}
                         />
                       </LineChart>
@@ -258,7 +258,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <Network className="h-5 w-5 text-purple-600" />
+              <Network className="h-5 w-5 text-indigo" />
               <CardTitle>Related Themes</CardTitle>
             </div>
             <CardDescription>
@@ -270,13 +270,13 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
               {Object.entries(themes.theme_correlations).map(
                 ([theme, related]) => (
                   <div key={theme} className="p-4 border rounded-lg">
-                    <h4 className="font-medium text-gray-900 mb-3">{theme}</h4>
+                    <h4 className="font-medium text-ink mb-3">{theme}</h4>
                     <div className="flex flex-wrap gap-2">
                       {related.map(relatedTheme => (
                         <Badge
                           key={relatedTheme}
                           variant="secondary"
-                          className="bg-purple-50 text-purple-700 border-purple-200"
+                          className="bg-indigo-bg text-indigo border-indigo"
                         >
                           {relatedTheme}
                         </Badge>

--- a/src/components/programs/program-trends.tsx
+++ b/src/components/programs/program-trends.tsx
@@ -56,7 +56,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
     return (
       <Card>
         <CardContent className="flex items-center justify-center py-12">
-          <p className="text-gray-600">No trend data available</p>
+          <p className="text-ink-3">No trend data available</p>
         </CardContent>
       </Card>
     )
@@ -91,8 +91,8 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
       {/* Time Range Selector */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">Trend Analysis</h2>
-          <p className="text-gray-600 mt-1">
+          <h2 className="text-2xl font-bold text-ink">Trend Analysis</h2>
+          <p className="text-ink-3 mt-1">
             Session frequency and completion patterns over time
           </p>
         </div>
@@ -117,7 +117,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
       <Card>
         <CardHeader>
           <div className="flex items-center gap-2">
-            <Activity className="h-5 w-5 text-blue-600" />
+            <Activity className="h-5 w-5 text-ds-accent" />
             <CardTitle>Session Frequency</CardTitle>
           </div>
           <CardDescription>Number of sessions per week</CardDescription>
@@ -133,7 +133,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
               <Line
                 type="monotone"
                 dataKey="sessions"
-                stroke="#3B82F6"
+                stroke="var(--ds-accent)"
                 strokeWidth={2}
               />
             </LineChart>
@@ -147,7 +147,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <TrendingUp className="h-5 w-5 text-green-600" />
+              <TrendingUp className="h-5 w-5 text-forest" />
               <CardTitle>Completion Rate</CardTitle>
             </div>
             <CardDescription>
@@ -165,7 +165,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
                 <Line
                   type="monotone"
                   dataKey="rate"
-                  stroke="#10B981"
+                  stroke="var(--forest)"
                   strokeWidth={2}
                   name="Completion %"
                 />
@@ -178,7 +178,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <Calendar className="h-5 w-5 text-purple-600" />
+              <Calendar className="h-5 w-5 text-indigo" />
               <CardTitle>Sessions by Weekday</CardTitle>
             </div>
             <CardDescription>Which days have the most activity</CardDescription>
@@ -191,7 +191,7 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
                 <YAxis />
                 <Tooltip />
                 <Legend />
-                <Bar dataKey="sessions" fill="#8B5CF6" name="Sessions" />
+                <Bar dataKey="sessions" fill="var(--indigo)" name="Sessions" />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>
@@ -209,9 +209,9 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {Object.entries(trends.monthly_summary).map(([month, count]) => (
                 <div key={month} className="p-4 border rounded-lg">
-                  <p className="text-sm text-gray-600">{month}</p>
-                  <p className="text-2xl font-bold text-gray-900">{count}</p>
-                  <p className="text-xs text-gray-500">sessions</p>
+                  <p className="text-sm text-ink-3">{month}</p>
+                  <p className="text-2xl font-bold text-ink">{count}</p>
+                  <p className="text-xs text-ink-3">sessions</p>
                 </div>
               ))}
             </div>

--- a/src/components/programs/program-wins.tsx
+++ b/src/components/programs/program-wins.tsx
@@ -67,9 +67,9 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
 
   if (loading) {
     return (
-      <Card className="border-gray-200 shadow-sm">
+      <Card className="border-line shadow-sm">
         <CardContent className="py-12 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 text-gray-400 animate-spin" />
+          <Loader2 className="h-8 w-8 text-ink-4 animate-spin" />
         </CardContent>
       </Card>
     )
@@ -79,8 +79,8 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
     return (
       <Card>
         <CardContent className="py-12 text-center">
-          <Trophy className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-          <p className="text-gray-600">Unable to load wins data</p>
+          <Trophy className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+          <p className="text-ink-3">Unable to load wins data</p>
         </CardContent>
       </Card>
     )
@@ -96,12 +96,12 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
   return (
     <div className="space-y-6">
       {/* Summary Card */}
-      <Card className="bg-gradient-to-br from-amber-50 to-orange-50 border-amber-200">
+      <Card className=" border-amber-token">
         <CardHeader>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center">
-                <Trophy className="h-6 w-6 text-amber-600" />
+              <div className="w-12 h-12 rounded-full bg-amber-token-bg flex items-center justify-center">
+                <Trophy className="h-6 w-6 text-amber-token" />
               </div>
               <div>
                 <CardTitle className="text-xl">Sandbox Wins</CardTitle>
@@ -111,10 +111,10 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
               </div>
             </div>
             <div className="text-right">
-              <p className="text-3xl font-bold text-amber-700">
+              <p className="text-3xl font-bold text-amber-token">
                 {data.total_wins}
               </p>
-              <p className="text-sm text-amber-600">
+              <p className="text-sm text-amber-token">
                 Total Wins ({approvedWinsCount} approved)
               </p>
             </div>
@@ -122,36 +122,36 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <div className="bg-white/60 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-gray-900">
+            <div className="bg-surface-1/60 rounded-lg p-3 text-center">
+              <p className="text-2xl font-bold text-ink">
                 {data.clients.length}
               </p>
-              <p className="text-xs text-gray-600">Total Clients</p>
+              <p className="text-xs text-ink-3">Total Clients</p>
             </div>
-            <div className="bg-white/60 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-gray-900">
+            <div className="bg-surface-1/60 rounded-lg p-3 text-center">
+              <p className="text-2xl font-bold text-ink">
                 {clientsWithWins.length}
               </p>
-              <p className="text-xs text-gray-600">Clients with Wins</p>
+              <p className="text-xs text-ink-3">Clients with Wins</p>
             </div>
-            <div className="bg-white/60 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-gray-900">
+            <div className="bg-surface-1/60 rounded-lg p-3 text-center">
+              <p className="text-2xl font-bold text-ink">
                 {data.total_wins > 0
                   ? Math.round(
                       (data.total_wins / clientsWithWins.length) * 10,
                     ) / 10
                   : 0}
               </p>
-              <p className="text-xs text-gray-600">Avg Wins/Client</p>
+              <p className="text-xs text-ink-3">Avg Wins/Client</p>
             </div>
-            <div className="bg-white/60 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-gray-900">
+            <div className="bg-surface-1/60 rounded-lg p-3 text-center">
+              <p className="text-2xl font-bold text-ink">
                 {Math.round(
                   (approvedWinsCount / Math.max(data.total_wins, 1)) * 100,
                 )}
                 %
               </p>
-              <p className="text-xs text-gray-600">Approval Rate</p>
+              <p className="text-xs text-ink-3">Approval Rate</p>
             </div>
           </div>
         </CardContent>
@@ -160,39 +160,39 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
       {/* Clients with Wins */}
       {clientsWithWins.length > 0 ? (
         <Card>
-          <CardHeader className="bg-gray-50 border-b">
+          <CardHeader className="bg-paper border-b">
             <CardTitle className="text-lg">Wins by Client</CardTitle>
             <CardDescription>
               Click on a client to expand and see their wins
             </CardDescription>
           </CardHeader>
           <CardContent className="p-0">
-            <div className="divide-y divide-gray-100">
+            <div className="divide-y divide-line">
               {clientsWithWins
                 .sort((a, b) => b.total_wins - a.total_wins)
                 .map(client => (
-                  <div key={client.client_id} className="bg-white">
+                  <div key={client.client_id} className="bg-surface-1">
                     {/* Client Header */}
                     <button
                       onClick={() => toggleClient(client.client_id)}
-                      className="w-full px-6 py-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
+                      className="w-full px-6 py-4 flex items-center justify-between hover:bg-paper transition-colors"
                     >
                       <div className="flex items-center gap-3">
                         {expandedClients.has(client.client_id) ? (
-                          <ChevronDown className="h-5 w-5 text-gray-400" />
+                          <ChevronDown className="h-5 w-5 text-ink-4" />
                         ) : (
-                          <ChevronRight className="h-5 w-5 text-gray-400" />
+                          <ChevronRight className="h-5 w-5 text-ink-4" />
                         )}
-                        <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
-                          <User className="h-5 w-5 text-gray-500" />
+                        <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center">
+                          <User className="h-5 w-5 text-ink-3" />
                         </div>
                         <div className="text-left">
-                          <h4 className="font-medium text-gray-900">
+                          <h4 className="font-medium text-ink">
                             {client.client_name}
                           </h4>
                         </div>
                       </div>
-                      <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100">
+                      <Badge className="bg-amber-token-bg text-amber-token hover:bg-amber-token-bg">
                         {client.total_wins} win
                         {client.total_wins !== 1 ? 's' : ''}
                       </Badge>
@@ -206,36 +206,36 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
                             key={win.id}
                             className={`p-4 rounded-lg border ${
                               win.is_approved
-                                ? 'bg-white border-gray-200'
-                                : 'bg-amber-50 border-amber-200'
+                                ? 'bg-surface-1 border-line'
+                                : 'bg-amber-token-bg border-amber-token'
                             }`}
                           >
                             <div className="flex items-start gap-3">
                               <div
                                 className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
                                   win.is_approved
-                                    ? 'bg-amber-100'
-                                    : 'bg-amber-200'
+                                    ? 'bg-amber-token-bg'
+                                    : 'bg-amber-token-bg'
                                 }`}
                               >
                                 <Trophy
                                   className={`h-4 w-4 ${
                                     win.is_approved
-                                      ? 'text-amber-600'
-                                      : 'text-amber-700'
+                                      ? 'text-amber-token'
+                                      : 'text-amber-token'
                                   }`}
                                 />
                               </div>
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-start justify-between gap-2">
-                                  <h5 className="font-medium text-gray-900">
+                                  <h5 className="font-medium text-ink">
                                     {win.title}
                                   </h5>
                                   <div className="flex gap-1.5 flex-shrink-0">
                                     {win.is_ai_generated && (
                                       <Badge
                                         variant="secondary"
-                                        className="bg-gray-100 text-gray-500 text-xs"
+                                        className="bg-surface-3 text-ink-3 text-xs"
                                       >
                                         AI
                                       </Badge>
@@ -243,7 +243,7 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
                                     {!win.is_approved && (
                                       <Badge
                                         variant="secondary"
-                                        className="bg-amber-100 text-amber-700 text-xs"
+                                        className="bg-amber-token-bg text-amber-token text-xs"
                                       >
                                         Pending
                                       </Badge>
@@ -251,11 +251,11 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
                                   </div>
                                 </div>
                                 {win.description && (
-                                  <p className="text-sm text-gray-600 mt-1">
+                                  <p className="text-sm text-ink-3 mt-1">
                                     {win.description}
                                   </p>
                                 )}
-                                <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+                                <div className="flex items-center gap-4 mt-2 text-xs text-ink-3">
                                   {win.session_date && (
                                     <span className="flex items-center gap-1">
                                       <Calendar className="h-3 w-3" />
@@ -267,7 +267,7 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
                                   )}
                                   <Link
                                     href={`/sessions/${win.session_id}`}
-                                    className="flex items-center gap-1 text-blue-600 hover:underline"
+                                    className="flex items-center gap-1 text-ds-accent hover:underline"
                                     onClick={e => e.stopPropagation()}
                                   >
                                     <ExternalLink className="h-3 w-3" />
@@ -284,7 +284,7 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="w-full text-gray-600 hover:text-gray-900"
+                            className="w-full text-ink-3 hover:text-ink"
                           >
                             View Client Profile
                             <ExternalLink className="h-4 w-4 ml-2" />
@@ -300,11 +300,11 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
       ) : (
         <Card>
           <CardContent className="py-16 text-center">
-            <Trophy className="h-16 w-16 text-gray-300 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">
+            <Trophy className="h-16 w-16 text-ink-2 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold text-ink mb-2">
               No wins recorded yet
             </h3>
-            <p className="text-gray-600 max-w-md mx-auto">
+            <p className="text-ink-3 max-w-md mx-auto">
               Wins will appear here as they are recorded during coaching
               sessions. Use AI extraction from session details or add wins
               manually.
@@ -317,7 +317,7 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
       {clientsWithoutWins.length > 0 && (
         <Card className="border-dashed">
           <CardHeader>
-            <CardTitle className="text-base text-gray-600">
+            <CardTitle className="text-base text-ink-3">
               Clients Without Recorded Wins
             </CardTitle>
           </CardHeader>
@@ -330,7 +330,7 @@ export function ProgramWins({ programId }: ProgramWinsProps) {
                 >
                   <Badge
                     variant="outline"
-                    className="cursor-pointer hover:bg-gray-50 transition-colors"
+                    className="cursor-pointer hover:bg-paper transition-colors"
                   >
                     {client.client_name}
                   </Badge>

--- a/src/components/session-notes/notes-list.tsx
+++ b/src/components/session-notes/notes-list.tsx
@@ -272,13 +272,13 @@ export function NotesList({
       return (
         <div
           key={note.id}
-          className="border border-gray-300 rounded-xl p-4 bg-gray-50"
+          className="border border-line-strong rounded-xl p-4 bg-paper"
         >
           <Textarea
             value={editContent}
             onChange={e => setEditContent(e.target.value)}
             placeholder="Note content"
-            className="min-h-[120px] mb-3 border-gray-200 bg-white resize-none"
+            className="min-h-[120px] mb-3 border-line bg-surface-1 resize-none"
             autoFocus
           />
           <div className="flex items-center justify-end gap-2">
@@ -295,7 +295,7 @@ export function NotesList({
               size="sm"
               onClick={saveEdit}
               disabled={saving || !editContent.trim()}
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 "
             >
               {saving ? (
                 <Loader2 className="h-4 w-4 mr-1 animate-spin" />
@@ -312,16 +312,16 @@ export function NotesList({
     return (
       <div
         key={note.id}
-        className="group border border-gray-200 rounded-xl p-4 hover:border-gray-300 hover:shadow-sm transition-all bg-white"
+        className="group border border-line rounded-xl p-4 hover:border-line-strong hover:shadow-sm transition-all bg-surface-1"
       >
         {/* Header with type badge and actions */}
         <div className="flex items-start justify-between gap-3 mb-3">
           <div className="flex items-center gap-2">
-            <div className="h-7 w-7 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
-              <Icon className="h-3.5 w-3.5 text-gray-600" />
+            <div className="h-7 w-7 rounded-lg bg-surface-3 flex items-center justify-center flex-shrink-0">
+              <Icon className="h-3.5 w-3.5 text-ink-3" />
             </div>
-            <div className="flex items-center gap-2 text-xs text-gray-500">
-              <span className="font-medium text-gray-700">
+            <div className="flex items-center gap-2 text-xs text-ink-3">
+              <span className="font-medium text-ink-2">
                 {config.shortLabel}
               </span>
               <span>•</span>
@@ -329,7 +329,7 @@ export function NotesList({
               {note.updated_at !== note.created_at && (
                 <>
                   <span>•</span>
-                  <span className="text-gray-400">edited</span>
+                  <span className="text-ink-4">edited</span>
                 </>
               )}
             </div>
@@ -341,7 +341,7 @@ export function NotesList({
               variant="ghost"
               size="sm"
               onClick={() => startEditing(note)}
-              className="h-8 w-8 p-0 text-gray-500 hover:text-gray-900"
+              className="h-8 w-8 p-0 text-ink-3 hover:text-ink"
             >
               <Pencil className="h-3.5 w-3.5" />
             </Button>
@@ -349,7 +349,7 @@ export function NotesList({
               variant="ghost"
               size="sm"
               onClick={() => setNoteToDelete(note)}
-              className="h-8 w-8 p-0 text-gray-500 hover:text-red-600"
+              className="h-8 w-8 p-0 text-ink-3 hover:text-vermillion"
             >
               <Trash2 className="h-3.5 w-3.5" />
             </Button>
@@ -358,7 +358,7 @@ export function NotesList({
 
         {/* Content */}
         <div
-          className="text-sm text-gray-700 leading-relaxed prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-1"
+          className="text-sm text-ink-2 leading-relaxed prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-1"
           dangerouslySetInnerHTML={{ __html: note.content }}
         />
       </div>
@@ -371,14 +371,14 @@ export function NotesList({
       <div className="space-y-3">
         {loading ? (
           <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+            <Loader2 className="h-6 w-6 animate-spin text-ink-4" />
           </div>
         ) : displayedNotes.length > 0 ? (
           displayedNotes.map(renderNoteCard)
         ) : (
           <div className="text-center py-8">
-            <StickyNote className="h-10 w-10 mx-auto mb-3 text-gray-300" />
-            <p className="text-sm text-gray-500">No notes yet</p>
+            <StickyNote className="h-10 w-10 mx-auto mb-3 text-ink-2" />
+            <p className="text-sm text-ink-3">No notes yet</p>
           </div>
         )}
 
@@ -387,7 +387,7 @@ export function NotesList({
           open={!!noteToDelete}
           onOpenChange={open => !open && setNoteToDelete(null)}
         >
-          <AlertDialogContent className="bg-white">
+          <AlertDialogContent className="bg-surface-1">
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Note?</AlertDialogTitle>
               <AlertDialogDescription>
@@ -400,7 +400,7 @@ export function NotesList({
               <AlertDialogAction
                 onClick={handleDeleteNote}
                 disabled={deleting}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-vermillion hover:bg-vermillion"
               >
                 {deleting ? 'Deleting...' : 'Delete'}
               </AlertDialogAction>
@@ -421,8 +421,8 @@ export function NotesList({
             onClick={() => setActiveFilter('all')}
             className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
               activeFilter === 'all'
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                ? 'bg-ink text-ink-on-dark '
+                : 'bg-surface-3 text-ink-3 hover:bg-surface-3'
             }`}
           >
             All
@@ -439,8 +439,8 @@ export function NotesList({
                 onClick={() => setActiveFilter(type)}
                 className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
                   activeFilter === type
-                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    ? 'bg-ink text-ink-on-dark '
+                    : 'bg-surface-3 text-ink-3 hover:bg-surface-3'
                 }`}
               >
                 {config.shortLabel}
@@ -456,7 +456,7 @@ export function NotesList({
         <Button
           onClick={() => setShowCreateForm(true)}
           size="sm"
-          className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+          className="bg-ink hover:bg-ink-2 "
         >
           <Plus className="h-4 w-4 mr-1" />
           Add Note
@@ -465,13 +465,11 @@ export function NotesList({
 
       {/* Create note form */}
       {showCreateForm && (
-        <div className="border border-gray-200 rounded-xl p-4 bg-gray-50">
+        <div className="border border-line rounded-xl p-4 bg-paper">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
-              <StickyNote className="h-4 w-4 text-gray-600" />
-              <span className="text-sm font-medium text-gray-900">
-                New Note
-              </span>
+              <StickyNote className="h-4 w-4 text-ink-3" />
+              <span className="text-sm font-medium text-ink">New Note</span>
             </div>
             {/* Note type selector - compact */}
             <div className="flex items-center gap-1">
@@ -485,8 +483,8 @@ export function NotesList({
                     title={config.description}
                     className={`flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-lg transition-colors ${
                       newNoteType === type
-                        ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                        : 'bg-white border border-gray-200 text-gray-600 hover:border-gray-300'
+                        ? 'bg-ink text-ink-on-dark '
+                        : 'bg-surface-1 border border-line text-ink-3 hover:border-line-strong'
                     }`}
                   >
                     <TypeIcon className="h-3 w-3" />
@@ -501,7 +499,7 @@ export function NotesList({
             value={newNoteContent}
             onChange={e => setNewNoteContent(e.target.value)}
             placeholder="Capture your thoughts, observations, or action items..."
-            className="min-h-[120px] mb-3 border-gray-200 bg-white resize-none"
+            className="min-h-[120px] mb-3 border-line bg-surface-1 resize-none"
             autoFocus
           />
           <div className="flex items-center justify-end gap-2">
@@ -520,7 +518,7 @@ export function NotesList({
               size="sm"
               onClick={handleCreateNote}
               disabled={creating || !newNoteContent.trim()}
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 "
             >
               {creating ? (
                 <Loader2 className="h-4 w-4 mr-1 animate-spin" />
@@ -536,19 +534,19 @@ export function NotesList({
       {/* Notes list */}
       {loading ? (
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+          <Loader2 className="h-8 w-8 animate-spin text-ink-4" />
         </div>
       ) : displayedNotes.length > 0 ? (
         <div className="space-y-3">{displayedNotes.map(renderNoteCard)}</div>
       ) : (
-        <div className="text-center py-12 bg-gray-50 rounded-xl border border-gray-200">
-          <StickyNote className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-          <h3 className="font-medium text-gray-900 mb-1">
+        <div className="text-center py-12 bg-paper rounded-xl border border-line">
+          <StickyNote className="h-12 w-12 mx-auto mb-4 text-ink-2" />
+          <h3 className="font-medium text-ink mb-1">
             {activeFilter === 'all'
               ? 'No notes yet'
               : `No ${NOTE_TYPE_CONFIG[activeFilter as NoteType]?.label.toLowerCase() || 'notes'} yet`}
           </h3>
-          <p className="text-sm text-gray-500 mb-4">
+          <p className="text-sm text-ink-3 mb-4">
             {isClientPortal
               ? 'Add your reflections and thoughts about this session'
               : 'Capture important observations and insights'}
@@ -557,7 +555,7 @@ export function NotesList({
             onClick={() => setShowCreateForm(true)}
             size="sm"
             variant="outline"
-            className="border-gray-300"
+            className="border-line-strong"
           >
             <Plus className="h-4 w-4 mr-1" />
             Add your first note
@@ -567,7 +565,7 @@ export function NotesList({
 
       {/* Show more indicator */}
       {maxNotes && filteredNotes.length > maxNotes && (
-        <p className="text-center text-sm text-gray-500">
+        <p className="text-center text-sm text-ink-3">
           +{filteredNotes.length - maxNotes} more notes
         </p>
       )}
@@ -577,19 +575,19 @@ export function NotesList({
         open={!!noteToDelete}
         onOpenChange={open => !open && setNoteToDelete(null)}
       >
-        <AlertDialogContent className="bg-white border-gray-200">
+        <AlertDialogContent className="bg-surface-1 border-line">
           <AlertDialogHeader>
-            <AlertDialogTitle className="text-gray-900">
+            <AlertDialogTitle className="text-ink">
               Delete Note
             </AlertDialogTitle>
-            <AlertDialogDescription className="text-gray-600">
+            <AlertDialogDescription className="text-ink-3">
               Are you sure you want to delete &quot;{noteToDelete?.title}&quot;?
               This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel
-              className="border-gray-300 text-gray-900 hover:bg-gray-100"
+              className="border-line-strong text-ink hover:bg-surface-3"
               disabled={deleting}
             >
               Cancel
@@ -597,7 +595,7 @@ export function NotesList({
             <AlertDialogAction
               onClick={handleDeleteNote}
               disabled={deleting}
-              className="bg-red-600 hover:bg-red-700 text-white"
+              className="bg-vermillion hover:bg-vermillion text-ink-on-dark"
             >
               {deleting ? (
                 <>

--- a/src/components/session-notes/notes-list.tsx
+++ b/src/components/session-notes/notes-list.tsx
@@ -108,8 +108,23 @@ export function NotesList({
   )
   const [creating, setCreating] = useState(false)
 
-  // Get available note types based on portal type
+  // Types visible to the viewer. client_private notes are created during the
+  // live meeting via the guest endpoint — clients should see them after the
+  // call ends, but should not create new ones from the portal (no live token).
   const availableTypes: NoteType[] = isClientPortal
+    ? ['shared', 'client_reflection', 'client_private']
+    : [
+        'coach_private',
+        'shared',
+        'client_reflection',
+        'client_private',
+        'pre_session',
+        'post_session',
+      ]
+
+  // Types the viewer can create from the create-note form here. Excludes
+  // client_private for the client portal — that one is live-meeting-only.
+  const creatableTypes: NoteType[] = isClientPortal
     ? ['shared', 'client_reflection']
     : [
         'coach_private',
@@ -473,7 +488,7 @@ export function NotesList({
             </div>
             {/* Note type selector - compact */}
             <div className="flex items-center gap-1">
-              {availableTypes.map(type => {
+              {creatableTypes.map(type => {
                 const config = NOTE_TYPE_CONFIG[type]
                 const TypeIcon = config.icon
                 return (

--- a/src/components/session-notes/quick-note.tsx
+++ b/src/components/session-notes/quick-note.tsx
@@ -161,24 +161,22 @@ export function QuickNote({
   )
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-800 overflow-hidden h-full flex flex-col">
+    <div className="border border-line rounded-xl bg-surface-1 overflow-hidden h-full flex flex-col">
       {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between flex-shrink-0">
+      <div className="px-4 py-3 border-b border-line flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-2">
-          <FileText className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-          <span className="text-sm font-semibold text-gray-900 dark:text-white">
-            Notes
-          </span>
+          <FileText className="h-4 w-4 text-ink-2 " />
+          <span className="text-sm font-semibold text-ink ">Notes</span>
         </div>
 
         {/* Note type toggle */}
-        <div className="flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700 rounded-md p-0.5">
+        <div className="flex items-center gap-0.5 bg-surface-3 rounded-md p-0.5">
           <button
             onClick={() => setSelectedType('coach_private')}
             className={`flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${
               selectedType === 'coach_private'
-                ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                ? 'bg-surface-1 text-ink shadow-sm'
+                : 'text-ink-3 hover:text-ink-2 '
             }`}
           >
             <Lock className="h-3 w-3" />
@@ -188,8 +186,8 @@ export function QuickNote({
             onClick={() => setSelectedType('shared')}
             className={`flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${
               selectedType === 'shared'
-                ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                ? 'bg-surface-1 text-ink shadow-sm'
+                : 'text-ink-3 hover:text-ink-2 '
             }`}
           >
             <Users className="h-3 w-3" />
@@ -216,7 +214,7 @@ export function QuickNote({
             disabled={!hasContent(content)}
             size="sm"
             title="Save Note (Shift+Enter)"
-            className="bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+            className="bg-ink hover:bg-ink-2 "
           >
             <Check className="h-3.5 w-3.5 mr-1.5" />
             Save Note
@@ -230,13 +228,13 @@ export function QuickNote({
       {/* Session Notes List - collapsible */}
       {sortedNotes.length > 0 && (
         <div
-          className={`${notesListOpen ? 'flex-[2]' : 'flex-shrink-0'} min-h-0 border-t border-gray-100 dark:border-gray-700 flex flex-col`}
+          className={`${notesListOpen ? 'flex-[2]' : 'flex-shrink-0'} min-h-0 border-t border-line flex flex-col`}
         >
           <button
             onClick={() => setNotesListOpen(!notesListOpen)}
-            className="px-4 py-2 bg-gray-50 dark:bg-gray-700/50 flex items-center justify-between flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors w-full"
+            className="px-4 py-2 bg-paper flex items-center justify-between flex-shrink-0 hover:bg-surface-3 transition-colors w-full"
           >
-            <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+            <span className="text-xs font-medium text-ink-3 ">
               Session Notes
             </span>
             <div className="flex items-center gap-1.5">
@@ -244,9 +242,9 @@ export function QuickNote({
                 {sortedNotes.length}
               </Badge>
               {notesListOpen ? (
-                <ChevronUp className="h-3 w-3 text-gray-400" />
+                <ChevronUp className="h-3 w-3 text-ink-4" />
               ) : (
-                <ChevronDown className="h-3 w-3 text-gray-400" />
+                <ChevronDown className="h-3 w-3 text-ink-4" />
               )}
             </div>
           </button>
@@ -255,7 +253,7 @@ export function QuickNote({
               {sortedNotes.map(note => (
                 <div
                   key={note.id}
-                  className="px-4 py-3 border-b border-gray-50 dark:border-gray-700 last:border-b-0 hover:bg-gray-50/50 dark:hover:bg-gray-700/50"
+                  className="px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper/50 "
                 >
                   {editingNoteId === note.id ? (
                     // Edit mode
@@ -281,7 +279,7 @@ export function QuickNote({
                           disabled={
                             !hasContent(editContent) || updateNote.isPending
                           }
-                          className="h-7 text-xs bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+                          className="h-7 text-xs bg-ink hover:bg-ink-2 "
                         >
                           {updateNote.isPending ? (
                             <Loader2 className="h-3 w-3 mr-1 animate-spin" />
@@ -297,13 +295,13 @@ export function QuickNote({
                     <div>
                       <div className="flex items-start justify-between gap-2">
                         <div
-                          className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3 flex-1 prose prose-sm dark:prose-invert max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0.5"
+                          className="text-sm text-ink-2 line-clamp-3 flex-1 prose prose-sm dark:prose-invert max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-0.5"
                           dangerouslySetInnerHTML={{ __html: note.content }}
                         />
                         <div className="flex items-center gap-1 flex-shrink-0">
                           <button
                             onClick={() => handleStartEdit(note)}
-                            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                            className="p-1 text-ink-4 hover:text-ink-3 hover:bg-surface-3 rounded"
                             title="Edit note"
                           >
                             <Pencil className="h-3.5 w-3.5" />
@@ -316,17 +314,14 @@ export function QuickNote({
                           >
                             <PopoverTrigger asChild>
                               <button
-                                className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded"
+                                className="p-1 text-ink-4 hover:text-vermillion hover:bg-vermillion-bg rounded"
                                 title="Delete note"
                               >
                                 <Trash2 className="h-3.5 w-3.5" />
                               </button>
                             </PopoverTrigger>
-                            <PopoverContent
-                              className="w-auto p-3 dark:bg-gray-800 dark:border-gray-700"
-                              align="end"
-                            >
-                              <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
+                            <PopoverContent className="w-auto p-3 " align="end">
+                              <p className="text-sm text-ink-2 mb-2">
                                 Delete this note?
                               </p>
                               <div className="flex items-center gap-2">
@@ -361,8 +356,8 @@ export function QuickNote({
                           variant="outline"
                           className={`text-xs px-1.5 py-0 h-5 ${
                             note.note_type === 'coach_private'
-                              ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700'
-                              : 'border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                              ? 'border-line-strong text-ink-2 bg-paper '
+                              : 'border-ds-accent text-ds-accent bg-ds-accent-bg '
                           }`}
                         >
                           {note.note_type === 'coach_private' ? (
@@ -374,7 +369,7 @@ export function QuickNote({
                             ? 'Private'
                             : 'Shared'}
                         </Badge>
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-ink-4">
                           {formatRelativeTime(note.created_at)}
                         </span>
                       </div>
@@ -389,10 +384,10 @@ export function QuickNote({
 
       {/* Empty state for notes (only show after loading) */}
       {!notesLoading && sortedNotes.length === 0 && (
-        <div className="flex-shrink-0 border-t border-gray-100 dark:border-gray-700 px-4 py-3 flex items-center justify-center">
+        <div className="flex-shrink-0 border-t border-line px-4 py-3 flex items-center justify-center">
           <div className="text-center">
-            <FileText className="h-6 w-6 text-gray-300 dark:text-gray-600 mx-auto mb-1" />
-            <p className="text-xs text-gray-400">No notes captured yet</p>
+            <FileText className="h-6 w-6 text-ink-2 mx-auto mb-1" />
+            <p className="text-xs text-ink-4">No notes captured yet</p>
           </div>
         </div>
       )}

--- a/src/components/sessions/coach-evaluation-dialog.tsx
+++ b/src/components/sessions/coach-evaluation-dialog.tsx
@@ -224,10 +224,10 @@ export function CoachEvaluationDialog({
                   className={cn(
                     'block w-full h-1.5 rounded-full transition',
                     active
-                      ? 'bg-indigo-500'
+                      ? 'bg-indigo'
                       : answered
-                        ? 'bg-indigo-300 hover:bg-indigo-400'
-                        : 'bg-gray-200 hover:bg-gray-300',
+                        ? 'bg-indigo hover:bg-indigo'
+                        : 'bg-surface-3 hover:bg-line',
                   )}
                 />
               </li>
@@ -242,10 +242,10 @@ export function CoachEvaluationDialog({
               className={cn(
                 'block h-1.5 w-6 rounded-full transition',
                 onReview
-                  ? 'bg-indigo-500'
+                  ? 'bg-indigo'
                   : allAnswered
-                    ? 'bg-indigo-300 hover:bg-indigo-400'
-                    : 'bg-gray-100',
+                    ? 'bg-indigo hover:bg-indigo'
+                    : 'bg-surface-3',
               )}
             />
           </li>
@@ -267,7 +267,7 @@ export function CoachEvaluationDialog({
                     onClick={() => handleSelect(opt.value)}
                     disabled={isPending}
                     className={cn(
-                      'h-12 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-400',
+                      'h-12 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo',
                       'flex flex-col items-center justify-center px-1',
                       isSelected ? opt.selectedClass : opt.unselectedClass,
                     )}
@@ -279,23 +279,23 @@ export function CoachEvaluationDialog({
             </div>
             <p className="mt-5 text-xs text-app-secondary">
               Press{' '}
-              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-paper text-[10px] font-mono">
                 1
               </kbd>
               –
-              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-paper text-[10px] font-mono">
                 4
               </kbd>{' '}
               ·{' '}
-              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-paper text-[10px] font-mono">
                 N
               </kbd>{' '}
               for Not Observed ·{' '}
-              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-paper text-[10px] font-mono">
                 ←
               </kbd>
               /
-              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-gray-50 dark:bg-gray-800 text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-app-border bg-paper text-[10px] font-mono">
                 →
               </kbd>{' '}
               to navigate
@@ -318,7 +318,7 @@ export function CoachEvaluationDialog({
                       type="button"
                       onClick={() => setStep(i)}
                       title={q.text}
-                      className="flex items-center gap-2 rounded-md border border-app-border px-2 py-1.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      className="flex items-center gap-2 rounded-md border border-app-border px-2 py-1.5 text-left hover:bg-paper "
                     >
                       <span className="text-[10px] font-medium text-app-secondary shrink-0">
                         Q{i + 1}
@@ -376,7 +376,7 @@ export function CoachEvaluationDialog({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                className="text-vermillion hover:bg-vermillion-bg hover:text-vermillion"
                 onClick={() => setConfirmDeleteOpen(true)}
                 disabled={isPending}
               >
@@ -434,7 +434,7 @@ export function CoachEvaluationDialog({
             <AlertDialogAction
               onClick={handleDelete}
               disabled={isPending}
-              className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+              className="bg-vermillion hover:bg-vermillion focus:ring-vermillion"
             >
               Delete
             </AlertDialogAction>

--- a/src/components/sessions/comments-sidebar.tsx
+++ b/src/components/sessions/comments-sidebar.tsx
@@ -311,11 +311,11 @@ export const CommentsSidebar = forwardRef<
   )
 
   return (
-    <Card className={cn('border-gray-200 flex flex-col', className)}>
-      <CardHeader className="border-b border-gray-200 py-3">
+    <Card className={cn('border-line flex flex-col', className)}>
+      <CardHeader className="border-b border-line py-3">
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2 text-base font-semibold">
-            <MessageSquare className="h-4 w-4 text-gray-500" />
+            <MessageSquare className="h-4 w-4 text-ink-3" />
             Comments
           </CardTitle>
           <Badge variant="secondary" className="text-xs">
@@ -324,16 +324,16 @@ export const CommentsSidebar = forwardRef<
         </div>
       </CardHeader>
       <CardContent className="p-0">
-        <div className="border-b border-gray-100 p-3">
+        <div className="border-b border-line p-3">
           <div className="mb-2 flex items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-ink-3">
               At
             </span>
             {offsetEditValue === null ? (
               <button
                 type="button"
                 onClick={startEditingOffset}
-                className="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-0.5 font-mono text-xs text-indigo-700 ring-1 ring-indigo-100 hover:bg-indigo-100"
+                className="inline-flex items-center gap-1 rounded-full bg-indigo-bg px-2 py-0.5 font-mono text-xs text-indigo ring-1 ring-indigo hover:bg-indigo-bg"
                 title="Click to edit timestamp"
               >
                 <Clock className="h-3 w-3" />
@@ -364,7 +364,7 @@ export const CommentsSidebar = forwardRef<
               <button
                 type="button"
                 onClick={() => setDraftOffsetSec(getCurrentTime())}
-                className="text-[11px] text-gray-500 hover:text-indigo-600 hover:underline"
+                className="text-[11px] text-ink-3 hover:text-indigo hover:underline"
                 title="Pin to current playback time"
               >
                 use current
@@ -382,7 +382,7 @@ export const CommentsSidebar = forwardRef<
             className="min-h-[72px] resize-none text-sm"
           />
           <div className="mt-2 flex items-center justify-between">
-            <span className="text-[11px] text-gray-400">
+            <span className="text-[11px] text-ink-4">
               ⌘/Ctrl + Enter to send
             </span>
             <div className="flex items-center gap-2">
@@ -402,7 +402,7 @@ export const CommentsSidebar = forwardRef<
                 size="sm"
                 onClick={handleSubmit}
                 disabled={!draftContent.trim()}
-                className="bg-indigo-600 hover:bg-indigo-700 text-white"
+                className="bg-indigo hover:bg-indigo text-ink-on-dark"
               >
                 Comment
               </Button>
@@ -416,20 +416,20 @@ export const CommentsSidebar = forwardRef<
               {[0, 1, 2].map(i => (
                 <div
                   key={i}
-                  className="h-16 animate-pulse rounded-md bg-gray-100"
+                  className="h-16 animate-pulse rounded-md bg-surface-3"
                 />
               ))}
             </div>
           ) : threads.length === 0 ? (
-            <div className="px-4 py-10 text-center text-sm text-gray-500">
-              <p className="font-medium text-gray-700">No comments yet.</p>
-              <p className="mt-1 text-gray-500">
+            <div className="px-4 py-10 text-center text-sm text-ink-3">
+              <p className="font-medium text-ink-2">No comments yet.</p>
+              <p className="mt-1 text-ink-3">
                 Click any line in the transcript or the button above to leave
                 the first one.
               </p>
             </div>
           ) : (
-            <ul className="divide-y divide-gray-100">
+            <ul className="divide-y divide-line">
               {threads.map(thread => (
                 <ThreadItem
                   key={thread.id}
@@ -510,8 +510,8 @@ function ThreadItem({
       className={cn(
         'transition-colors',
         isActive
-          ? 'bg-indigo-50/60 ring-inset ring-1 ring-indigo-200'
-          : 'hover:bg-gray-50',
+          ? 'bg-indigo-bg/60 ring-inset ring-1 ring-indigo'
+          : 'hover:bg-paper',
       )}
     >
       <CommentBody
@@ -531,7 +531,7 @@ function ThreadItem({
       />
 
       {(replyCount > 0 || showingReplyComposer) && (
-        <div className="ml-7 border-l-2 border-indigo-100 pl-3 pb-3 pr-3 space-y-2">
+        <div className="ml-7 border-l-2 border-indigo pl-3 pb-3 pr-3 space-y-2">
           {thread.replies.map(reply => (
             <CommentBody
               key={reply.id}
@@ -549,7 +549,7 @@ function ThreadItem({
             />
           ))}
           {showingReplyComposer && (
-            <div className="rounded-md border border-gray-200 bg-white p-2">
+            <div className="rounded-md border border-line bg-surface-1 p-2">
               <Textarea
                 ref={replyTextareaRef}
                 value={replyValue}
@@ -567,7 +567,7 @@ function ThreadItem({
                 className="min-h-[56px] resize-none text-sm"
               />
               <div className="mt-1.5 flex items-center justify-between">
-                <span className="text-[11px] text-gray-400">
+                <span className="text-[11px] text-ink-4">
                   ⌘/Ctrl + Enter to send · Esc to cancel
                 </span>
                 <div className="flex items-center gap-1">
@@ -578,7 +578,7 @@ function ThreadItem({
                     size="sm"
                     onClick={onSubmitReply}
                     disabled={!replyValue.trim()}
-                    className="bg-indigo-600 hover:bg-indigo-700 text-white"
+                    className="bg-indigo hover:bg-indigo text-ink-on-dark"
                   >
                     Reply
                   </Button>
@@ -647,7 +647,7 @@ function CommentBody({
         <Button
           variant="ghost"
           size="sm"
-          className="h-5 w-5 p-0 text-gray-500 hover:text-indigo-700"
+          className="h-5 w-5 p-0 text-ink-3 hover:text-indigo"
           title="Edit"
           onClick={() => {
             setEditingId(comment.id)
@@ -663,7 +663,7 @@ function CommentBody({
             <Button
               variant="ghost"
               size="sm"
-              className="h-5 w-5 p-0 text-gray-500 hover:text-red-600 hover:bg-red-50"
+              className="h-5 w-5 p-0 text-ink-3 hover:text-vermillion hover:bg-vermillion-bg"
               title="Delete"
             >
               <Trash2 className="h-3 w-3" />
@@ -678,7 +678,7 @@ function CommentBody({
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={() => onDelete(comment.id)}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-vermillion hover:bg-vermillion"
               >
                 Delete
               </AlertDialogAction>
@@ -702,20 +702,20 @@ function CommentBody({
               e.stopPropagation()
               onSeek()
             }}
-            className="rounded-full bg-gray-100 px-2 py-0.5 font-mono text-[11px] text-gray-700 hover:bg-indigo-100 hover:text-indigo-700"
+            className="rounded-full bg-surface-3 px-2 py-0.5 font-mono text-[11px] text-ink-2 hover:bg-indigo-bg hover:text-indigo"
           >
             {formatVideoOffset(comment.video_offset_seconds)}
           </button>
         ) : (
-          <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
+          <span className="inline-flex items-center gap-1 text-[11px] text-ink-3">
             <CornerDownRight className="h-3 w-3" />
-            <span className="font-medium text-gray-700">{authorLabel}</span>
+            <span className="font-medium text-ink-2">{authorLabel}</span>
           </span>
         )}
-        <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
+        <span className="inline-flex items-center gap-1 text-[11px] text-ink-3">
           {showOffsetChip && (
             <>
-              <span className="font-medium text-gray-700">{authorLabel}</span>
+              <span className="font-medium text-ink-2">{authorLabel}</span>
               <span className="mx-1">·</span>
             </>
           )}
@@ -757,7 +757,7 @@ function CommentBody({
                 setEditingId(null)
                 setEditValue('')
               }}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white"
+              className="bg-indigo hover:bg-indigo text-ink-on-dark"
             >
               <Check className="h-3.5 w-3.5 mr-1" />
               Save
@@ -767,7 +767,7 @@ function CommentBody({
       ) : (
         <p
           className={cn(
-            'whitespace-pre-wrap text-sm leading-relaxed text-gray-800',
+            'whitespace-pre-wrap text-sm leading-relaxed text-ink-2',
             compact ? 'mt-0.5' : 'mt-1',
           )}
         >
@@ -783,13 +783,13 @@ function CommentBody({
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 px-2 text-xs text-gray-600 hover:text-indigo-700"
+              className="h-6 px-2 text-xs text-ink-3 hover:text-indigo"
               onClick={onReply}
             >
               <Reply className="h-3 w-3 mr-1" />
               Reply
               {replyCount > 0 && (
-                <span className="ml-1 text-[10px] text-gray-500">
+                <span className="ml-1 text-[10px] text-ink-3">
                   ({replyCount})
                 </span>
               )}
@@ -816,7 +816,7 @@ function CommentBody({
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-6 px-2 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
+                    className="h-6 px-2 text-xs text-vermillion hover:bg-vermillion-bg hover:text-vermillion"
                   >
                     <Trash2 className="h-3 w-3 mr-1" />
                     Delete
@@ -833,7 +833,7 @@ function CommentBody({
                     <AlertDialogCancel>Cancel</AlertDialogCancel>
                     <AlertDialogAction
                       onClick={() => onDelete(comment.id)}
-                      className="bg-red-600 hover:bg-red-700"
+                      className="bg-vermillion hover:bg-vermillion"
                     >
                       Delete
                     </AlertDialogAction>

--- a/src/components/sessions/evaluations-list.tsx
+++ b/src/components/sessions/evaluations-list.tsx
@@ -40,7 +40,7 @@ export function EvaluationsList({
   const avg = useMemo(() => averageScore(evaluations), [evaluations])
 
   return (
-    <section className="mt-6 rounded-lg border border-app-border bg-white dark:bg-gray-900 p-4">
+    <section className="mt-6 rounded-lg border border-app-border bg-surface-1 p-4">
       <header className="flex items-baseline justify-between mb-3">
         <h2 className="text-base font-semibold text-app-primary">
           Peer evaluations{' '}
@@ -120,16 +120,16 @@ function EvaluationRow({
   }
 
   return (
-    <li className="rounded-md border border-app-border bg-white dark:bg-gray-800">
+    <li className="rounded-md border border-app-border bg-surface-1 ">
       <button
         type="button"
         onClick={() => setExpanded(prev => !prev)}
-        className="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60"
+        className="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-paper "
       >
         {expanded ? (
-          <ChevronDown className="h-4 w-4 mt-0.5 text-gray-400 shrink-0" />
+          <ChevronDown className="h-4 w-4 mt-0.5 text-ink-4 shrink-0" />
         ) : (
-          <ChevronRight className="h-4 w-4 mt-0.5 text-gray-400 shrink-0" />
+          <ChevronRight className="h-4 w-4 mt-0.5 text-ink-4 shrink-0" />
         )}
         <div className="flex-1 min-w-0">
           <div className="flex items-baseline gap-2 flex-wrap">
@@ -137,7 +137,7 @@ function EvaluationRow({
               {reviewerLabel}
             </span>
             {isOwn && (
-              <span className="text-[10px] uppercase tracking-wide rounded bg-indigo-50 text-indigo-700 px-1.5 py-0.5">
+              <span className="text-[10px] uppercase tracking-wide rounded bg-indigo-bg text-indigo px-1.5 py-0.5">
                 you
               </span>
             )}
@@ -199,7 +199,7 @@ function EvaluationRow({
             })}
           </ol>
           {evaluation.feedback && (
-            <div className="rounded bg-gray-50 dark:bg-gray-900/40 p-2 mt-2">
+            <div className="rounded bg-paper p-2 mt-2">
               <p className="text-[10px] uppercase tracking-wide text-app-secondary mb-1">
                 Feedback
               </p>
@@ -214,7 +214,7 @@ function EvaluationRow({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                className="text-vermillion hover:bg-vermillion-bg hover:text-vermillion"
                 onClick={() => setConfirmOpen(true)}
                 disabled={deleteMut.isPending}
               >
@@ -244,7 +244,7 @@ function EvaluationRow({
             <AlertDialogAction
               onClick={handleDelete}
               disabled={deleteMut.isPending}
-              className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+              className="bg-vermillion hover:bg-vermillion focus:ring-vermillion"
             >
               Delete
             </AlertDialogAction>

--- a/src/components/sessions/manual-session-modal.tsx
+++ b/src/components/sessions/manual-session-modal.tsx
@@ -136,7 +136,7 @@ export function ManualSessionModal({
               htmlFor="client"
               className="text-base font-medium text-foreground"
             >
-              Client <span className="text-red-500">*</span>
+              Client <span className="text-vermillion">*</span>
             </Label>
             {loadingClients ? (
               <div className="flex items-center justify-center p-3 border rounded-md">
@@ -236,7 +236,7 @@ export function ManualSessionModal({
             <Button
               type="submit"
               disabled={creating || !formData.client_id || loadingClients}
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 text-ink-on-dark "
             >
               {creating ? (
                 <>

--- a/src/components/sessions/media-uploader.tsx
+++ b/src/components/sessions/media-uploader.tsx
@@ -202,28 +202,26 @@ export function MediaUploader({
                 className={cn(
                   'border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors',
                   isDragActive
-                    ? 'border-gray-900 bg-gray-50'
-                    : 'border-gray-300 hover:border-gray-400',
+                    ? 'border-line bg-paper'
+                    : 'border-line-strong hover:border-line-strong',
                   isProcessing && 'opacity-50 cursor-not-allowed',
                 )}
               >
                 <input {...getInputProps()} />
-                <Upload className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+                <Upload className="w-12 h-12 mx-auto text-ink-4 mb-4" />
                 {isDragActive ? (
-                  <p className="text-gray-900 font-medium">
-                    Drop the file here
-                  </p>
+                  <p className="text-ink font-medium">Drop the file here</p>
                 ) : (
                   <>
-                    <p className="text-gray-600 mb-2">
+                    <p className="text-ink-3 mb-2">
                       Drag & drop a file here, or click to select
                     </p>
-                    <p className="text-sm text-gray-400">
+                    <p className="text-sm text-ink-4">
                       Audio ({supportedFormats.audio.join(', ')}), Video (
                       {supportedFormats.video.join(', ')}), Documents (
                       {supportedFormats.documents.join(', ')})
                     </p>
-                    <p className="text-xs text-gray-400 mt-1">
+                    <p className="text-xs text-ink-4 mt-1">
                       Max 1GB for media, 10MB for documents
                     </p>
                   </>
@@ -232,12 +230,12 @@ export function MediaUploader({
             ) : (
               <div className="space-y-4">
                 {/* File Preview */}
-                <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                <div className="flex items-center justify-between p-4 bg-paper rounded-lg">
                   <div className="flex items-center space-x-3">
-                    <File className="w-8 h-8 text-gray-700" />
+                    <File className="w-8 h-8 text-ink-2" />
                     <div>
-                      <p className="font-medium text-gray-900">{file.name}</p>
-                      <p className="text-sm text-gray-500">
+                      <p className="font-medium text-ink">{file.name}</p>
+                      <p className="text-sm text-ink-3">
                         {formatFileSize(file.size)}
                       </p>
                     </div>
@@ -253,8 +251,8 @@ export function MediaUploader({
                 {uploading && (
                   <div className="space-y-2">
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-gray-600">Uploading...</span>
-                      <span className="text-gray-900 font-medium">
+                      <span className="text-ink-3">Uploading...</span>
+                      <span className="text-ink font-medium">
                         {uploadProgress}%
                       </span>
                     </div>
@@ -265,7 +263,7 @@ export function MediaUploader({
                 {/* Time estimate + upload button (before upload) */}
                 {!isProcessing && (
                   <>
-                    <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                    <div className="flex items-center gap-1.5 text-sm text-ink-3">
                       <Clock className="w-3.5 h-3.5" />
                       <span>
                         Estimated processing time:{' '}
@@ -276,7 +274,7 @@ export function MediaUploader({
                     <Button
                       onClick={handleUpload}
                       disabled={!file}
-                      className="w-full bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+                      className="w-full bg-ink hover:bg-ink-2 text-ink-on-dark "
                     >
                       <Upload className="w-4 h-4 mr-2" />
                       Upload & Process
@@ -300,11 +298,11 @@ export function MediaUploader({
               />
 
               {/* Character count + time estimate */}
-              <div className="flex items-center justify-between text-sm text-gray-500">
+              <div className="flex items-center justify-between text-sm text-ink-3">
                 <span>
                   {pastedText.length.toLocaleString()} chars
                   {pastedText.length > 0 && pastedText.length < 50 && (
-                    <span className="text-amber-600 ml-2">
+                    <span className="text-amber-token ml-2">
                       (minimum 50 characters)
                     </span>
                   )}
@@ -322,7 +320,7 @@ export function MediaUploader({
                 <Button
                   onClick={handlePasteSubmit}
                   disabled={pastedText.length < 50}
-                  className="w-full bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+                  className="w-full bg-ink hover:bg-ink-2 text-ink-on-dark "
                 >
                   <ClipboardPaste className="w-4 h-4 mr-2" />
                   Process Text

--- a/src/components/sessions/schedule-session-modal.tsx
+++ b/src/components/sessions/schedule-session-modal.tsx
@@ -161,7 +161,7 @@ export function ScheduleSessionModal({
           {!preselectedClientId && (
             <div className="space-y-2">
               <Label className="text-sm font-medium">
-                Client <span className="text-red-500">*</span>
+                Client <span className="text-vermillion">*</span>
               </Label>
               {loadingClients ? (
                 <div className="flex items-center justify-center p-3 border rounded-md">
@@ -187,7 +187,7 @@ export function ScheduleSessionModal({
           {/* Date Selection */}
           <div className="space-y-2">
             <Label className="text-sm font-medium">
-              Date <span className="text-red-500">*</span>
+              Date <span className="text-vermillion">*</span>
             </Label>
 
             {/* Quick date pills */}
@@ -200,8 +200,8 @@ export function ScheduleSessionModal({
                   className={cn(
                     'px-3 py-1.5 text-xs font-medium rounded-full border transition-all',
                     sessionDate && isSameDay(sessionDate, qd.date)
-                      ? 'bg-gray-900 text-white border-gray-900 dark:bg-white dark:text-gray-900 dark:border-white'
-                      : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400 hover:text-gray-900 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700 dark:hover:border-gray-500',
+                      ? 'bg-ink text-ink-on-dark border-line '
+                      : 'bg-surface-1 text-ink-3 border-line hover:border-line-strong hover:text-ink ',
                   )}
                 >
                   {qd.label}
@@ -285,8 +285,8 @@ export function ScheduleSessionModal({
                   className={cn(
                     'px-3 py-2 text-sm font-medium transition-colors',
                     period === 'AM'
-                      ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                      : 'bg-white text-gray-500 hover:text-gray-900 dark:bg-gray-800 dark:text-gray-400',
+                      ? 'bg-ink text-ink-on-dark '
+                      : 'bg-surface-1 text-ink-3 hover:text-ink ',
                   )}
                 >
                   AM
@@ -297,8 +297,8 @@ export function ScheduleSessionModal({
                   className={cn(
                     'px-3 py-2 text-sm font-medium transition-colors',
                     period === 'PM'
-                      ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                      : 'bg-white text-gray-500 hover:text-gray-900 dark:bg-gray-800 dark:text-gray-400',
+                      ? 'bg-ink text-ink-on-dark '
+                      : 'bg-surface-1 text-ink-3 hover:text-ink ',
                   )}
                 >
                   PM
@@ -383,7 +383,7 @@ export function ScheduleSessionModal({
                 !sessionDate ||
                 loadingClients
               }
-              className="bg-gray-900 dark:bg-white hover:bg-gray-800 dark:hover:bg-gray-100 text-white dark:text-gray-900"
+              className="bg-ink hover:bg-ink-2 text-ink-on-dark "
             >
               {scheduleSession.isPending ? (
                 <>

--- a/src/components/sessions/sentiment-gauge.tsx
+++ b/src/components/sessions/sentiment-gauge.tsx
@@ -29,31 +29,26 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
 
   // Get sentiment icon
   const getSentimentIcon = () => {
-    if (sentiment.score >= 7)
-      return <Smile className="h-8 w-8 text-gray-700 dark:text-gray-300" />
-    if (sentiment.score >= 4)
-      return <Meh className="h-8 w-8 text-gray-600 dark:text-gray-400" />
-    return <Frown className="h-8 w-8 text-gray-500 dark:text-gray-400" />
+    if (sentiment.score >= 7) return <Smile className="h-8 w-8 text-ink-2 " />
+    if (sentiment.score >= 4) return <Meh className="h-8 w-8 text-ink-3 " />
+    return <Frown className="h-8 w-8 text-ink-3 " />
   }
 
   // Get energy icon
   const getEnergyIcon = () => {
     const energy = sentiment.energy_level?.toLowerCase()
-    if (energy?.includes('high'))
-      return <Zap className="h-4 w-4 text-gray-700 dark:text-gray-300" />
+    if (energy?.includes('high')) return <Zap className="h-4 w-4 text-ink-2 " />
     if (energy?.includes('low'))
-      return <BatteryLow className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-    return <Battery className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+      return <BatteryLow className="h-4 w-4 text-ink-3 " />
+    return <Battery className="h-4 w-4 text-ink-3 " />
   }
 
   // Get engagement color
   const getEngagementColor = () => {
     const engagement = sentiment.engagement?.toLowerCase()
-    if (engagement === 'high')
-      return 'text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-700'
-    if (engagement === 'medium')
-      return 'text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700'
-    return 'text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700'
+    if (engagement === 'high') return 'text-ink bg-surface-3 '
+    if (engagement === 'medium') return 'text-ink-2 bg-paper '
+    return 'text-ink-3 bg-paper '
   }
 
   return (
@@ -66,7 +61,7 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
             <path
               d="M 20 90 A 80 80 0 0 1 180 90"
               fill="none"
-              className="stroke-gray-200 dark:stroke-gray-700"
+              className="stroke-ink-2 "
               strokeWidth="12"
               strokeLinecap="round"
             />
@@ -74,7 +69,7 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
             <path
               d="M 20 90 A 80 80 0 0 1 73 30"
               fill="none"
-              className="stroke-gray-400 dark:stroke-gray-600"
+              className="stroke-ink-4 "
               strokeWidth="10"
               strokeLinecap="round"
               opacity="0.3"
@@ -82,7 +77,7 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
             <path
               d="M 73 30 A 80 80 0 0 1 127 30"
               fill="none"
-              className="stroke-gray-500 dark:stroke-gray-500"
+              className="stroke-ink-3 "
               strokeWidth="10"
               strokeLinecap="round"
               opacity="0.3"
@@ -90,7 +85,7 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
             <path
               d="M 127 30 A 80 80 0 0 1 180 90"
               fill="none"
-              className="stroke-gray-700 dark:stroke-gray-300"
+              className="stroke-ink-2 "
               strokeWidth="10"
               strokeLinecap="round"
               opacity="0.3"
@@ -99,7 +94,7 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
 
           {/* Needle */}
           <div
-            className="absolute bottom-0 left-1/2 origin-bottom bg-gray-900 dark:bg-gray-100"
+            className="absolute bottom-0 left-1/2 origin-bottom bg-ink "
             style={{
               transform: `translateX(-50%) rotate(${rotation}deg)`,
               transition: 'transform 1s ease-out',
@@ -107,21 +102,21 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
               height: '75px',
             }}
           >
-            <div className="absolute -top-1 -left-1 w-3 h-3 bg-gray-900 dark:bg-gray-100 rounded-full" />
+            <div className="absolute -top-1 -left-1 w-3 h-3 bg-ink rounded-full" />
           </div>
 
           {/* Center dot */}
-          <div className="absolute bottom-0 left-1/2 w-4 h-4 bg-gray-900 dark:bg-gray-100 rounded-full transform -translate-x-1/2 translate-y-1/2" />
+          <div className="absolute bottom-0 left-1/2 w-4 h-4 bg-ink rounded-full transform -translate-x-1/2 translate-y-1/2" />
         </div>
 
         {/* Score and Icon */}
         <div className="flex items-center gap-3">
           {getSentimentIcon()}
           <div className="text-center">
-            <div className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            <div className="text-3xl font-bold text-ink ">
               {sentiment.score.toFixed(1)}
             </div>
-            <div className="text-sm font-medium text-gray-600 dark:text-gray-400 capitalize">
+            <div className="text-sm font-medium text-ink-3 capitalize">
               {sentiment.overall}
             </div>
           </div>
@@ -130,16 +125,14 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
 
       {/* Progression */}
       {sentiment.progression && (
-        <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
+        <div className="bg-paper rounded-lg p-3">
           <div className="flex items-start gap-2">
-            <Activity className="h-4 w-4 text-gray-600 dark:text-gray-400 mt-0.5" />
+            <Activity className="h-4 w-4 text-ink-3 mt-0.5" />
             <div className="flex-1">
-              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <p className="text-xs font-medium text-ink-2 mb-1">
                 Session Progression
               </p>
-              <p className="text-xs text-gray-600 dark:text-gray-400">
-                {sentiment.progression}
-              </p>
+              <p className="text-xs text-ink-3 ">{sentiment.progression}</p>
             </div>
           </div>
         </div>
@@ -149,12 +142,12 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
       <div className="grid grid-cols-2 gap-3">
         {/* Engagement */}
         {sentiment.engagement && (
-          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+          <div className="bg-surface-1 border border-line rounded-lg p-3">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+              <span className="text-xs font-medium text-ink-3 ">
                 Engagement
               </span>
-              <TrendingUp className="h-3 w-3 text-gray-400 dark:text-gray-500" />
+              <TrendingUp className="h-3 w-3 text-ink-4 " />
             </div>
             <span
               className={`inline-block px-2 py-0.5 rounded text-xs font-medium capitalize ${getEngagementColor()}`}
@@ -166,14 +159,12 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
 
         {/* Energy */}
         {sentiment.energy_level && (
-          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+          <div className="bg-surface-1 border border-line rounded-lg p-3">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-                Energy
-              </span>
+              <span className="text-xs font-medium text-ink-3 ">Energy</span>
               {getEnergyIcon()}
             </div>
-            <span className="text-xs font-medium text-gray-700 dark:text-gray-300 capitalize">
+            <span className="text-xs font-medium text-ink-2 capitalize">
               {sentiment.energy_level}
             </span>
           </div>
@@ -183,14 +174,14 @@ export function SentimentGauge({ sentiment }: SentimentGaugeProps) {
       {/* Emotions */}
       {sentiment.emotions && sentiment.emotions.length > 0 && (
         <div>
-          <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
+          <p className="text-xs font-medium text-ink-3 mb-2">
             Detected Emotions
           </p>
           <div className="flex flex-wrap gap-1.5">
             {sentiment.emotions.map((emotion, idx) => (
               <span
                 key={idx}
-                className="inline-block px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded text-xs capitalize"
+                className="inline-block px-2 py-1 bg-surface-3 text-ink-2 rounded text-xs capitalize"
               >
                 {emotion}
               </span>

--- a/src/components/sessions/session-card.tsx
+++ b/src/components/sessions/session-card.tsx
@@ -72,34 +72,28 @@ export function SessionCard({
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return (
-          <CheckCircle2 className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-        )
+        return <CheckCircle2 className="h-4 w-4 text-ink-2 " />
       case 'in_progress':
       case 'recording':
-        return (
-          <Circle className="h-4 w-4 text-gray-900 dark:text-white animate-pulse" />
-        )
+        return <Circle className="h-4 w-4 text-ink animate-pulse" />
       case 'error':
-        return (
-          <AlertCircle className="h-4 w-4 text-gray-800 dark:text-gray-200" />
-        )
+        return <AlertCircle className="h-4 w-4 text-ink-2 " />
       default:
-        return <Circle className="h-4 w-4 text-gray-400" />
+        return <Circle className="h-4 w-4 text-ink-4" />
     }
   }
 
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
+        return 'bg-ink text-ink-on-dark border-line '
       case 'in_progress':
       case 'recording':
-        return 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
+        return 'bg-ink-2 text-ink-on-dark border-line '
       case 'error':
-        return 'bg-gray-700 dark:bg-gray-300 text-white dark:text-gray-900 border-gray-700 dark:border-gray-300'
+        return 'bg-ink-2 text-ink-on-dark border-line '
       default:
-        return 'bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-700'
+        return 'bg-surface-3 text-ink-2 border-line '
     }
   }
 
@@ -155,7 +149,7 @@ export function SessionCard({
   }
 
   return (
-    <Card className="hover:shadow-lg transition-all duration-200 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-500">
+    <Card className="hover:shadow-lg transition-all duration-200 border border-line bg-surface-1 hover:border-line-strong ">
       <CardContent className="p-4 space-y-3">
         {/* Session Title - Editable */}
         {!isViewer && isEditingTitle ? (
@@ -174,7 +168,7 @@ export function SessionCard({
               size="sm"
               onClick={handleSaveTitle}
               disabled={isSavingTitle}
-              className="h-8 w-8 p-0 text-green-600 hover:text-green-700 hover:bg-green-50 dark:hover:bg-green-900/30"
+              className="h-8 w-8 p-0 text-forest hover:text-forest hover:bg-forest-bg "
             >
               <Check className="h-4 w-4" />
             </Button>
@@ -183,14 +177,14 @@ export function SessionCard({
               size="sm"
               onClick={handleCancelEdit}
               disabled={isSavingTitle}
-              className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30"
+              className="h-8 w-8 p-0 text-vermillion hover:text-vermillion hover:bg-vermillion-bg "
             >
               <X className="h-4 w-4" />
             </Button>
           </div>
         ) : (
           <div className="flex items-center gap-2 group">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white flex-1 line-clamp-1">
+            <h3 className="text-sm font-semibold text-ink flex-1 line-clamp-1">
               {displayTitle}
             </h3>
             {!isViewer && (
@@ -214,12 +208,12 @@ export function SessionCard({
           <div className="flex items-center gap-2 flex-1">
             {getStatusIcon(session.status)}
             <div className="flex flex-col">
-              <span className="text-sm font-semibold text-gray-900 dark:text-white">
+              <span className="text-sm font-semibold text-ink ">
                 {getPlatformName(session.meeting_url)}
               </span>
               {/* NEW: Coach and Client info */}
               {(coachName || clientName) && (
-                <span className="text-xs text-gray-500 dark:text-gray-400">
+                <span className="text-xs text-ink-3 ">
                   {coachName && (
                     <span className="font-medium">Coach: {coachName}</span>
                   )}
@@ -233,7 +227,7 @@ export function SessionCard({
           </div>
           <div className="flex items-center gap-2">
             {durationMinutes && (
-              <div className="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400">
+              <div className="flex items-center gap-1 text-xs text-ink-3 ">
                 <Clock className="h-3 w-3" />
                 <span className="font-medium">{durationMinutes}m</span>
               </div>
@@ -252,65 +246,63 @@ export function SessionCard({
         {/* AI Summary - The main focus */}
         {isViewer ? (
           // Viewers see restricted message instead of actual content
-          <div className="p-4 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl">
+          <div className="p-4 bg-paper border border-line rounded-xl">
             <div className="flex items-start gap-3">
-              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                <Lock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+              <div className="p-2 bg-surface-3 rounded-lg">
+                <Lock className="h-4 w-4 text-ink-3 " />
               </div>
               <div className="flex-1">
-                <p className="text-xs font-bold text-gray-700 dark:text-gray-300 mb-1.5 uppercase tracking-wider">
+                <p className="text-xs font-bold text-ink-2 mb-1.5 uppercase tracking-wider">
                   Restricted Access
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                <p className="text-sm text-ink-3 leading-relaxed">
                   Session content is not available with viewer permissions
                 </p>
               </div>
             </div>
           </div>
         ) : meetingSummary ? (
-          <div className="p-4 bg-gradient-to-b from-gray-50 to-white dark:from-gray-800 dark:to-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl">
+          <div className="p-4  border border-line rounded-xl">
             <div className="flex items-start gap-3">
-              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                <FileText className="h-4 w-4 text-gray-700 dark:text-gray-300" />
+              <div className="p-2 bg-surface-3 rounded-lg">
+                <FileText className="h-4 w-4 text-ink-2 " />
               </div>
               <div className="flex-1">
-                <p className="text-xs font-bold text-gray-900 dark:text-white mb-1.5 uppercase tracking-wider">
+                <p className="text-xs font-bold text-ink mb-1.5 uppercase tracking-wider">
                   Session Summary
                 </p>
-                <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed line-clamp-2">
+                <p className="text-sm text-ink-2 leading-relaxed line-clamp-2">
                   {meetingSummary}
                 </p>
               </div>
             </div>
           </div>
         ) : session.status === 'completed' ? (
-          <div className="p-4 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl">
-            <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">
+          <div className="p-4 bg-paper border border-line rounded-xl">
+            <p className="text-sm text-ink-3 font-medium">
               Processing summary...
             </p>
           </div>
         ) : session.status === 'in_progress' ||
           session.status === 'recording' ? (
-          <div className="p-4 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-xl">
+          <div className="p-4 bg-ink text-ink-on-dark rounded-xl">
             <p className="text-sm font-medium">
               Live Session • Recording in progress
             </p>
           </div>
         ) : (
-          <div className="p-4 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl">
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Initializing session...
-            </p>
+          <div className="p-4 bg-paper border border-line rounded-xl">
+            <p className="text-sm text-ink-3 ">Initializing session...</p>
           </div>
         )}
 
         {/* Footer with date, time and action */}
-        <div className="flex items-center justify-between pt-3 border-t border-gray-100 dark:border-gray-700">
+        <div className="flex items-center justify-between pt-3 border-t border-line ">
           <div className="flex flex-col">
-            <span className="text-xs text-gray-700 dark:text-gray-300 font-medium">
+            <span className="text-xs text-ink-2 font-medium">
               {formatDate(session.created_at, 'EEEE, MMM d, yyyy')}
             </span>
-            <span className="text-xs text-gray-400 dark:text-gray-500">
+            <span className="text-xs text-ink-4 ">
               {formatRelativeTime(session.created_at)}
             </span>
           </div>
@@ -320,7 +312,7 @@ export function SessionCard({
                 variant="ghost"
                 size="sm"
                 onClick={() => setShowEditModal(true)}
-                className="text-xs hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white font-medium"
+                className="text-xs hover:bg-surface-3 text-ink-2 hover:text-ink font-medium"
               >
                 <SquarePen className="h-3 w-3 mr-1" />
                 Edit
@@ -335,7 +327,7 @@ export function SessionCard({
                     variant="ghost"
                     size="sm"
                     disabled
-                    className="text-xs text-gray-400 font-medium cursor-not-allowed"
+                    className="text-xs text-ink-4 font-medium cursor-not-allowed"
                   >
                     <Lock className="h-3 w-3 mr-1" />
                     Restricted
@@ -346,7 +338,7 @@ export function SessionCard({
                   variant="ghost"
                   size="sm"
                   onClick={() => onViewDetails(session.id)}
-                  className="text-xs hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white font-medium"
+                  className="text-xs hover:bg-surface-3 text-ink-2 hover:text-ink font-medium"
                 >
                   <Eye className="h-3 w-3 mr-1" />
                   View Details

--- a/src/components/sessions/session-title-editor.tsx
+++ b/src/components/sessions/session-title-editor.tsx
@@ -82,28 +82,28 @@ export function SessionTitleEditor({
               }, 150)
             }}
             placeholder="Enter session title"
-            className="text-lg font-semibold text-gray-900 dark:text-white bg-transparent border-b border-gray-300 dark:border-gray-600 focus:border-gray-900 dark:focus:border-white outline-none w-full min-w-0"
+            className="text-lg font-semibold text-ink bg-transparent border-b border-line-strong focus:border-line outline-none w-full min-w-0"
             autoFocus
             disabled={isSaving}
           />
           <div className="flex items-center shrink-0">
             {isSaving ? (
               <div className="p-1">
-                <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-400" />
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-ink-4" />
               </div>
             ) : (
               <>
                 <button
                   onMouseDown={e => e.preventDefault()}
                   onClick={handleSave}
-                  className="p-1 rounded text-green-600 hover:text-green-700 hover:bg-green-50 dark:hover:bg-green-900/30 transition-colors"
+                  className="p-1 rounded text-forest hover:text-forest hover:bg-forest-bg transition-colors"
                 >
                   <Check className="h-3.5 w-3.5" />
                 </button>
                 <button
                   onMouseDown={e => e.preventDefault()}
                   onClick={handleCancel}
-                  className="p-1 rounded text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
+                  className="p-1 rounded text-vermillion hover:text-vermillion hover:bg-vermillion-bg transition-colors"
                 >
                   <X className="h-3.5 w-3.5" />
                 </button>
@@ -114,7 +114,7 @@ export function SessionTitleEditor({
       ) : (
         <>
           <h1
-            className="text-lg font-semibold text-gray-900 dark:text-white truncate cursor-pointer"
+            className="text-lg font-semibold text-ink truncate cursor-pointer"
             onClick={() => setIsEditing(true)}
             title={displayTitle}
           >

--- a/src/components/sessions/share-session-dialog.tsx
+++ b/src/components/sessions/share-session-dialog.tsx
@@ -130,7 +130,7 @@ export function ShareSessionDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-lg">
-            <Share2 className="h-5 w-5 text-indigo-600" />
+            <Share2 className="h-5 w-5 text-indigo" />
             Share session
           </DialogTitle>
           <DialogDescription>
@@ -141,11 +141,11 @@ export function ShareSessionDialog({
 
         <div className="space-y-4">
           <div>
-            <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">
+            <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-ink-3">
               Add coaches
             </label>
             <div className="relative">
-              <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-4" />
               <Input
                 value={search}
                 onChange={e => setSearch(e.target.value)}
@@ -153,12 +153,12 @@ export function ShareSessionDialog({
                 className="pl-8"
               />
               {searchQuery.isFetching && search && (
-                <Loader2 className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-gray-400" />
+                <Loader2 className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-ink-4" />
               )}
             </div>
 
             {search.trim() && visibleResults.length > 0 && (
-              <div className="mt-2 max-h-48 overflow-y-auto rounded-md border border-gray-200">
+              <div className="mt-2 max-h-48 overflow-y-auto rounded-md border border-line">
                 {visibleResults.map(u => (
                   <button
                     key={u.id}
@@ -170,15 +170,15 @@ export function ShareSessionDialog({
                         email: u.email,
                       })
                     }
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-paper"
                   >
                     <Initial label={u.full_name || u.email} />
                     <span className="flex-1">
-                      <span className="block text-gray-900">
+                      <span className="block text-ink">
                         {u.full_name || u.email}
                       </span>
                       {u.full_name && (
-                        <span className="block text-xs text-gray-500">
+                        <span className="block text-xs text-ink-3">
                           {u.email}
                         </span>
                       )}
@@ -191,12 +191,12 @@ export function ShareSessionDialog({
             {search.trim() &&
               !searchQuery.isFetching &&
               visibleResults.length === 0 && (
-                <p className="mt-2 text-xs text-gray-500">No matches.</p>
+                <p className="mt-2 text-xs text-ink-3">No matches.</p>
               )}
 
             {!search.trim() && recentVisible.length > 0 && (
               <div className="mt-2">
-                <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-gray-400">
+                <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-ink-4">
                   Recently shared with
                 </p>
                 <div className="flex flex-wrap gap-1.5">
@@ -205,7 +205,7 @@ export function ShareSessionDialog({
                       key={r.id}
                       type="button"
                       onClick={() => handleAdd(r)}
-                      className="rounded-full border border-gray-200 px-2.5 py-1 text-xs text-gray-700 hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700"
+                      className="rounded-full border border-line px-2.5 py-1 text-xs text-ink-2 hover:border-indigo hover:bg-indigo-bg hover:text-indigo"
                     >
                       {r.full_name || r.email}
                     </button>
@@ -216,7 +216,7 @@ export function ShareSessionDialog({
           </div>
 
           <div>
-            <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-gray-500">
+            <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-ink-3">
               Shared with
             </label>
             {sharesQuery.isLoading ? (
@@ -224,7 +224,7 @@ export function ShareSessionDialog({
                 {[0, 1].map(i => (
                   <div
                     key={i}
-                    className="h-7 animate-pulse rounded bg-gray-100"
+                    className="h-7 animate-pulse rounded bg-surface-3"
                   />
                 ))}
               </div>
@@ -233,14 +233,14 @@ export function ShareSessionDialog({
                 {sharesQuery.data.shares.map(s => (
                   <span
                     key={s.id}
-                    className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-700 ring-1 ring-indigo-200"
+                    className="inline-flex items-center gap-1.5 rounded-full bg-indigo-bg px-2.5 py-1 text-xs text-indigo ring-1 ring-indigo"
                   >
                     {s.shared_with_name || s.shared_with_email}
                     <button
                       type="button"
                       onClick={() => handleRevoke(s.id)}
                       disabled={revokeMut.isPending}
-                      className="rounded-full p-0.5 text-indigo-400 hover:bg-indigo-100 hover:text-indigo-700"
+                      className="rounded-full p-0.5 text-indigo hover:bg-indigo-bg hover:text-indigo"
                       aria-label={`Remove ${s.shared_with_name || s.shared_with_email}`}
                     >
                       <X className="h-3 w-3" />
@@ -249,19 +249,17 @@ export function ShareSessionDialog({
                 ))}
               </div>
             ) : (
-              <p className="text-xs text-gray-500">
-                Not shared with anyone yet.
-              </p>
+              <p className="text-xs text-ink-3">Not shared with anyone yet.</p>
             )}
           </div>
 
-          <div className="flex items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
-            <Users className="mt-0.5 h-4 w-4 text-gray-500" />
+          <div className="flex items-start gap-3 rounded-md border border-line bg-paper p-3">
+            <Users className="mt-0.5 h-4 w-4 text-ink-3" />
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-900">
+              <p className="text-sm font-medium text-ink">
                 Share with all coaches
               </p>
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-ink-3">
                 Anyone in your team with a coach role will be able to view and
                 comment.
               </p>
@@ -289,7 +287,7 @@ function Initial({ label }: { label: string }) {
   return (
     <span
       className={cn(
-        'flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-100 text-[11px] font-medium text-indigo-700',
+        'flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-bg text-[11px] font-medium text-indigo',
       )}
     >
       {initial}

--- a/src/components/sessions/shared-session-row.tsx
+++ b/src/components/sessions/shared-session-row.tsx
@@ -70,15 +70,15 @@ export function SharedSessionRow({ session, onOpen }: SharedSessionRowProps) {
       }}
       className={cn(
         'group flex flex-col sm:flex-row gap-4 p-4 cursor-pointer',
-        'border border-app-border bg-white dark:bg-gray-900',
-        'hover:border-indigo-300 hover:shadow-md transition-all duration-150',
-        'focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2',
+        'border border-app-border bg-surface-1 ',
+        'hover:border-indigo hover:shadow-md transition-all duration-150',
+        'focus:outline-none focus:ring-2 focus:ring-indigo focus:ring-offset-2',
       )}
     >
       {/* Thumbnail */}
       <div
         className={cn(
-          'relative flex-shrink-0 overflow-hidden rounded-lg bg-gray-900',
+          'relative flex-shrink-0 overflow-hidden rounded-lg bg-ink',
           'w-full sm:w-64 aspect-video',
         )}
       >
@@ -98,26 +98,26 @@ export function SharedSessionRow({ session, onOpen }: SharedSessionRowProps) {
               )}
             />
             {!thumbReady && (
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
-                <Video className="h-8 w-8 text-gray-500 animate-pulse" />
+              <div className="absolute inset-0 flex items-center justify-center bg-ink-2">
+                <Video className="h-8 w-8 text-ink-3 animate-pulse" />
               </div>
             )}
             {/* Play overlay */}
-            <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/20 transition-colors">
-              <div className="rounded-full bg-white/90 p-3 shadow-lg opacity-90 group-hover:opacity-100 group-hover:scale-110 transition-transform">
-                <Play className="h-5 w-5 text-gray-900 fill-current" />
+            <div className="absolute inset-0 flex items-center justify-center bg-overlay group-hover:bg-overlay transition-colors">
+              <div className="rounded-full bg-surface-1/90 p-3 shadow-lg opacity-90 group-hover:opacity-100 group-hover:scale-110 transition-transform">
+                <Play className="h-5 w-5 text-ink fill-current" />
               </div>
             </div>
             {duration && (
-              <div className="absolute bottom-2 right-2 rounded bg-black/70 px-1.5 py-0.5 text-xs font-medium text-white">
+              <div className="absolute bottom-2 right-2 rounded bg-overlay px-1.5 py-0.5 text-xs font-medium text-ink-on-dark">
                 {duration}
               </div>
             )}
           </>
         ) : (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-gray-100 dark:bg-gray-800">
-            <Video className="h-8 w-8 text-gray-400" />
-            <span className="text-xs text-gray-500 dark:text-gray-400">
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-3 ">
+            <Video className="h-8 w-8 text-ink-4" />
+            <span className="text-xs text-ink-3 ">
               {session.video_unavailable
                 ? 'Recording unavailable'
                 : 'No recording yet'}
@@ -165,7 +165,7 @@ export function SharedSessionRow({ session, onOpen }: SharedSessionRowProps) {
               {dateLabel} · {relative}
             </span>
           </div>
-          <span className="flex items-center gap-1.5 text-xs font-medium text-indigo-600 group-hover:text-indigo-700">
+          <span className="flex items-center gap-1.5 text-xs font-medium text-indigo group-hover:text-indigo">
             <MessageSquare className="h-3.5 w-3.5" />
             Open review
           </span>

--- a/src/components/sessions/transcript-pane.tsx
+++ b/src/components/sessions/transcript-pane.tsx
@@ -44,12 +44,12 @@ interface TranscriptPaneProps {
 }
 
 const SPEAKER_PALETTE = [
-  'bg-indigo-50 text-indigo-700 ring-indigo-100',
-  'bg-emerald-50 text-emerald-700 ring-emerald-100',
-  'bg-amber-50 text-amber-700 ring-amber-100',
-  'bg-rose-50 text-rose-700 ring-rose-100',
-  'bg-sky-50 text-sky-700 ring-sky-100',
-  'bg-violet-50 text-violet-700 ring-violet-100',
+  'bg-indigo-bg text-indigo ring-indigo',
+  'bg-forest-bg text-forest ring-forest',
+  'bg-amber-token-bg text-amber-token ring-amber-token',
+  'bg-vermillion-bg text-vermillion ring-vermillion',
+  'bg-ds-accent-bg text-ds-accent ring-ds-accent',
+  'bg-indigo-bg text-indigo ring-indigo',
 ]
 
 function speakerSwatch(speaker: string): string {
@@ -70,9 +70,7 @@ function highlightMatch(text: string, needle: string): React.ReactNode {
   return (
     <>
       {before}
-      <mark className="rounded bg-yellow-200 px-0.5 text-gray-900">
-        {match}
-      </mark>
+      <mark className="rounded bg-amber-token-bg px-0.5 text-ink">{match}</mark>
       {after}
     </>
   )
@@ -169,10 +167,10 @@ export const TranscriptPane = forwardRef<
   const visibleMatchSet = useMemo(() => new Set(matches), [matches])
 
   return (
-    <Card className={cn('border-gray-200 flex flex-col', className)}>
-      <CardHeader className="border-b border-gray-200 py-3">
+    <Card className={cn('border-line flex flex-col', className)}>
+      <CardHeader className="border-b border-line py-3">
         <div className="flex items-center justify-between gap-3">
-          <CardTitle className="text-base font-semibold text-gray-900">
+          <CardTitle className="text-base font-semibold text-ink">
             Transcript
           </CardTitle>
           <div className="flex items-center gap-2">
@@ -183,7 +181,7 @@ export const TranscriptPane = forwardRef<
                 size="sm"
                 onClick={scrollToActive}
                 title="Scroll the transcript to where the video is"
-                className="h-7 px-2 text-xs text-indigo-600 hover:bg-indigo-50 hover:text-indigo-700"
+                className="h-7 px-2 text-xs text-indigo hover:bg-indigo-bg hover:text-indigo"
               >
                 <Crosshair className="h-3.5 w-3.5 mr-1" />
                 Jump to current
@@ -195,7 +193,7 @@ export const TranscriptPane = forwardRef<
           </div>
         </div>
         <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-4" />
           <Input
             ref={searchRef}
             value={search}
@@ -208,14 +206,14 @@ export const TranscriptPane = forwardRef<
             <button
               type="button"
               onClick={() => setSearch('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-4 hover:text-ink-3"
               aria-label="Clear search"
             >
               <X className="h-3.5 w-3.5" />
             </button>
           )}
           {search && matches.length > 0 && (
-            <span className="absolute right-7 top-1/2 -translate-y-1/2 text-[11px] text-gray-500">
+            <span className="absolute right-7 top-1/2 -translate-y-1/2 text-[11px] text-ink-3">
               {matchIndex + 1}/{matches.length}
             </span>
           )}
@@ -223,7 +221,7 @@ export const TranscriptPane = forwardRef<
       </CardHeader>
       <CardContent className="p-0">
         {entries.length === 0 ? (
-          <div className="px-4 py-12 text-center text-sm text-gray-500">
+          <div className="px-4 py-12 text-center text-sm text-ink-3">
             {videoAnchorAt
               ? 'Transcript not available yet — usually ready a minute or two after the session ends.'
               : 'Session timing data is not available, so the transcript cannot be synced with the video.'}
@@ -231,7 +229,7 @@ export const TranscriptPane = forwardRef<
         ) : (
           <div
             ref={containerRef}
-            className="max-h-[28rem] overflow-y-auto divide-y divide-gray-100"
+            className="max-h-[28rem] overflow-y-auto divide-y divide-line"
             role="list"
             aria-label="Transcript synced with video"
           >
@@ -249,16 +247,16 @@ export const TranscriptPane = forwardRef<
                   className={cn(
                     'group relative px-4 py-3 transition-colors',
                     isActive
-                      ? 'bg-indigo-50/70 border-l-4 border-l-indigo-500 pl-3'
-                      : 'border-l-4 border-l-transparent hover:bg-gray-50',
-                    isMatch && !isActive && 'bg-yellow-50/60',
+                      ? 'bg-indigo-bg/70 border-l-4 border-l-indigo-500 pl-3'
+                      : 'border-l-4 border-l-transparent hover:bg-paper',
+                    isMatch && !isActive && 'bg-amber-token-bg/60',
                   )}
                 >
                   <div className="flex items-start gap-3">
                     <button
                       type="button"
                       onClick={() => onSeek(offsetSec)}
-                      className="shrink-0 rounded font-mono text-[11px] text-gray-500 hover:text-indigo-600 hover:underline"
+                      className="shrink-0 rounded font-mono text-[11px] text-ink-3 hover:text-indigo hover:underline"
                       title="Jump to this moment"
                     >
                       {formatVideoOffset(offsetSec)}
@@ -274,7 +272,7 @@ export const TranscriptPane = forwardRef<
                     <p
                       className={cn(
                         'flex-1 text-sm leading-relaxed cursor-pointer',
-                        isActive ? 'text-gray-900' : 'text-gray-700',
+                        isActive ? 'text-ink' : 'text-ink-2',
                       )}
                       onClick={() => onSeek(offsetSec)}
                     >

--- a/src/components/sessions/video-player.tsx
+++ b/src/components/sessions/video-player.tsx
@@ -179,7 +179,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
     if (videoUnavailable) {
       return (
-        <Card className={cn('border-gray-200', className)}>
+        <Card className={cn('border-line', className)}>
           <CardHeader className="pb-4">
             <CardTitle className="flex items-center gap-2 text-lg">
               <Video className="h-5 w-5" />
@@ -188,11 +188,11 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           </CardHeader>
           <CardContent>
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <VideoOff className="h-12 w-12 text-amber-500 mb-4" />
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <VideoOff className="h-12 w-12 text-amber-token mb-4" />
+              <h3 className="text-lg font-semibold text-ink mb-2">
                 Recording no longer available
               </h3>
-              <p className="text-gray-500 max-w-md">
+              <p className="text-ink-3 max-w-md">
                 This session was recorded, but the video file expired before it
                 could be archived. The transcript and analysis are still
                 available below.
@@ -205,7 +205,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
     if (!videoUrl) {
       return (
-        <Card className={cn('border-gray-200', className)}>
+        <Card className={cn('border-line', className)}>
           <CardHeader className="pb-4">
             <CardTitle className="flex items-center gap-2 text-lg">
               <Video className="h-5 w-5" />
@@ -214,11 +214,11 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           </CardHeader>
           <CardContent>
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <VideoOff className="h-12 w-12 text-gray-300 mb-4" />
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <VideoOff className="h-12 w-12 text-ink-2 mb-4" />
+              <h3 className="text-lg font-semibold text-ink mb-2">
                 No Recording Available
               </h3>
-              <p className="text-gray-500 max-w-md">
+              <p className="text-ink-3 max-w-md">
                 This session does not have a video recording. Recordings are
                 only available for sessions conducted with the meeting bot.
               </p>
@@ -230,7 +230,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
     if (error && !refreshing) {
       return (
-        <Card className={cn('border-gray-200', className)}>
+        <Card className={cn('border-line', className)}>
           <CardHeader className="pb-4">
             <CardTitle className="flex items-center gap-2 text-lg">
               <Video className="h-5 w-5" />
@@ -239,18 +239,18 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           </CardHeader>
           <CardContent>
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <AlertCircle className="h-12 w-12 text-amber-500 mb-4" />
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <AlertCircle className="h-12 w-12 text-amber-token mb-4" />
+              <h3 className="text-lg font-semibold text-ink mb-2">
                 Video URL Expired
               </h3>
-              <p className="text-gray-500 mb-6 max-w-md">
+              <p className="text-ink-3 mb-6 max-w-md">
                 The video link has expired. Click the button below to get a
                 fresh link.
               </p>
               <Button
                 onClick={handleRefresh}
                 disabled={refreshing}
-                className="bg-black hover:bg-gray-800 text-white"
+                className="bg-ink hover:bg-ink-2 text-ink-on-dark"
               >
                 {refreshing ? (
                   <>
@@ -271,7 +271,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     }
 
     return (
-      <Card className={cn('border-gray-200', className)}>
+      <Card className={cn('border-line', className)}>
         <CardHeader className="pb-4">
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2 text-lg">
@@ -283,7 +283,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               size="sm"
               onClick={handleRefresh}
               disabled={refreshing}
-              className="border-gray-300 hover:bg-gray-50"
+              className="border-line-strong hover:bg-paper"
             >
               {refreshing ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -294,12 +294,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           </div>
         </CardHeader>
         <CardContent>
-          <div className="relative rounded-lg overflow-hidden bg-black">
+          <div className="relative rounded-lg overflow-hidden bg-ink">
             {loading && (
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-900 z-10">
+              <div className="absolute inset-0 flex items-center justify-center bg-ink z-10">
                 <div className="flex flex-col items-center">
-                  <Loader2 className="h-8 w-8 text-white animate-spin mb-2" />
-                  <p className="text-white text-sm">Loading video...</p>
+                  <Loader2 className="h-8 w-8 text-ink-on-dark animate-spin mb-2" />
+                  <p className="text-ink-on-dark text-sm">Loading video...</p>
                 </div>
               </div>
             )}
@@ -325,7 +325,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
           {visibleMarkers.length > 0 && (
             <div className="mt-2">
-              <div className="relative h-3 w-full rounded bg-gray-100">
+              <div className="relative h-3 w-full rounded bg-surface-3">
                 {visibleMarkers.map(m => (
                   <button
                     key={m.id}
@@ -335,21 +335,21 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
                     className={cn(
                       'absolute top-1/2 -translate-x-1/2 -translate-y-1/2 h-2.5 w-2.5 rounded-full transition-transform hover:scale-150',
                       m.tone === 'mine'
-                        ? 'bg-indigo-500 ring-1 ring-indigo-200'
-                        : 'bg-amber-500 ring-1 ring-amber-200',
+                        ? 'bg-indigo ring-1 ring-indigo'
+                        : 'bg-amber-token ring-1 ring-amber-token',
                     )}
                     style={{ left: `${m.leftPercent}%` }}
                   />
                 ))}
               </div>
-              <div className="mt-1 flex items-center justify-between text-[11px] text-gray-400">
+              <div className="mt-1 flex items-center justify-between text-[11px] text-ink-4">
                 <span>0:00</span>
                 <span>{formatClock(duration)}</span>
               </div>
             </div>
           )}
 
-          <p className="text-xs text-gray-500 mt-3 text-center">
+          <p className="text-xs text-ink-3 mt-3 text-center">
             Video links expire periodically. If playback fails, click the
             refresh button to get a new link.
           </p>

--- a/src/components/sessions/video-review-panel.tsx
+++ b/src/components/sessions/video-review-panel.tsx
@@ -236,16 +236,14 @@ export function VideoReviewPanel({
   return (
     <div className={cn('space-y-4', className)}>
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-base font-semibold text-gray-900">
-          Session review
-        </h3>
+        <h3 className="text-base font-semibold text-ink">Session review</h3>
         <div className="flex items-center gap-1">
           <Button
             variant="ghost"
             size="sm"
             onClick={() => setHelpOpen(true)}
             title="Keyboard shortcuts"
-            className="text-gray-500 hover:text-gray-700"
+            className="text-ink-3 hover:text-ink-2"
           >
             <Keyboard className="h-4 w-4" />
           </Button>
@@ -254,7 +252,7 @@ export function VideoReviewPanel({
               variant="outline"
               size="sm"
               onClick={() => setShareOpen(true)}
-              className="border-indigo-200 text-indigo-700 hover:bg-indigo-50"
+              className="border-indigo text-indigo hover:bg-indigo-bg"
             >
               <Share2 className="h-4 w-4 mr-1.5" />
               Share
@@ -278,7 +276,7 @@ export function VideoReviewPanel({
                   variant="ghost"
                   size="sm"
                   onClick={() => setTranscriptOpen(false)}
-                  className="h-7 px-2 text-xs text-gray-600 hover:text-gray-900"
+                  className="h-7 px-2 text-xs text-ink-3 hover:text-ink"
                 >
                   <ChevronDown className="h-3.5 w-3.5 mr-1" />
                   Hide transcript
@@ -290,20 +288,20 @@ export function VideoReviewPanel({
             <button
               type="button"
               onClick={() => setTranscriptOpen(true)}
-              className="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-left hover:bg-gray-50"
+              className="flex w-full items-center justify-between gap-2 rounded-lg border border-line bg-surface-1 px-4 py-2.5 text-left hover:bg-paper"
               aria-expanded={false}
             >
               <div className="flex items-center gap-2">
-                <ChevronRight className="h-4 w-4 text-gray-500" />
-                <span className="text-sm font-semibold text-gray-900">
+                <ChevronRight className="h-4 w-4 text-ink-3" />
+                <span className="text-sm font-semibold text-ink">
                   Transcript
                 </span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-ink-3">
                   {transcript.length}{' '}
                   {transcript.length === 1 ? 'line' : 'lines'}
                 </span>
               </div>
-              <span className="text-xs text-indigo-600">Show</span>
+              <span className="text-xs text-indigo">Show</span>
             </button>
           )
         ) : (
@@ -362,8 +360,8 @@ export function VideoReviewPanel({
 function ShortcutRow({ keys, label }: { keys: string; label: string }) {
   return (
     <li className="flex items-center justify-between gap-3 py-1">
-      <span className="text-gray-700">{label}</span>
-      <kbd className="rounded bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-700">
+      <span className="text-ink-2">{label}</span>
+      <kbd className="rounded bg-surface-3 px-2 py-0.5 font-mono text-xs text-ink-2">
         {keys}
       </kbd>
     </li>

--- a/src/components/sessions/word-cloud.tsx
+++ b/src/components/sessions/word-cloud.tsx
@@ -100,20 +100,20 @@ export function WordCloud({
   const getTierClasses = (tier: string) => {
     switch (tier) {
       case 'primary':
-        return 'text-gray-900 dark:text-gray-100 font-bold'
+        return 'text-ink font-bold'
       case 'secondary':
-        return 'text-gray-700 dark:text-gray-300 font-semibold'
+        return 'text-ink-2 font-semibold'
       case 'tertiary':
-        return 'text-gray-500 dark:text-gray-400 font-medium'
+        return 'text-ink-3 font-medium'
       default:
-        return 'text-gray-400 dark:text-gray-500 font-normal'
+        return 'text-ink-4 font-normal'
     }
   }
 
   return (
     <div className={`relative ${className}`}>
       {/* Background decoration */}
-      <div className="absolute inset-0 bg-gradient-to-br from-gray-50/50 dark:from-gray-800/50 via-transparent to-gray-50/50 dark:to-gray-800/50 rounded-lg" />
+      <div className="absolute inset-0  via-transparent rounded-lg" />
 
       {/* Word cloud container */}
       <div className="relative flex flex-wrap gap-3 md:gap-4 justify-center items-center p-6">
@@ -130,8 +130,8 @@ export function WordCloud({
                 hover:scale-110 hover:z-10
                 cursor-default select-none
                 ${isImportant ? 'hover:drop-shadow-lg' : 'hover:drop-shadow-md'}
-                ${item.tier === 'primary' ? 'px-3 py-1 bg-gradient-to-r from-gray-100/80 dark:from-gray-700/80 to-gray-50/80 dark:to-gray-800/80 rounded-lg' : ''}
-                ${item.tier === 'secondary' ? 'px-2 py-0.5 bg-gray-50/60 dark:bg-gray-700/60 rounded-md' : ''}
+                ${item.tier === 'primary' ? 'px-3 py-1  rounded-lg' : ''}
+                ${item.tier === 'secondary' ? 'px-2 py-0.5 bg-paper/60 rounded-md' : ''}
                 ${getTierClasses(item.tier)}
               `}
               style={{
@@ -161,7 +161,7 @@ export function WordCloud({
               <span className="relative">
                 {item.word}
                 {item.tier === 'primary' && (
-                  <span className="absolute -top-1 -right-2 text-xs text-gray-400 dark:text-gray-500 font-normal">
+                  <span className="absolute -top-1 -right-2 text-xs text-ink-4 font-normal">
                     {item.rawFreq > 1 && `×${item.rawFreq}`}
                   </span>
                 )}
@@ -173,7 +173,7 @@ export function WordCloud({
 
       {/* Subtle gradient overlay for depth */}
       <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute inset-0 bg-gradient-to-t from-white/20 dark:from-gray-900/20 via-transparent to-transparent rounded-lg" />
+        <div className="absolute inset-0  via-transparent to-transparent rounded-lg" />
       </div>
     </div>
   )

--- a/src/components/sprints/outcome-card.tsx
+++ b/src/components/sprints/outcome-card.tsx
@@ -54,9 +54,9 @@ export function OutcomeCard({
     <Card
       className={cn(
         'border-2 transition-all cursor-pointer',
-        isCompleted && 'border-green-200 bg-green-50/50',
+        isCompleted && 'border-forest bg-forest-bg/50',
         isSelected && !isCompleted && 'border-primary bg-primary/5',
-        !isCompleted && !isSelected && 'hover:border-gray-300',
+        !isCompleted && !isSelected && 'hover:border-line-strong',
       )}
       onClick={onClick}
     >
@@ -65,9 +65,9 @@ export function OutcomeCard({
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2 flex-1 min-w-0">
             {isCompleted ? (
-              <CheckCircle className="h-5 w-5 text-green-600 flex-shrink-0" />
+              <CheckCircle className="h-5 w-5 text-forest flex-shrink-0" />
             ) : (
-              <Circle className="h-5 w-5 text-gray-400 flex-shrink-0" />
+              <Circle className="h-5 w-5 text-ink-4 flex-shrink-0" />
             )}
             <h4 className="font-semibold text-sm truncate">{outcome.title}</h4>
           </div>
@@ -76,7 +76,7 @@ export function OutcomeCard({
               variant={isCompleted ? 'default' : 'secondary'}
               className={cn(
                 'text-xs',
-                isCompleted && 'bg-green-100 text-green-800',
+                isCompleted && 'bg-forest-bg text-forest',
               )}
             >
               {outcome.status}
@@ -116,7 +116,7 @@ export function OutcomeCard({
                       e.stopPropagation()
                       onDelete()
                     }}
-                    className="text-red-600"
+                    className="text-vermillion"
                   >
                     <Trash2 className="h-4 w-4 mr-2" />
                     Delete
@@ -130,7 +130,7 @@ export function OutcomeCard({
         {/* Progress */}
         <div className="mt-3 flex items-center gap-3">
           <Progress value={outcome.progress_percentage} className="flex-1" />
-          <span className="text-xs font-medium text-gray-600 w-10 text-right">
+          <span className="text-xs font-medium text-ink-3 w-10 text-right">
             {outcome.progress_percentage}%
           </span>
         </div>
@@ -143,7 +143,7 @@ export function OutcomeCard({
               variant={sprint.status === 'active' ? 'default' : 'secondary'}
               className={cn(
                 'cursor-pointer hover:opacity-80 text-xs',
-                sprint.status === 'active' && 'bg-blue-100 text-blue-800',
+                sprint.status === 'active' && 'bg-ds-accent-bg text-ds-accent',
               )}
               onClick={e => {
                 e.stopPropagation()
@@ -153,19 +153,19 @@ export function OutcomeCard({
               <Calendar className="h-3 w-3 mr-1" />
               {sprint.title}
               {sprint.status === 'active' && (
-                <span className="ml-1 w-1.5 h-1.5 rounded-full bg-green-500" />
+                <span className="ml-1 w-1.5 h-1.5 rounded-full bg-forest" />
               )}
             </Badge>
           ))}
           {linkedSprints.length === 0 && (
-            <span className="text-xs text-gray-500 italic">
+            <span className="text-xs text-ink-3 italic">
               No sprint assigned
             </span>
           )}
         </div>
 
         {/* Commitment count */}
-        <div className="mt-2 flex items-center gap-4 text-xs text-gray-600">
+        <div className="mt-2 flex items-center gap-4 text-xs text-ink-3">
           <div className="flex items-center gap-1">
             <Link2 className="h-3.5 w-3.5" />
             <span>
@@ -174,7 +174,7 @@ export function OutcomeCard({
             </span>
           </div>
           {activeSprints.length > 0 && (
-            <div className="flex items-center gap-1 text-blue-600">
+            <div className="flex items-center gap-1 text-ds-accent">
               <Calendar className="h-3.5 w-3.5" />
               <span>{activeSprints.length} active sprint(s)</span>
             </div>

--- a/src/components/sprints/outcome-centric-view.tsx
+++ b/src/components/sprints/outcome-centric-view.tsx
@@ -115,9 +115,7 @@ export function OutcomeCentricView({
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center justify-center h-32">
-            <div className="animate-pulse text-gray-500">
-              Loading outcomes...
-            </div>
+            <div className="animate-pulse text-ink-3">Loading outcomes...</div>
           </div>
         </CardContent>
       </Card>
@@ -126,24 +124,24 @@ export function OutcomeCentricView({
 
   return (
     <>
-      <Card className="border-gray-200 shadow-sm">
+      <Card className="border-line shadow-sm">
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <TargetIcon className="h-5 w-5 text-gray-700" />
-              <h3 className="font-semibold text-gray-900">
+              <TargetIcon className="h-5 w-5 text-ink-2" />
+              <h3 className="font-semibold text-ink">
                 Meta Performance Outcomes & Progress
               </h3>
             </div>
             <div className="flex items-center gap-2">
               {/* Filter Toggle */}
-              <div className="flex items-center gap-1 bg-gray-100 rounded-lg p-1">
+              <div className="flex items-center gap-1 bg-surface-3 rounded-lg p-1">
                 <Button
                   variant="ghost"
                   size="sm"
                   className={cn(
                     'h-7 px-3 text-xs',
-                    viewFilter === 'all' && 'bg-white shadow-sm',
+                    viewFilter === 'all' && 'bg-surface-1 shadow-sm',
                   )}
                   onClick={() => setViewFilter('all')}
                 >
@@ -154,7 +152,7 @@ export function OutcomeCentricView({
                   size="sm"
                   className={cn(
                     'h-7 px-3 text-xs',
-                    viewFilter === 'active_sprint' && 'bg-white shadow-sm',
+                    viewFilter === 'active_sprint' && 'bg-surface-1 shadow-sm',
                   )}
                   onClick={() => setViewFilter('active_sprint')}
                 >
@@ -172,8 +170,8 @@ export function OutcomeCentricView({
 
         <CardContent className="pt-0">
           {groupedOutcomes.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              <TargetIcon className="h-12 w-12 mx-auto mb-3 text-gray-300" />
+            <div className="text-center py-8 text-ink-3">
+              <TargetIcon className="h-12 w-12 mx-auto mb-3 text-ink-2" />
               <p className="text-sm">
                 {viewFilter === 'active_sprint'
                   ? 'No meta performance outcomes in active sprint'
@@ -198,13 +196,13 @@ export function OutcomeCentricView({
                   onOpenChange={() => toggleGoal(group.goal.id)}
                 >
                   <CollapsibleTrigger asChild>
-                    <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-gray-50 hover:bg-gray-100 cursor-pointer transition-colors">
+                    <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-paper hover:bg-surface-3 cursor-pointer transition-colors">
                       {isGoalExpanded(group.goal.id) ? (
-                        <ChevronDown className="h-4 w-4 text-gray-500" />
+                        <ChevronDown className="h-4 w-4 text-ink-3" />
                       ) : (
-                        <ChevronRight className="h-4 w-4 text-gray-500" />
+                        <ChevronRight className="h-4 w-4 text-ink-3" />
                       )}
-                      <span className="font-medium text-sm text-gray-900">
+                      <span className="font-medium text-sm text-ink">
                         {group.goal.title}
                       </span>
                       <Badge variant="secondary" className="ml-auto text-xs">
@@ -242,9 +240,9 @@ export function OutcomeCentricView({
 
           {/* Active Sprint Info */}
           {currentSprint && (
-            <div className="mt-4 pt-4 border-t border-gray-200">
+            <div className="mt-4 pt-4 border-t border-line">
               <div className="flex items-center justify-between text-sm">
-                <div className="flex items-center gap-2 text-gray-600">
+                <div className="flex items-center gap-2 text-ink-3">
                   <Calendar className="h-4 w-4" />
                   <span>Active: {currentSprint.title}</span>
                 </div>

--- a/src/components/sprints/sprint-form-modal.tsx
+++ b/src/components/sprints/sprint-form-modal.tsx
@@ -339,7 +339,7 @@ export function SprintFormModal({
                           'flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors',
                           isSelected
                             ? 'bg-primary/5 border-primary'
-                            : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500',
+                            : 'bg-surface-1 border-line hover:border-line-strong ',
                         )}
                         onClick={() => {
                           if (isSelected) {
@@ -356,22 +356,22 @@ export function SprintFormModal({
                             'w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 mt-0.5',
                             isSelected
                               ? 'bg-primary border-primary'
-                              : 'border-gray-300',
+                              : 'border-line-strong',
                           )}
                         >
                           {isSelected && (
-                            <Check className="h-3 w-3 text-white" />
+                            <Check className="h-3 w-3 text-ink-on-dark" />
                           )}
                         </div>
                         <div className="flex-1 min-w-0">
-                          <div className="font-medium text-sm text-gray-900 dark:text-white">
+                          <div className="font-medium text-sm text-ink ">
                             {outcome.title}
                           </div>
-                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          <div className="text-xs text-ink-3 mt-0.5">
                             Vision: {goalTitle}
                           </div>
                           {outcome.description && (
-                            <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-2">
+                            <div className="text-xs text-ink-3 mt-1 line-clamp-2">
                               {outcome.description}
                             </div>
                           )}
@@ -381,7 +381,7 @@ export function SprintFormModal({
                   })}
                 </div>
               ) : (
-                <div className="text-sm text-amber-700 dark:text-amber-400 p-4 border border-amber-200 dark:border-amber-800 rounded-lg bg-amber-50 dark:bg-amber-900/30">
+                <div className="text-sm text-amber-token p-4 border border-amber-token rounded-lg bg-amber-token-bg ">
                   <strong>No meta performance outcomes available.</strong> You
                   must create at least one meta performance outcome before
                   creating a sprint. Go to the Meta Performance Outcomes section
@@ -389,7 +389,7 @@ export function SprintFormModal({
                 </div>
               )}
               {selectedOutcomeIds.length > 0 && (
-                <div className="text-xs text-gray-600 dark:text-gray-400">
+                <div className="text-xs text-ink-3 ">
                   {selectedOutcomeIds.length} meta performance outcome(s)
                   selected
                 </div>

--- a/src/components/sprints/sprint-status-menu.tsx
+++ b/src/components/sprints/sprint-status-menu.tsx
@@ -57,25 +57,25 @@ export function SprintStatusMenu({
       value: 'planning' as SprintStatus,
       label: 'Planning',
       icon: Edit,
-      color: 'text-yellow-600',
+      color: 'text-amber-token',
     },
     {
       value: 'active' as SprintStatus,
       label: 'Active',
       icon: Play,
-      color: 'text-green-600',
+      color: 'text-forest',
     },
     {
       value: 'completed' as SprintStatus,
       label: 'Completed',
       icon: CheckCircle,
-      color: 'text-blue-600',
+      color: 'text-ds-accent',
     },
     {
       value: 'cancelled' as SprintStatus,
       label: 'Cancelled',
       icon: X,
-      color: 'text-gray-600',
+      color: 'text-ink-3',
     },
   ]
 
@@ -98,12 +98,12 @@ export function SprintStatusMenu({
               key={option.value}
               onClick={() => !isCurrent && handleStatusChange(option.value)}
               disabled={isCurrent || updating}
-              className={isCurrent ? 'bg-gray-50' : ''}
+              className={isCurrent ? 'bg-paper' : ''}
             >
               <Icon className={`h-4 w-4 mr-2 ${option.color}`} />
               <span>{option.label}</span>
               {isCurrent && (
-                <span className="ml-auto text-xs text-gray-500">(Current)</span>
+                <span className="ml-auto text-xs text-ink-3">(Current)</span>
               )}
             </DropdownMenuItem>
           )

--- a/src/components/sprints/target-form-modal.tsx
+++ b/src/components/sprints/target-form-modal.tsx
@@ -206,7 +206,7 @@ export function TargetFormModal({
                           'flex items-center gap-2 px-3 py-1.5 rounded-lg border cursor-pointer transition-colors',
                           isSelected
                             ? 'bg-primary text-primary-foreground border-primary'
-                            : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500',
+                            : 'bg-surface-1 border-line-strong hover:border-line-strong ',
                         )}
                         onClick={() => {
                           if (isSelected) {
@@ -222,8 +222,8 @@ export function TargetFormModal({
                           className={cn(
                             'w-4 h-4 rounded border-2 flex items-center justify-center',
                             isSelected
-                              ? 'bg-white border-white'
-                              : 'bg-white border-gray-300',
+                              ? 'bg-surface-1 border-paper'
+                              : 'bg-surface-1 border-line-strong',
                           )}
                         >
                           {isSelected && (
@@ -238,12 +238,10 @@ export function TargetFormModal({
                   })}
                 </div>
               ) : (
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  No active visions
-                </div>
+                <div className="text-sm text-ink-3 ">No active visions</div>
               )}
               {selectedGoalIds.length > 0 && (
-                <p className="text-xs text-gray-600 dark:text-gray-400">
+                <p className="text-xs text-ink-3 ">
                   {selectedGoalIds.length} vision
                   {selectedGoalIds.length !== 1 ? 's' : ''} selected
                 </p>

--- a/src/components/ui/ai-provider-selector.tsx
+++ b/src/components/ui/ai-provider-selector.tsx
@@ -71,7 +71,7 @@ export function AIProviderSelector({
     return (
       <div className={className}>
         <Select value={value} onValueChange={v => onChange(v as AIProvider)}>
-          <SelectTrigger className="w-full bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+          <SelectTrigger className="w-full bg-surface-1 border-line ">
             <SelectValue>
               {(() => {
                 const provider = providers.find(p => p.id === value)
@@ -105,7 +105,7 @@ export function AIProviderSelector({
                         </Badge>
                       )}
                     </div>
-                    <p className="text-xs text-gray-500 mt-0.5">
+                    <p className="text-xs text-ink-3 mt-0.5">
                       {provider.description}
                     </p>
                   </div>
@@ -138,12 +138,12 @@ export function AIProviderSelector({
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger>
-                        <Info className="h-3 w-3 text-gray-400" />
+                        <Info className="h-3 w-3 text-ink-4" />
                       </TooltipTrigger>
                       <TooltipContent>
                         <p className="text-xs">{provider.description}</p>
                         {provider.models && (
-                          <p className="text-xs text-gray-400 mt-1">
+                          <p className="text-xs text-ink-4 mt-1">
                             Models: {provider.models.join(', ')}
                           </p>
                         )}
@@ -151,7 +151,7 @@ export function AIProviderSelector({
                     </Tooltip>
                   </TooltipProvider>
                 </div>
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-ink-3 mt-1">
                   {provider.description}
                 </p>
               </Label>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-overlay',
         className,
       )}
       {...props}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,28 +1,36 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          'border-transparent bg-destructive text-ink-on-dark [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20',
         outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        live: 'bg-forest-bg text-forest border-forest/20',
+        completed: 'bg-surface-2 text-ink-2 border-line',
+        processing: 'bg-amber-token-bg text-amber-token border-amber-token/20',
+        scheduled: 'bg-indigo-bg text-indigo border-indigo/20',
+        error: 'bg-vermillion-bg text-vermillion border-vermillion/20',
+        success: 'bg-forest-bg text-forest border-forest/20',
+        warning: 'bg-amber-token-bg text-amber-token border-amber-token/20',
+        info: 'bg-ds-accent-bg text-ds-accent border-ds-accent/20',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
+  },
 )
 
 function Badge({
@@ -30,9 +38,9 @@ function Badge({
   variant,
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
+}: React.ComponentProps<'span'> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
+  const Comp = asChild ? Slot : 'span'
 
   return (
     <Comp

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         default:
           'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-ink-on-dark shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary:

--- a/src/components/ui/chat-markdown.tsx
+++ b/src/components/ui/chat-markdown.tsx
@@ -15,22 +15,22 @@ export function ChatMarkdown({ content }: ChatMarkdownProps) {
         components={{
           // Headings
           h1: ({ children }) => (
-            <h1 className="text-base font-bold text-gray-900 dark:text-white mb-2 mt-3 first:mt-0">
+            <h1 className="text-base font-bold text-ink mb-2 mt-3 first:mt-0">
               {children}
             </h1>
           ),
           h2: ({ children }) => (
-            <h2 className="text-sm font-bold text-gray-900 dark:text-white mb-1.5 mt-3 first:mt-0">
+            <h2 className="text-sm font-bold text-ink mb-1.5 mt-3 first:mt-0">
               {children}
             </h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1 mt-2.5 first:mt-0">
+            <h3 className="text-sm font-semibold text-ink-2 mb-1 mt-2.5 first:mt-0">
               {children}
             </h3>
           ),
           h4: ({ children }) => (
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1 mt-2 first:mt-0">
+            <h4 className="text-sm font-semibold text-ink-2 mb-1 mt-2 first:mt-0">
               {children}
             </h4>
           ),
@@ -42,12 +42,12 @@ export function ChatMarkdown({ content }: ChatMarkdownProps) {
 
           // Lists
           ul: ({ children }) => (
-            <ul className="list-disc pl-5 mb-2 space-y-0.5 text-gray-700 dark:text-gray-300">
+            <ul className="list-disc pl-5 mb-2 space-y-0.5 text-ink-2 ">
               {children}
             </ul>
           ),
           ol: ({ children }) => (
-            <ol className="list-decimal pl-5 mb-2 space-y-0.5 text-gray-700 dark:text-gray-300">
+            <ol className="list-decimal pl-5 mb-2 space-y-0.5 text-ink-2 ">
               {children}
             </ol>
           ),
@@ -57,14 +57,10 @@ export function ChatMarkdown({ content }: ChatMarkdownProps) {
 
           // Inline formatting
           strong: ({ children }) => (
-            <strong className="font-semibold text-gray-900 dark:text-white">
-              {children}
-            </strong>
+            <strong className="font-semibold text-ink ">{children}</strong>
           ),
           em: ({ children }) => (
-            <em className="italic text-gray-700 dark:text-gray-300">
-              {children}
-            </em>
+            <em className="italic text-ink-2 ">{children}</em>
           ),
 
           // Links
@@ -73,7 +69,7 @@ export function ChatMarkdown({ content }: ChatMarkdownProps) {
               href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 underline underline-offset-2"
+              className="text-ds-accent hover:text-ds-accent underline underline-offset-2"
             >
               {children}
             </a>
@@ -81,25 +77,23 @@ export function ChatMarkdown({ content }: ChatMarkdownProps) {
 
           // Blockquotes
           blockquote: ({ children }) => (
-            <blockquote className="border-l-3 border-gray-300 dark:border-gray-600 pl-3 my-2 text-gray-600 dark:text-gray-400 italic">
+            <blockquote className="border-l-3 border-line-strong pl-3 my-2 text-ink-3 italic">
               {children}
             </blockquote>
           ),
 
           // Horizontal rule
-          hr: () => (
-            <hr className="my-3 border-gray-200 dark:border-gray-700" />
-          ),
+          hr: () => <hr className="my-3 border-line " />,
 
           // Code
           code: ({ className, children }: any) => {
             const isBlock = className?.includes('language-')
             return isBlock ? (
-              <code className="block bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 p-3 rounded-md text-xs font-mono overflow-x-auto my-2 border border-gray-200 dark:border-gray-700">
+              <code className="block bg-paper text-ink-2 p-3 rounded-md text-xs font-mono overflow-x-auto my-2 border border-line ">
                 {children}
               </code>
             ) : (
-              <code className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-1.5 py-0.5 rounded text-xs font-mono">
+              <code className="bg-surface-3 text-ink-2 px-1.5 py-0.5 rounded text-xs font-mono">
                 {children}
               </code>
             )
@@ -110,28 +104,28 @@ export function ChatMarkdown({ content }: ChatMarkdownProps) {
 
           // Tables
           table: ({ children }) => (
-            <div className="my-3 overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+            <div className="my-3 overflow-x-auto rounded-lg border border-line ">
+              <table className="min-w-full divide-y divide-line text-sm">
                 {children}
               </table>
             </div>
           ),
           thead: ({ children }) => (
-            <thead className="bg-gray-50 dark:bg-gray-800">{children}</thead>
+            <thead className="bg-paper ">{children}</thead>
           ),
           tbody: ({ children }) => (
-            <tbody className="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-900">
+            <tbody className="divide-y divide-line bg-surface-1 ">
               {children}
             </tbody>
           ),
           tr: ({ children }) => <tr>{children}</tr>,
           th: ({ children }) => (
-            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider">
+            <th className="px-3 py-2 text-left text-xs font-semibold text-ink-2 uppercase tracking-wider">
               {children}
             </th>
           ),
           td: ({ children }) => (
-            <td className="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+            <td className="px-3 py-2 text-sm text-ink-2 whitespace-nowrap">
               {children}
             </td>
           ),

--- a/src/components/ui/client-card.tsx
+++ b/src/components/ui/client-card.tsx
@@ -15,22 +15,17 @@ interface ClientCardProps {
 }
 
 function getHealthStatus(lastSessionDate?: string | null): {
-  color: string
   dotClass: string
 } {
   if (!lastSessionDate) {
-    return { color: 'gray', dotClass: 'bg-gray-400' }
+    return { dotClass: 'bg-ink-4' }
   }
   const daysSince = Math.floor(
     (Date.now() - new Date(lastSessionDate).getTime()) / (1000 * 60 * 60 * 24),
   )
-  if (daysSince <= 14) {
-    return { color: 'green', dotClass: 'bg-green-500' }
-  }
-  if (daysSince <= 30) {
-    return { color: 'yellow', dotClass: 'bg-amber-500' }
-  }
-  return { color: 'red', dotClass: 'bg-red-500' }
+  if (daysSince <= 14) return { dotClass: 'bg-forest' }
+  if (daysSince <= 30) return { dotClass: 'bg-amber-token' }
+  return { dotClass: 'bg-vermillion' }
 }
 
 function formatLastSession(dateStr: string): string {
@@ -70,7 +65,7 @@ export function ClientCard({
     <PermissionGate resource="clients" action="view" fallback={null}>
       <Card
         className={cn(
-          'border border-gray-200 dark:border-gray-700 hover:border-gray-900 dark:hover:border-gray-500 hover:shadow-sm transition-all duration-200',
+          'border border-line hover:border-line-strong hover:shadow-sm transition-all duration-200',
           onClick && !isViewer ? 'cursor-pointer' : 'cursor-default',
           className,
         )}
@@ -79,14 +74,14 @@ export function ClientCard({
         <CardContent className="p-4">
           <div className="flex items-center gap-3">
             <div className="relative flex-shrink-0">
-              <Avatar className="h-10 w-10 bg-gray-900 border-2 border-gray-200 dark:border-gray-700">
-                <AvatarFallback className="bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-sm font-bold">
+              <Avatar className="h-10 w-10 bg-ink border-2 border-line">
+                <AvatarFallback className="bg-ink text-ink-on-dark text-sm font-bold">
                   {getInitials(name)}
                 </AvatarFallback>
               </Avatar>
               <span
                 className={cn(
-                  'absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-white dark:border-gray-900',
+                  'absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-paper',
                   health.dotClass,
                 )}
                 title={
@@ -97,26 +92,22 @@ export function ClientCard({
               />
             </div>
             <div className="flex-1 min-w-0">
-              <h3 className="font-semibold text-gray-900 dark:text-white text-sm truncate">
+              <h3 className="font-semibold text-ink text-sm truncate">
                 {name}
               </h3>
               {lastSessionDate ? (
                 <div className="flex items-center gap-1 mt-1">
-                  <Calendar className="h-3 w-3 text-gray-400 flex-shrink-0" />
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <Calendar className="h-3 w-3 text-ink-4 flex-shrink-0" />
+                  <p className="text-xs text-ink-3">
                     {formatLastSession(lastSessionDate)}
                   </p>
                 </div>
               ) : email ? (
-                <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-1">
-                  {email}
-                </p>
+                <p className="text-xs text-ink-3 truncate mt-1">{email}</p>
               ) : isMyClient === false && coachName ? (
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  by {coachName}
-                </p>
+                <p className="text-xs text-ink-3 mt-1">by {coachName}</p>
               ) : (
-                <p className="text-xs text-gray-400 mt-1">No sessions yet</p>
+                <p className="text-xs text-ink-4 mt-1">No sessions yet</p>
               )}
             </div>
           </div>

--- a/src/components/ui/confirmation-dialog.tsx
+++ b/src/components/ui/confirmation-dialog.tsx
@@ -43,7 +43,7 @@ export function ConfirmationDialog({
             onClick={onConfirm}
             className={
               variant === 'destructive'
-                ? 'bg-red-600 hover:bg-red-700 text-white'
+                ? 'bg-vermillion hover:bg-vermillion text-ink-on-dark'
                 : ''
             }
           >

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -18,7 +18,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-gray-900 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-line bg-surface-1 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}
@@ -81,7 +81,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight text-neutral-900 dark:text-white',
+      'text-lg font-semibold leading-none tracking-tight text-ink',
       className,
     )}
     {...props}
@@ -95,7 +95,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-neutral-500 dark:text-neutral-400', className)}
+    className={cn('text-sm text-ink-3', className)}
     {...props}
   />
 ))

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -33,27 +33,22 @@ export function EmptyState({
     <div className={cn('text-center py-12', className)}>
       <div
         className={cn(
-          'mx-auto w-12 h-12 bg-neutral-100 dark:bg-neutral-800 rounded-full flex items-center justify-center mb-3',
+          'mx-auto w-12 h-12 bg-surface-3 rounded-full flex items-center justify-center mb-3',
           iconClassName,
         )}
       >
-        <Icon className="h-6 w-6 text-neutral-400" />
+        <Icon className="h-6 w-6 text-ink-3" strokeWidth={1.75} />
       </div>
-      <h3 className="text-sm font-medium text-neutral-900 dark:text-white mb-1">
-        {title}
-      </h3>
+      <h3 className="text-sm font-medium text-ink mb-1">{title}</h3>
       {description && (
-        <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4 max-w-sm mx-auto">
+        <p className="text-sm text-ink-3 mb-4 max-w-sm mx-auto">
           {description}
         </p>
       )}
       {(action || secondaryAction) && (
         <div className="flex items-center justify-center gap-3">
           {action && (
-            <Button
-              onClick={action.onClick}
-              className="bg-neutral-900 dark:bg-white hover:bg-neutral-800 dark:hover:bg-neutral-100 text-white dark:text-neutral-900"
-            >
+            <Button onClick={action.onClick}>
               {action.icon && <action.icon className="h-4 w-4 mr-2" />}
               {action.label}
             </Button>
@@ -62,7 +57,6 @@ export function EmptyState({
             <Button
               variant={secondaryAction.variant || 'outline'}
               onClick={secondaryAction.onClick}
-              className="border-neutral-300 dark:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300"
             >
               {secondaryAction.label}
             </Button>

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -5,7 +5,10 @@ interface LoadingSpinnerProps {
   className?: string
 }
 
-export function LoadingSpinner({ size = 'md', className }: LoadingSpinnerProps) {
+export function LoadingSpinner({
+  size = 'md',
+  className,
+}: LoadingSpinnerProps) {
   const sizeClasses = {
     sm: 'h-6 w-6 border-2',
     md: 'h-10 w-10 border-2',
@@ -15,9 +18,9 @@ export function LoadingSpinner({ size = 'md', className }: LoadingSpinnerProps) 
   return (
     <div
       className={cn(
-        'animate-spin rounded-full border-neutral-900 border-t-transparent',
+        'animate-spin rounded-full border-ink border-t-transparent',
         sizeClasses[size],
-        className
+        className,
       )}
     />
   )

--- a/src/components/ui/loading-state.tsx
+++ b/src/components/ui/loading-state.tsx
@@ -5,35 +5,22 @@ interface LoadingStateProps {
   message?: string
   size?: 'sm' | 'md' | 'lg'
   className?: string
+  /** Retained for backward compatibility — both modes now render the DS spinner. */
   variant?: 'default' | 'gradient'
 }
 
-export function LoadingState({ 
-  message = 'Loading...', 
-  size = 'md', 
+export function LoadingState({
+  message = 'Loading...',
+  size = 'md',
   className,
-  variant = 'default' 
 }: LoadingStateProps) {
-  if (variant === 'gradient') {
-    return (
-      <div className={cn('flex items-center justify-center min-h-[60vh]', className)}>
-        <div className="text-center space-y-4">
-          <div className="relative w-16 h-16 mx-auto">
-            <div className="absolute inset-0 animate-spin rounded-full h-16 w-16 border-4 border-purple-200 border-t-purple-600"></div>
-            <div className="absolute inset-2 animate-spin rounded-full h-12 w-12 border-4 border-blue-200 border-t-blue-600 animation-delay-150"></div>
-            <div className="absolute inset-4 animate-spin rounded-full h-8 w-8 border-4 border-purple-200 border-t-purple-600 animation-delay-300"></div>
-          </div>
-          <p className="text-gray-600 font-medium animate-pulse">{message}</p>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className={cn('flex items-center justify-center min-h-[60vh]', className)}>
+    <div
+      className={cn('flex items-center justify-center min-h-[60vh]', className)}
+    >
       <div className="text-center">
         <LoadingSpinner size={size} className="mx-auto" />
-        <p className="mt-3 text-neutral-600 text-sm">{message}</p>
+        <p className="mt-3 text-ink-3 text-sm">{message}</p>
       </div>
     </div>
   )

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -6,6 +6,10 @@ interface PageHeaderProps {
   title: string
   description?: string
   icon?: LucideIcon
+  /**
+   * Retained for backward compatibility — both values now render the same
+   * DS-aligned header. The DS forbids decorative gradients.
+   */
   iconVariant?: 'default' | 'gradient'
   actions?: ReactNode
   className?: string
@@ -15,7 +19,6 @@ export function PageHeader({
   title,
   description,
   icon: Icon,
-  iconVariant = 'default',
   actions,
   className,
 }: PageHeaderProps) {
@@ -23,37 +26,15 @@ export function PageHeader({
     <div className={cn('mb-8', className)}>
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          {Icon && (
+          {Icon ? (
             <div className="flex items-center gap-3 mb-2">
-              {iconVariant === 'gradient' ? (
-                <div className="p-2 bg-gradient-to-r from-purple-500 to-blue-500 rounded-xl shadow-lg">
-                  <Icon className="h-6 w-6 text-white" />
-                </div>
-              ) : (
-                <Icon className="h-6 w-6 text-neutral-600 dark:text-neutral-400" />
-              )}
-              <h1
-                className={cn(
-                  'text-3xl',
-                  iconVariant === 'gradient'
-                    ? 'font-bold bg-gradient-to-r from-slate-900 to-slate-700 dark:from-white dark:to-gray-300 bg-clip-text text-transparent'
-                    : 'font-semibold text-neutral-900 dark:text-white',
-                )}
-              >
-                {title}
-              </h1>
+              <Icon className="h-6 w-6 text-ink-3" strokeWidth={1.75} />
+              <h1 className="text-3xl font-semibold text-ink">{title}</h1>
             </div>
+          ) : (
+            <h1 className="text-3xl font-semibold text-ink">{title}</h1>
           )}
-          {!Icon && (
-            <h1 className="text-3xl font-semibold text-neutral-900 dark:text-white">
-              {title}
-            </h1>
-          )}
-          {description && (
-            <p className="text-neutral-500 dark:text-neutral-400 mt-1">
-              {description}
-            </p>
-          )}
+          {description && <p className="text-ink-3 mt-1">{description}</p>}
         </div>
         {actions && <div className="flex items-center gap-3">{actions}</div>}
       </div>

--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -48,9 +48,8 @@ function ToolbarButton({
       title={title}
       className={cn(
         'p-1.5 rounded-md transition-colors',
-        'hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 dark:focus:ring-offset-gray-800',
-        isActive &&
-          'bg-gray-200 dark:bg-gray-600 text-blue-600 dark:text-blue-400',
+        'hover:bg-surface-3 focus:outline-none focus:ring-2 focus:ring-ds-accent focus:ring-offset-1 ',
+        isActive && 'bg-surface-3 text-ds-accent ',
         disabled && 'opacity-50 cursor-not-allowed',
       )}
     >
@@ -92,7 +91,7 @@ export function RichTextEditor({
       Placeholder.configure({
         placeholder,
         emptyEditorClass:
-          'before:content-[attr(data-placeholder)] before:text-gray-400 dark:before:text-gray-500 before:float-left before:h-0 before:pointer-events-none',
+          'before:content-[attr(data-placeholder)] before:text-ink-4 before:float-left before:h-0 before:pointer-events-none',
       }),
     ],
     content,
@@ -157,22 +156,22 @@ export function RichTextEditor({
     return (
       <div
         className={cn(
-          'border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 overflow-hidden',
+          'border border-line rounded-lg bg-surface-1 overflow-hidden',
           className,
         )}
       >
         {/* Toolbar placeholder */}
-        <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800">
-          <div className="h-7 w-7 bg-gray-200 dark:bg-gray-600 rounded-md animate-pulse" />
-          <div className="h-7 w-7 bg-gray-200 dark:bg-gray-600 rounded-md animate-pulse" />
-          <div className="h-7 w-7 bg-gray-200 dark:bg-gray-600 rounded-md animate-pulse" />
-          <div className="w-px h-5 bg-gray-300 dark:bg-gray-500 mx-1" />
-          <div className="h-7 w-7 bg-gray-200 dark:bg-gray-600 rounded-md animate-pulse" />
-          <div className="h-7 w-7 bg-gray-200 dark:bg-gray-600 rounded-md animate-pulse" />
+        <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-line bg-paper ">
+          <div className="h-7 w-7 bg-surface-3 rounded-md animate-pulse" />
+          <div className="h-7 w-7 bg-surface-3 rounded-md animate-pulse" />
+          <div className="h-7 w-7 bg-surface-3 rounded-md animate-pulse" />
+          <div className="w-px h-5 bg-line mx-1" />
+          <div className="h-7 w-7 bg-surface-3 rounded-md animate-pulse" />
+          <div className="h-7 w-7 bg-surface-3 rounded-md animate-pulse" />
         </div>
         {/* Content placeholder */}
         <div className="px-3 py-2" style={{ minHeight }}>
-          <div className="h-4 bg-gray-100 dark:bg-gray-600 rounded w-3/4 animate-pulse" />
+          <div className="h-4 bg-surface-3 rounded w-3/4 animate-pulse" />
         </div>
       </div>
     )
@@ -181,15 +180,15 @@ export function RichTextEditor({
   return (
     <div
       className={cn(
-        'border border-gray-200 dark:border-gray-600 rounded-lg overflow-hidden bg-white dark:bg-gray-700 flex flex-col',
-        'focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500',
-        disabled && 'opacity-60 bg-gray-50 dark:bg-gray-800',
+        'border border-line rounded-lg overflow-hidden bg-surface-1 flex flex-col',
+        'focus-within:ring-2 focus-within:ring-ds-accent focus-within:border-ds-accent',
+        disabled && 'opacity-60 bg-paper ',
         className,
       )}
       onKeyDown={onKeyDown}
     >
       {/* Toolbar */}
-      <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 flex-shrink-0">
+      <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-line bg-paper flex-shrink-0">
         <ToolbarButton
           onClick={toggleBold}
           isActive={editor.isActive('bold')}
@@ -217,7 +216,7 @@ export function RichTextEditor({
           <UnderlineIcon className="h-4 w-4" />
         </ToolbarButton>
 
-        <div className="w-px h-5 bg-gray-300 dark:bg-gray-500 mx-1" />
+        <div className="w-px h-5 bg-line mx-1" />
 
         <ToolbarButton
           onClick={toggleBulletList}
@@ -239,7 +238,7 @@ export function RichTextEditor({
       </div>
 
       {/* Editor Content */}
-      <div className="px-3 py-2 flex-1 overflow-y-auto text-gray-900 dark:text-gray-100">
+      <div className="px-3 py-2 flex-1 overflow-y-auto text-ink ">
         <EditorContent editor={editor} />
       </div>
     </div>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-white dark:bg-gray-900 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  'fixed z-50 gap-4 bg-surface-1 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
   {
     variants: {
       side: {
@@ -64,7 +64,7 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white dark:ring-offset-gray-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-neutral-950 dark:focus:ring-neutral-300 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-neutral-100 dark:data-[state=open]:bg-neutral-800">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-surface-1 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ds-accent focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-surface-3">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
@@ -108,10 +108,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn(
-      'text-lg font-semibold text-neutral-950 dark:text-white',
-      className,
-    )}
+    className={cn('text-lg font-semibold text-ink', className)}
     {...props}
   />
 ))
@@ -123,7 +120,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-neutral-500 dark:text-neutral-400', className)}
+    className={cn('text-sm text-ink-3', className)}
     {...props}
   />
 ))

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -9,39 +9,19 @@ interface StatCardProps {
   subtitle?: string
   icon: LucideIcon
   footer?: ReactNode
+  /**
+   * Variant controls only the icon-dot accent color now — never the
+   * background. The DS forbids gradient surfaces.
+   */
   variant?: 'blue' | 'green' | 'purple' | 'orange'
   className?: string
 }
 
-const variantStyles = {
-  blue: {
-    bg: 'bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200',
-    icon: 'bg-blue-500',
-    text: 'text-blue-900',
-    subtitle: 'text-blue-600',
-    footer: 'text-blue-600'
-  },
-  green: {
-    bg: 'bg-gradient-to-br from-green-50 to-emerald-100 border-green-200',
-    icon: 'bg-green-500',
-    text: 'text-green-900',
-    subtitle: 'text-green-600',
-    footer: 'text-green-600'
-  },
-  purple: {
-    bg: 'bg-gradient-to-br from-purple-50 to-violet-100 border-purple-200',
-    icon: 'bg-purple-500',
-    text: 'text-purple-900',
-    subtitle: 'text-purple-600',
-    footer: 'text-purple-600'
-  },
-  orange: {
-    bg: 'bg-gradient-to-br from-orange-50 to-amber-100 border-orange-200',
-    icon: 'bg-orange-500',
-    text: 'text-orange-900',
-    subtitle: 'text-orange-600',
-    footer: 'text-orange-600'
-  }
+const ACCENT: Record<NonNullable<StatCardProps['variant']>, string> = {
+  blue: 'text-ds-accent',
+  green: 'text-forest',
+  purple: 'text-indigo',
+  orange: 'text-amber-token',
 }
 
 export function StatCard({
@@ -51,37 +31,37 @@ export function StatCard({
   icon: Icon,
   footer,
   variant = 'blue',
-  className
+  className,
 }: StatCardProps) {
-  const styles = variantStyles[variant]
+  const accent = ACCENT[variant]
 
   return (
-    <Card className={cn(
-      styles.bg,
-      'shadow-sm hover:shadow-md transition-all duration-200',
-      className
-    )}>
+    <Card
+      className={cn(
+        'bg-surface-1 border border-line shadow-xs hover:shadow-sm transition-shadow duration-200',
+        className,
+      )}
+    >
       <CardContent className="p-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className={cn('text-3xl font-bold', styles.text)}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-3xl font-bold text-ink leading-tight tracking-tight">
               {value}
             </p>
-            <p className={cn('text-sm font-medium', styles.subtitle)}>
-              {title}
-            </p>
-            {subtitle && (
-              <p className={cn('text-xs mt-1', styles.subtitle)}>
-                {subtitle}
-              </p>
-            )}
+            <p className="text-sm font-medium text-ink-3 mt-1">{title}</p>
+            {subtitle && <p className="text-xs text-ink-4 mt-1">{subtitle}</p>}
           </div>
-          <div className={cn('p-4 rounded-2xl shadow-lg', styles.icon)}>
-            <Icon className="h-6 w-6 text-white" />
+          <div
+            className={cn(
+              'shrink-0 w-9 h-9 rounded-md bg-surface-3 flex items-center justify-center',
+              accent,
+            )}
+          >
+            <Icon className="h-4 w-4" strokeWidth={1.75} />
           </div>
         </div>
         {footer && (
-          <div className={cn('mt-4 flex items-center text-xs', styles.footer)}>
+          <div className="mt-4 flex items-center text-xs text-ink-3">
             {footer}
           </div>
         )}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -19,10 +19,10 @@ export function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
 
   const bgColor =
     type === 'success'
-      ? 'bg-green-50 border-green-200'
-      : 'bg-red-50 border-red-200'
-  const textColor = type === 'success' ? 'text-green-800' : 'text-red-800'
-  const iconColor = type === 'success' ? 'text-green-600' : 'text-red-600'
+      ? 'bg-forest-bg border-forest/20'
+      : 'bg-vermillion-bg border-vermillion/20'
+  const textColor = type === 'success' ? 'text-forest' : 'text-vermillion'
+  const iconColor = type === 'success' ? 'text-forest' : 'text-vermillion'
   const Icon = type === 'success' ? CheckCircle2 : AlertCircle
 
   return (

--- a/src/components/wins/client-wins-timeline.tsx
+++ b/src/components/wins/client-wins-timeline.tsx
@@ -44,9 +44,9 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
 
   if (loading) {
     return (
-      <Card className="border-gray-200 dark:border-gray-700 shadow-sm">
+      <Card className="border-line shadow-sm">
         <CardContent className="py-12 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 text-gray-400 animate-spin" />
+          <Loader2 className="h-8 w-8 text-ink-4 animate-spin" />
         </CardContent>
       </Card>
     )
@@ -81,16 +81,16 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
   const pendingWins = wins.filter(w => !w.is_approved)
 
   return (
-    <Card className="border-gray-200 dark:border-gray-700 shadow-sm">
-      <CardHeader className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+    <Card className="border-line shadow-sm">
+      <CardHeader className="bg-paper border-b border-line ">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center">
-              <Trophy className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            <div className="w-10 h-10 rounded-full bg-amber-token-bg flex items-center justify-center">
+              <Trophy className="h-5 w-5 text-amber-token " />
             </div>
             <div>
               <CardTitle className="text-lg">Client Wins</CardTitle>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-3 ">
                 Achievements and breakthroughs from all sessions
               </p>
             </div>
@@ -98,15 +98,12 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
           <div className="flex items-center gap-2">
             <Badge
               variant="secondary"
-              className="bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
+              className="bg-amber-token-bg text-amber-token "
             >
               {approvedWins.length} wins
             </Badge>
             {pendingWins.length > 0 && (
-              <Badge
-                variant="secondary"
-                className="bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
-              >
+              <Badge variant="secondary" className="bg-surface-3 text-ink-3 ">
                 {pendingWins.length} pending
               </Badge>
             )}
@@ -116,26 +113,26 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
 
       <CardContent className="p-0">
         {winsBySession.length > 0 ? (
-          <div className="divide-y divide-gray-100 dark:divide-gray-700">
+          <div className="divide-y divide-line ">
             {winsBySession.map(sessionGroup => (
               <div key={sessionGroup.sessionId} className="p-6">
                 {/* Session Header */}
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-3">
-                    <Calendar className="h-4 w-4 text-gray-400" />
+                    <Calendar className="h-4 w-4 text-ink-4" />
                     <div>
-                      <h4 className="font-medium text-gray-900 dark:text-white">
+                      <h4 className="font-medium text-ink ">
                         {sessionGroup.sessionTitle || 'Coaching Session'}
                       </h4>
                       {sessionGroup.sessionDate && (
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-ink-3 ">
                           {formatDate(sessionGroup.sessionDate, 'MMMM d, yyyy')}
                         </p>
                       )}
                     </div>
                   </div>
                   <Link href={`/sessions/${sessionGroup.sessionId}`}>
-                    <Button variant="ghost" size="sm" className="text-gray-500">
+                    <Button variant="ghost" size="sm" className="text-ink-3">
                       <ExternalLink className="h-4 w-4 mr-1" />
                       View Session
                     </Button>
@@ -149,36 +146,36 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
                       key={win.id}
                       className={`p-4 rounded-lg border ${
                         win.is_approved
-                          ? 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700'
-                          : 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800'
+                          ? 'bg-surface-1 border-line '
+                          : 'bg-amber-token-bg border-amber-token '
                       }`}
                     >
                       <div className="flex items-start gap-3">
                         <div
                           className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
                             win.is_approved
-                              ? 'bg-amber-100 dark:bg-amber-900/40'
-                              : 'bg-amber-200 dark:bg-amber-900/60'
+                              ? 'bg-amber-token-bg '
+                              : 'bg-amber-token-bg '
                           }`}
                         >
                           <Trophy
                             className={`h-4 w-4 ${
                               win.is_approved
-                                ? 'text-amber-600 dark:text-amber-400'
-                                : 'text-amber-700 dark:text-amber-300'
+                                ? 'text-amber-token '
+                                : 'text-amber-token '
                             }`}
                           />
                         </div>
                         <div className="flex-1">
                           <div className="flex items-start justify-between gap-2">
-                            <h5 className="font-medium text-gray-900 dark:text-white">
+                            <h5 className="font-medium text-ink ">
                               {win.title}
                             </h5>
                             <div className="flex gap-1.5">
                               {win.is_ai_generated && (
                                 <Badge
                                   variant="secondary"
-                                  className="bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs"
+                                  className="bg-surface-3 text-ink-3 text-xs"
                                 >
                                   AI
                                 </Badge>
@@ -186,7 +183,7 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
                               {!win.is_approved && (
                                 <Badge
                                   variant="secondary"
-                                  className="bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400 text-xs"
+                                  className="bg-amber-token-bg text-amber-token text-xs"
                                 >
                                   Pending
                                 </Badge>
@@ -194,7 +191,7 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
                             </div>
                           </div>
                           {win.description && (
-                            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                            <p className="text-sm text-ink-3 mt-1">
                               {win.description}
                             </p>
                           )}
@@ -208,11 +205,11 @@ export function ClientWinsTimeline({ clientId }: ClientWinsTimelineProps) {
           </div>
         ) : (
           <div className="py-16 text-center">
-            <Trophy className="h-12 w-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            <Trophy className="h-12 w-12 text-ink-2 mx-auto mb-4" />
+            <h3 className="text-lg font-medium text-ink mb-2">
               No wins recorded yet
             </h3>
-            <p className="text-gray-500 dark:text-gray-400 max-w-sm mx-auto">
+            <p className="text-ink-3 max-w-sm mx-auto">
               Wins will appear here as they are recorded during coaching
               sessions. Use AI extraction or add them manually from session
               details.

--- a/src/components/wins/session-wins.tsx
+++ b/src/components/wins/session-wins.tsx
@@ -68,7 +68,7 @@ function WinItem({
             <p className="text-sm font-medium flex-1 text-app-primary truncate">
               {win.title}
             </p>
-            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse flex-shrink-0" />
+            <span className="w-1.5 h-1.5 bg-amber-token rounded-full animate-pulse flex-shrink-0" />
           </div>
           <div className="flex items-center gap-1 flex-shrink-0">
             <Button
@@ -100,7 +100,7 @@ function WinItem({
               size="sm"
               variant="ghost"
               disabled={isApproving || isDeleting}
-              className="h-7 px-2 text-app-secondary hover:text-red-600"
+              className="h-7 px-2 text-app-secondary hover:text-vermillion"
               title="Reject win"
             >
               {isDeleting ? (
@@ -160,7 +160,7 @@ function WinItem({
               size="sm"
               variant="ghost"
               disabled={isDeleting}
-              className="h-7 px-2 text-app-secondary hover:text-red-600"
+              className="h-7 px-2 text-app-secondary hover:text-vermillion"
             >
               {isDeleting ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -414,7 +414,7 @@ export function SessionWins({
             {pendingWins.length > 0 && !isViewer && (
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <span className="w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse" />
+                  <span className="w-1.5 h-1.5 bg-amber-token rounded-full animate-pulse" />
                   <span className="text-xs font-medium text-app-secondary uppercase tracking-wide">
                     Pending ({pendingWins.length})
                   </span>
@@ -442,7 +442,7 @@ export function SessionWins({
               <div className="space-y-2">
                 {pendingWins.length > 0 && !isViewer && (
                   <div className="flex items-center gap-2">
-                    <span className="w-1.5 h-1.5 bg-gray-400 rounded-full" />
+                    <span className="w-1.5 h-1.5 bg-line rounded-full" />
                     <span className="text-xs font-medium text-app-secondary uppercase tracking-wide">
                       Confirmed ({approvedWins.length})
                     </span>

--- a/src/contexts/processing-context.tsx
+++ b/src/contexts/processing-context.tsx
@@ -388,8 +388,8 @@ function ProcessingCard({ session, onDismiss }: ProcessingCardProps) {
       className={`
         rounded-lg border bg-background p-3 shadow-lg
         animate-in slide-in-from-right-5 fade-in duration-300
-        ${isCompleted ? 'border-green-500/30' : ''}
-        ${isFailed ? 'border-red-500/30' : ''}
+        ${isCompleted ? 'border-forest/30' : ''}
+        ${isFailed ? 'border-vermillion/30' : ''}
         ${isProcessing ? 'border-border' : ''}
       `}
     >
@@ -400,10 +400,10 @@ function ProcessingCard({ session, onDismiss }: ProcessingCardProps) {
             <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
           )}
           {isCompleted && (
-            <CheckCircle className="h-4 w-4 shrink-0 text-green-500" />
+            <CheckCircle className="h-4 w-4 shrink-0 text-forest" />
           )}
           {isFailed && (
-            <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+            <AlertCircle className="h-4 w-4 shrink-0 text-vermillion" />
           )}
           <span className="text-sm font-medium truncate">{session.title}</span>
         </div>
@@ -428,9 +428,7 @@ function ProcessingCard({ session, onDismiss }: ProcessingCardProps) {
       {/* Status message */}
       {isCompleted && (
         <div className="flex items-center justify-between">
-          <p className="text-xs text-green-600 dark:text-green-400">
-            Ready for review
-          </p>
+          <p className="text-xs text-forest ">Ready for review</p>
           <Link
             href={`/sessions/${session.sessionId}`}
             className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
@@ -443,9 +441,7 @@ function ProcessingCard({ session, onDismiss }: ProcessingCardProps) {
 
       {isFailed && (
         <div className="flex items-center justify-between">
-          <p className="text-xs text-red-600 dark:text-red-400">
-            Processing failed
-          </p>
+          <p className="text-xs text-vermillion ">Processing failed</p>
           <Link
             href={`/sessions/${session.sessionId}`}
             className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"

--- a/src/hooks/use-confetti.ts
+++ b/src/hooks/use-confetti.ts
@@ -3,30 +3,36 @@ import { useCallback } from 'react'
 
 /**
  * Subtle confetti burst for task completion celebrations.
+ *
+ * Colors map to DS tokens: forest (success), ds-accent (action). Hex literals
+ * here because canvas-confetti renders on a <canvas> element and cannot read
+ * CSS variables — these values mirror --forest and --ds-accent.
  */
+const FOREST = '#15803D'
+const FOREST_BG = '#ECFDF5'
+const ACCENT = '#2563EB'
+
 export function useConfetti() {
   const fireConfetti = useCallback(
     (options?: { intensity?: 'subtle' | 'medium' }) => {
       const intensity = options?.intensity ?? 'subtle'
 
       if (intensity === 'medium') {
-        // For moving a task to "Done" column
         confetti({
           particleCount: 60,
           spread: 55,
           origin: { y: 0.65 },
-          colors: ['#10b981', '#34d399', '#6ee7b7', '#a7f3d0', '#3b82f6'],
+          colors: [FOREST, FOREST_BG, ACCENT],
           ticks: 120,
           gravity: 1.2,
           scalar: 0.9,
         })
       } else {
-        // For subtask checkbox — quick small pop
         confetti({
           particleCount: 25,
           spread: 40,
           origin: { y: 0.7 },
-          colors: ['#10b981', '#34d399', '#6ee7b7'],
+          colors: [FOREST, FOREST_BG],
           ticks: 80,
           gravity: 1.5,
           scalar: 0.7,

--- a/src/lib/coach-evaluation-questions.ts
+++ b/src/lib/coach-evaluation-questions.ts
@@ -60,32 +60,34 @@ export const SCORE_OPTIONS: ReadonlyArray<ScoreOption> = [
   {
     value: null,
     label: 'Not Observed',
-    selectedClass: 'bg-gray-300 text-gray-900 ring-2 ring-gray-500',
-    unselectedClass: 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+    selectedClass: 'bg-line text-ink ring-2 ring-line-strong',
+    unselectedClass: 'bg-surface-3 text-ink-3 hover:bg-surface-3',
   },
   {
     value: 1,
     label: '1',
-    selectedClass: 'bg-pink-300 text-pink-950 ring-2 ring-pink-600',
-    unselectedClass: 'bg-pink-100 text-pink-700 hover:bg-pink-200',
+    selectedClass: 'bg-vermillion text-ink-on-dark ring-2 ring-vermillion',
+    unselectedClass:
+      'bg-vermillion-bg text-vermillion hover:bg-vermillion-bg/80',
   },
   {
     value: 2,
     label: '2',
-    selectedClass: 'bg-orange-300 text-orange-950 ring-2 ring-orange-600',
-    unselectedClass: 'bg-orange-100 text-orange-700 hover:bg-orange-200',
+    selectedClass: 'bg-amber-token text-ink-on-dark ring-2 ring-amber-token',
+    unselectedClass:
+      'bg-amber-token-bg text-amber-token hover:bg-amber-token-bg/80',
   },
   {
     value: 3,
     label: '3',
-    selectedClass: 'bg-yellow-300 text-yellow-950 ring-2 ring-yellow-600',
-    unselectedClass: 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200',
+    selectedClass: 'bg-ds-accent text-ink-on-dark ring-2 ring-ds-accent',
+    unselectedClass: 'bg-ds-accent-bg text-ds-accent hover:bg-ds-accent-bg/80',
   },
   {
     value: 4,
     label: '4',
-    selectedClass: 'bg-green-300 text-green-950 ring-2 ring-green-600',
-    unselectedClass: 'bg-green-100 text-green-700 hover:bg-green-200',
+    selectedClass: 'bg-forest text-ink-on-dark ring-2 ring-forest',
+    unselectedClass: 'bg-forest-bg text-forest hover:bg-forest-bg/80',
   },
 ]
 
@@ -98,17 +100,17 @@ export function scoreLabel(value: ScoreValue | undefined): string {
 export function scoreChipClass(value: ScoreValue | undefined): string {
   switch (value) {
     case null:
-      return 'bg-gray-200 text-gray-700'
+      return 'bg-surface-3 text-ink-2'
     case 1:
-      return 'bg-pink-200 text-pink-800'
+      return 'bg-vermillion-bg text-vermillion'
     case 2:
-      return 'bg-orange-200 text-orange-800'
+      return 'bg-amber-token-bg text-amber-token'
     case 3:
-      return 'bg-yellow-200 text-yellow-800'
+      return 'bg-ds-accent-bg text-ds-accent'
     case 4:
-      return 'bg-green-200 text-green-800'
+      return 'bg-forest-bg text-forest'
     default:
-      return 'bg-gray-100 text-gray-500'
+      return 'bg-surface-3 text-ink-3'
   }
 }
 

--- a/src/lib/password-validation.ts
+++ b/src/lib/password-validation.ts
@@ -91,17 +91,17 @@ export function getStrengthLabel(score: number): string {
 export function getStrengthColor(score: number): string {
   switch (score) {
     case 5:
-      return 'text-green-600'
+      return 'text-forest'
     case 4:
-      return 'text-emerald-600'
+      return 'text-forest'
     case 3:
-      return 'text-yellow-600'
+      return 'text-amber-token'
     case 2:
-      return 'text-orange-600'
+      return 'text-amber-token'
     case 1:
-      return 'text-red-600'
+      return 'text-vermillion'
     default:
-      return 'text-gray-400'
+      return 'text-ink-4'
   }
 }
 
@@ -111,16 +111,16 @@ export function getStrengthColor(score: number): string {
 export function getStrengthBarColor(score: number): string {
   switch (score) {
     case 5:
-      return 'bg-green-500'
+      return 'bg-forest'
     case 4:
-      return 'bg-emerald-500'
+      return 'bg-forest'
     case 3:
-      return 'bg-yellow-500'
+      return 'bg-amber-token'
     case 2:
-      return 'bg-orange-500'
+      return 'bg-amber-token'
     case 1:
-      return 'bg-red-500'
+      return 'bg-vermillion'
     default:
-      return 'bg-gray-200'
+      return 'bg-surface-3'
   }
 }

--- a/src/services/live-meeting-service.ts
+++ b/src/services/live-meeting-service.ts
@@ -4,8 +4,28 @@
  * Uses token in URL and optional X-Guest-Token header
  */
 
+import AuthService from './auth-service'
+
 const BACKEND_URL =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+/**
+ * Build headers, optionally including the user's portal Authorization token
+ * when one is present. The live-meeting endpoints work without auth, but
+ * sending the token lets the backend claim the guest identifier for the
+ * logged-in client so their notes attribute to their portal account.
+ */
+function buildHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(extra || {}),
+  }
+  const token = AuthService.getToken()
+  if (token && !headers.Authorization) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  return headers
+}
 
 // ============ Types ============
 
@@ -217,9 +237,7 @@ export class LiveMeetingService {
   ): Promise<GuestIdentifier> {
     const response = await fetch(`${BACKEND_URL}/live-meeting/${token}/guest`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: buildHeaders(),
       body: JSON.stringify({
         guest_token: existingGuestToken || null,
         display_name: displayName || null,

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,4 +1,4 @@
-/* Markdown Content Styles for Chat Interface */
+/* Markdown Content Styles for Chat Interface — token-driven */
 
 .markdown-content {
   /* Reset some default styles */
@@ -22,23 +22,23 @@
   vertical-align: middle;
 }
 
-/* Code blocks scrollbar */
+/* Code blocks scrollbar — use ink-3 at low alpha so it tracks light/dark mode */
 .markdown-content pre code::-webkit-scrollbar {
   height: 6px;
 }
 
 .markdown-content pre code::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--surface-3);
   border-radius: 3px;
 }
 
 .markdown-content pre code::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--ink-4);
   border-radius: 3px;
 }
 
 .markdown-content pre code::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--ink-3);
 }
 
 /* Table responsiveness */
@@ -70,16 +70,16 @@
 .markdown-content dd {
   margin-left: 1.5rem;
   margin-bottom: 0.5rem;
-  color: #4b5563;
+  color: var(--ink-3);
 }
 
 /* Footnotes */
 .markdown-content .footnotes {
   margin-top: 2rem;
   padding-top: 1rem;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--line);
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--ink-3);
 }
 
 .markdown-content .footnotes ol {
@@ -93,19 +93,19 @@
   font-size: 0.75rem;
   font-family: ui-monospace, monospace;
   line-height: 1.25;
-  color: #1f2937;
+  color: var(--ink-2);
   vertical-align: middle;
-  background-color: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background-color: var(--surface-3);
+  border: 1px solid var(--line-strong);
   border-radius: 0.25rem;
-  box-shadow: inset 0 -1px 0 #d1d5db;
+  box-shadow: inset 0 -1px 0 var(--line-strong);
 }
 
 /* Math expressions (if using remark-math) */
 .markdown-content .math {
   overflow-x: auto;
   padding: 0.5rem;
-  background-color: #f9fafb;
+  background-color: var(--surface-2);
   border-radius: 0.25rem;
   margin: 0.75rem 0;
 }
@@ -114,15 +114,15 @@
 .markdown-content details {
   margin-bottom: 0.75rem;
   padding: 0.75rem;
-  background-color: #f9fafb;
-  border: 1px solid #e5e7eb;
+  background-color: var(--surface-2);
+  border: 1px solid var(--line);
   border-radius: 0.375rem;
 }
 
 .markdown-content summary {
   cursor: pointer;
   font-weight: 500;
-  color: #374151;
+  color: var(--ink-2);
 }
 
 .markdown-content details[open] summary {

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -155,36 +155,36 @@ export const CATEGORY_COLORS: Record<
   { bg: string; text: string }
 > = {
   general: {
-    bg: 'bg-gray-100 dark:bg-gray-800',
-    text: 'text-gray-700 dark:text-gray-300',
+    bg: 'bg-surface-3 ',
+    text: 'text-ink-2 ',
   },
   worksheet: {
-    bg: 'bg-blue-100 dark:bg-blue-900/30',
-    text: 'text-blue-700 dark:text-blue-400',
+    bg: 'bg-ds-accent-bg ',
+    text: 'text-ds-accent ',
   },
   exercise: {
-    bg: 'bg-green-100 dark:bg-green-900/30',
-    text: 'text-green-700 dark:text-green-400',
+    bg: 'bg-forest-bg ',
+    text: 'text-forest ',
   },
   article: {
-    bg: 'bg-purple-100 dark:bg-purple-900/30',
-    text: 'text-purple-700 dark:text-purple-400',
+    bg: 'bg-indigo-bg ',
+    text: 'text-indigo ',
   },
   template: {
-    bg: 'bg-orange-100 dark:bg-orange-900/30',
-    text: 'text-orange-700 dark:text-orange-400',
+    bg: 'bg-amber-token-bg ',
+    text: 'text-amber-token ',
   },
   video: {
-    bg: 'bg-red-100 dark:bg-red-900/30',
-    text: 'text-red-700 dark:text-red-400',
+    bg: 'bg-vermillion-bg ',
+    text: 'text-vermillion ',
   },
   document: {
-    bg: 'bg-indigo-100 dark:bg-indigo-900/30',
-    text: 'text-indigo-700 dark:text-indigo-400',
+    bg: 'bg-indigo-bg ',
+    text: 'text-indigo ',
   },
   link: {
-    bg: 'bg-teal-100 dark:bg-teal-900/30',
-    text: 'text-teal-700 dark:text-teal-400',
+    bg: 'bg-forest-bg ',
+    text: 'text-forest ',
   },
 }
 

--- a/src/types/session-note.ts
+++ b/src/types/session-note.ts
@@ -112,33 +112,33 @@ export const NOTE_TYPE_COLORS: Record<
   { bg: string; text: string; border: string }
 > = {
   coach_private: {
-    bg: 'bg-gray-50',
-    text: 'text-gray-700',
-    border: 'border-gray-200',
+    bg: 'bg-paper',
+    text: 'text-ink-2',
+    border: 'border-line',
   },
   shared: {
-    bg: 'bg-blue-50',
-    text: 'text-blue-700',
-    border: 'border-blue-200',
+    bg: 'bg-ds-accent-bg',
+    text: 'text-ds-accent',
+    border: 'border-ds-accent',
   },
   client_reflection: {
-    bg: 'bg-green-50',
-    text: 'text-green-700',
-    border: 'border-green-200',
+    bg: 'bg-forest-bg',
+    text: 'text-forest',
+    border: 'border-forest',
   },
   client_private: {
-    bg: 'bg-teal-50',
-    text: 'text-teal-700',
-    border: 'border-teal-200',
+    bg: 'bg-forest-bg',
+    text: 'text-forest',
+    border: 'border-forest',
   },
   pre_session: {
-    bg: 'bg-orange-50',
-    text: 'text-orange-700',
-    border: 'border-orange-200',
+    bg: 'bg-amber-token-bg',
+    text: 'text-amber-token',
+    border: 'border-amber-token',
   },
   post_session: {
-    bg: 'bg-indigo-50',
-    text: 'text-indigo-700',
-    border: 'border-indigo-200',
+    bg: 'bg-indigo-bg',
+    text: 'text-indigo',
+    border: 'border-indigo',
   },
 }


### PR DESCRIPTION
This PR has accumulated two logical pieces of work on the same branch. Shipping together since the redesign builds on the DS migration:

## Commit 1 — Adopt Coach Sidekick design system across the frontend (`f145708`)

- Replaces ~1.5k Tailwind palette utilities and ~2.3k `dark:palette-*` variants with the DS token scale defined in `globals.css`
- Foundation tokens (`paper` / `surface-*` / `ink*` / `line*` / status accents + `-bg` tints), shadcn/chart/sidebar/app-* remaps, brand-tile + overlay tokens fixed
- Primitives (dialog, sheet, badge, input, loading-state, toast) retire hardcoded palette classes
- DS components (`client-card`, `page-header`, `empty-state`, `stat-card`) drop gradient variants
- Navigation uses brand-tile bg + segmented active state; print view keeps inline hex literals retargeted to DS values
- ESLint `no-restricted-syntax` guardrail prevents palette regressions

## Commit 2 — Client portal redesign + restore View Client Portal + drop auto-extract (`f713bba`)

- **Client portal cosmetic redesign**: TopNav refresh (logo tile + "Coach Sidekick / CLIENT PORTAL" wordmark, Home / Sessions / Coaching Profile, bell + search + ink avatar). Dashboard hero "Next session" card + editorial recent-sessions rows. Sessions list editorial date-rail rows + inline search bar. Session detail editorial heading + pill meta row. Account page restyled (720px column). Coaching Profile new identity card. All main pages now `max-w-7xl` matching the coach portal.
- **Restore "View Client Portal" button** on the coach's client detail page (was removed in `167614c`). Mirrors the existing super-admin impersonation flow.
- **Drop frontend auto-extract `useEffect`** in `session-commitments-list.tsx` — was triggering duplicate commitment drafts across tabs / browser restarts. Backend `auto_extract_commitments_and_wins` still fires once per session on completion; manual Extract button remains.
- **Live-meeting notes** (paired with backend bundle in coach-sidekick-backend PR #44): `notes-list.tsx` adds `client_private` to `availableTypes` with separate `creatableTypes`. `live-meeting-service.ts` attaches `Authorization: Bearer` for claim propagation.

## Test plan

- [ ] `pnpm tsc --noEmit` clean
- [ ] `pnpm next build` succeeds for all `/client-portal/*` and `/sessions/...` routes
- [ ] Coach can click "View Client Portal" on a client detail page and the impersonation banner appears
- [ ] Opening a completed session no longer auto-fires `POST /commitments/extract/...`
- [ ] Manual Extract button still works
- [ ] During a live call, taking a personal note appears in the portal after the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)