### PR TITLE
Route client-portal commitment mutations to client endpoints

### DIFF
--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -585,6 +585,7 @@ export default function ClientDashboard() {
             clientId={clientId}
             onClose={() => setSelectedCommitmentId(null)}
             onCommitmentUpdate={invalidateAll}
+            clientMode
           />
         </>
       )}

--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { CommitmentService } from '@/services/commitment-service'
+import { ClientCommitmentService } from '@/services/client-commitment-service'
 import {
   useUpdateCommitment,
   useUpdateCommitmentProgress,
@@ -13,6 +14,16 @@ import {
   useUploadAttachment,
   useDeleteAttachment,
 } from '@/hooks/mutations/use-commitment-mutations'
+import {
+  useClientUpdateCommitment,
+  useClientUpdateCommitmentProgress,
+  useClientAddMilestone,
+  useClientUpdateMilestone,
+  useClientDeleteMilestone,
+  useClientDiscardCommitment,
+  useClientUploadAttachment,
+  useClientDeleteAttachment,
+} from '@/hooks/mutations/use-client-commitment-mutations'
 import { queryKeys } from '@/lib/query-client'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -97,6 +108,7 @@ interface CommitmentDetailPanelProps {
   onClose: () => void
   onCommitmentUpdate?: () => void
   guestContext?: GuestContext
+  clientMode?: boolean
 }
 
 // UUID v4 pattern check — prevents sending invalid IDs (e.g. "temp-*", "None") to the API
@@ -106,6 +118,7 @@ const UUID_RE =
 function useCommitment(
   commitmentId: string | null,
   guestContext?: GuestContext,
+  clientMode?: boolean,
 ) {
   const isValidId = !!commitmentId && UUID_RE.test(commitmentId)
   return useQuery({
@@ -117,6 +130,9 @@ function useCommitment(
           guestContext.guestToken,
           commitmentId!,
         )
+      }
+      if (clientMode) {
+        return ClientCommitmentService.getCommitment(commitmentId!)
       }
       return CommitmentService.getCommitment(commitmentId!)
     },
@@ -131,10 +147,12 @@ export function CommitmentDetailPanel({
   onClose,
   onCommitmentUpdate,
   guestContext,
+  clientMode,
 }: CommitmentDetailPanelProps) {
   const { data: commitment, isLoading } = useCommitment(
     commitmentId,
     guestContext,
+    clientMode,
   )
   const resolvedClientId = clientIdProp || commitment?.client_id
 
@@ -153,8 +171,16 @@ export function CommitmentDetailPanel({
     resolvedClientId ? { client_id: resolvedClientId } : undefined,
     guestQueryOpts,
   )
-  const updateCommitment = useUpdateCommitment({ silent: true })
-  const discardCommitment = useDiscardCommitment()
+  const coachUpdateCommitment = useUpdateCommitment({ silent: true })
+  const clientUpdateCommitment = useClientUpdateCommitment({ silent: true })
+  const updateCommitment = clientMode
+    ? clientUpdateCommitment
+    : coachUpdateCommitment
+  const coachDiscardCommitment = useDiscardCommitment()
+  const clientDiscardCommitment = useClientDiscardCommitment()
+  const discardCommitment = clientMode
+    ? clientDiscardCommitment
+    : coachDiscardCommitment
   const queryClient = useQueryClient()
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
@@ -278,13 +304,15 @@ export function CommitmentDetailPanel({
                   onFieldUpdate={handleFieldUpdate}
                 />
 
-                {/* Linked Meta Performance Outcomes & Sprints */}
-                <LinkedOutcomesSection
-                  commitment={commitment}
-                  commitmentId={commitmentId!}
-                  onCommitmentUpdate={onCommitmentUpdate}
-                  guestContext={guestContext}
-                />
+                {/* Linked Meta Performance Outcomes & Sprints - hidden in client mode (no client-portal TargetService) */}
+                {!clientMode && (
+                  <LinkedOutcomesSection
+                    commitment={commitment}
+                    commitmentId={commitmentId!}
+                    onCommitmentUpdate={onCommitmentUpdate}
+                    guestContext={guestContext}
+                  />
+                )}
 
                 {/* Description */}
                 <DescriptionSection
@@ -297,6 +325,7 @@ export function CommitmentDetailPanel({
                   <AttachmentsSection
                     commitment={commitment}
                     commitmentId={commitmentId!}
+                    clientMode={clientMode}
                   />
                 )}
 
@@ -305,6 +334,7 @@ export function CommitmentDetailPanel({
                   <MilestonesSection
                     commitment={commitment}
                     commitmentId={commitmentId!}
+                    clientMode={clientMode}
                   />
                 )}
 
@@ -314,6 +344,7 @@ export function CommitmentDetailPanel({
                     commitment={commitment}
                     commitmentId={commitmentId!}
                     onCommitmentUpdate={onCommitmentUpdate}
+                    clientMode={clientMode}
                   />
                 )}
 
@@ -936,12 +967,22 @@ function formatFileSize(bytes: number): string {
 function AttachmentsSection({
   commitment,
   commitmentId,
+  clientMode,
 }: {
   commitment: Commitment
   commitmentId: string
+  clientMode?: boolean
 }) {
-  const uploadAttachment = useUploadAttachment(commitmentId)
-  const deleteAttachment = useDeleteAttachment(commitmentId)
+  const coachUploadAttachment = useUploadAttachment(commitmentId)
+  const clientUploadAttachment = useClientUploadAttachment(commitmentId)
+  const uploadAttachment = clientMode
+    ? clientUploadAttachment
+    : coachUploadAttachment
+  const coachDeleteAttachment = useDeleteAttachment(commitmentId)
+  const clientDeleteAttachment = useClientDeleteAttachment(commitmentId)
+  const deleteAttachment = clientMode
+    ? clientDeleteAttachment
+    : coachDeleteAttachment
   const [isDragging, setIsDragging] = useState(false)
   const [uploadProgress, setUploadProgress] = useState<number | null>(null)
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
@@ -1001,10 +1042,15 @@ function AttachmentsSection({
 
     if (new Date() > expiresAt) {
       try {
-        const refreshed = await CommitmentService.refreshAttachmentUrl(
-          commitmentId,
-          attachment.id,
-        )
+        const refreshed = clientMode
+          ? await ClientCommitmentService.refreshAttachmentUrl(
+              commitmentId,
+              attachment.id,
+            )
+          : await CommitmentService.refreshAttachmentUrl(
+              commitmentId,
+              attachment.id,
+            )
         url = refreshed.file_url
       } catch {
         toast.error('Failed to refresh download link')
@@ -1160,14 +1206,26 @@ function AttachmentsSection({
 function MilestonesSection({
   commitment,
   commitmentId,
+  clientMode,
 }: {
   commitment: Commitment
   commitmentId: string
+  clientMode?: boolean
 }) {
   const [newMilestoneTitle, setNewMilestoneTitle] = useState('')
-  const addMilestone = useAddMilestone(commitmentId)
-  const updateMilestone = useUpdateMilestone(commitmentId)
-  const deleteMilestone = useDeleteMilestone(commitmentId)
+  const coachAddMilestone = useAddMilestone(commitmentId)
+  const clientAddMilestone = useClientAddMilestone(commitmentId)
+  const addMilestone = clientMode ? clientAddMilestone : coachAddMilestone
+  const coachUpdateMilestone = useUpdateMilestone(commitmentId)
+  const clientUpdateMilestone = useClientUpdateMilestone(commitmentId)
+  const updateMilestone = clientMode
+    ? clientUpdateMilestone
+    : coachUpdateMilestone
+  const coachDeleteMilestone = useDeleteMilestone(commitmentId)
+  const clientDeleteMilestone = useClientDeleteMilestone(commitmentId)
+  const deleteMilestone = clientMode
+    ? clientDeleteMilestone
+    : coachDeleteMilestone
   const { fireConfetti } = useConfetti()
 
   const milestones = commitment.milestones || []
@@ -1330,10 +1388,12 @@ function ActivitySection({
   commitment,
   commitmentId,
   onCommitmentUpdate,
+  clientMode,
 }: {
   commitment: Commitment
   commitmentId: string
   onCommitmentUpdate?: () => void
+  clientMode?: boolean
 }) {
   const [note, setNote] = useState('')
   const [showExtras, setShowExtras] = useState(false)
@@ -1341,7 +1401,9 @@ function ActivitySection({
   const [blockers, setBlockers] = useState('')
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const _queryClient = useQueryClient()
-  const updateProgress = useUpdateCommitmentProgress()
+  const coachUpdateProgress = useUpdateCommitmentProgress()
+  const clientUpdateProgress = useClientUpdateCommitmentProgress()
+  const updateProgress = clientMode ? clientUpdateProgress : coachUpdateProgress
 
   const updates = [...(commitment.updates || [])].sort(
     (a, b) =>

--- a/src/hooks/mutations/use-client-commitment-mutations.ts
+++ b/src/hooks/mutations/use-client-commitment-mutations.ts
@@ -1,0 +1,467 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ClientCommitmentService } from '@/services/client-commitment-service'
+import {
+  CommitmentAttachment,
+  CommitmentUpdate,
+  CommitmentUpdateCreate,
+  MilestoneCreate,
+} from '@/types/commitment'
+import { queryKeys } from '@/lib/query-client'
+import { toast } from 'sonner'
+
+export function useClientUpdateCommitment(options?: { silent?: boolean }) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      commitmentId,
+      data,
+    }: {
+      commitmentId: string
+      data: CommitmentUpdate
+    }) => ClientCommitmentService.updateCommitment(commitmentId, data as any),
+
+    onMutate: async ({ commitmentId, data }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.commitments.all })
+      const previousDetail = queryClient.getQueryData(
+        queryKeys.commitments.detail(commitmentId),
+      )
+
+      queryClient.setQueryData(
+        queryKeys.commitments.detail(commitmentId),
+        (old: any) => {
+          if (!old) return old
+          return { ...old, ...data }
+        },
+      )
+
+      return { previousDetail, commitmentId }
+    },
+
+    onError: (err, _variables, context) => {
+      if (context?.previousDetail && context?.commitmentId) {
+        queryClient.setQueryData(
+          queryKeys.commitments.detail(context.commitmentId),
+          context.previousDetail,
+        )
+      }
+
+      toast.error('Failed to update commitment', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSuccess: data => {
+      if (!options?.silent) {
+        toast.success('Commitment updated', {
+          description: data.title,
+        })
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+    },
+  })
+}
+
+export function useClientDiscardCommitment() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (commitmentId: string) =>
+      ClientCommitmentService.deleteCommitment(commitmentId),
+
+    onMutate: async commitmentId => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.commitments.all })
+
+      const commitmentData: any = queryClient.getQueryData(
+        queryKeys.commitments.detail(commitmentId),
+      )
+      const commitmentTitle = commitmentData?.title || 'Commitment'
+
+      const previousList = queryClient.getQueryData(
+        queryKeys.commitments.lists(),
+      )
+
+      queryClient.setQueryData(queryKeys.commitments.lists(), (old: any) => {
+        if (!old || !Array.isArray(old.commitments)) return old
+        return {
+          ...old,
+          commitments: old.commitments.filter(
+            (c: any) => c.id !== commitmentId,
+          ),
+          total: old.total - 1,
+        }
+      })
+
+      return { previousList, commitmentTitle, commitmentId }
+    },
+
+    onError: (err, _commitmentId, context) => {
+      if (context?.previousList) {
+        queryClient.setQueryData(
+          queryKeys.commitments.lists(),
+          context.previousList,
+        )
+      }
+
+      toast.error('Failed to delete commitment', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSuccess: (_data, _commitmentId, context) => {
+      toast.success('Commitment deleted', {
+        description: context?.commitmentTitle,
+      })
+    },
+
+    onSettled: (_data, _error, commitmentId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+      queryClient.removeQueries({
+        queryKey: queryKeys.commitments.detail(commitmentId),
+      })
+    },
+  })
+}
+
+export function useClientUpdateCommitmentProgress() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      commitmentId,
+      data,
+    }: {
+      commitmentId: string
+      data: CommitmentUpdateCreate
+    }) => ClientCommitmentService.updateProgress(commitmentId, data),
+
+    onMutate: async ({ commitmentId, data }) => {
+      const detailKey = queryKeys.commitments.detail(commitmentId)
+      await queryClient.cancelQueries({ queryKey: detailKey })
+      const previous = queryClient.getQueryData(detailKey)
+
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+
+        const optimisticUpdate = {
+          id: `temp-${Date.now()}`,
+          commitment_id: commitmentId,
+          updated_by_id: 'current-user',
+          progress_percentage: data.progress_percentage ?? null,
+          status_change:
+            data.progress_percentage === 100 && old.status === 'active'
+              ? 'completed'
+              : null,
+          note: data.note || null,
+          wins: data.wins || null,
+          blockers: data.blockers || null,
+          evidence_urls: data.evidence_urls || [],
+          created_at: new Date().toISOString(),
+        }
+
+        return {
+          ...old,
+          progress_percentage:
+            data.progress_percentage ?? old.progress_percentage,
+          status:
+            data.progress_percentage === 100 && old.status === 'active'
+              ? 'completed'
+              : old.status,
+          updates: [...(old.updates || []), optimisticUpdate],
+        }
+      })
+
+      return { previous, commitmentId }
+    },
+
+    onError: (err, _vars, context) => {
+      if (context?.previous && context?.commitmentId) {
+        queryClient.setQueryData(
+          queryKeys.commitments.detail(context.commitmentId),
+          context.previous,
+        )
+      }
+      toast.error('Failed to update progress', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSuccess: () => {
+      toast.success('Progress updated')
+    },
+
+    onSettled: (_data, _err, { commitmentId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.commitments.detail(commitmentId),
+      })
+    },
+  })
+}
+
+export function useClientAddMilestone(commitmentId: string) {
+  const queryClient = useQueryClient()
+  const detailKey = queryKeys.commitments.detail(commitmentId)
+
+  return useMutation({
+    mutationFn: (data: MilestoneCreate) =>
+      ClientCommitmentService.addMilestone(commitmentId, data),
+
+    onMutate: async newMilestone => {
+      await queryClient.cancelQueries({ queryKey: detailKey })
+      const previous = queryClient.getQueryData(detailKey)
+
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+        const optimistic = {
+          id: `temp-${Date.now()}`,
+          commitment_id: commitmentId,
+          title: newMilestone.title,
+          description: newMilestone.description || null,
+          target_date: newMilestone.target_date || null,
+          completed_date: null,
+          order_index:
+            newMilestone.order_index ?? (old.milestones?.length || 0),
+          status: 'pending',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }
+        return {
+          ...old,
+          milestones: [...(old.milestones || []), optimistic],
+        }
+      })
+
+      return { previous }
+    },
+
+    onError: (err, _data, context) => {
+      if (context?.previous)
+        queryClient.setQueryData(detailKey, context.previous)
+      toast.error('Failed to add milestone', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+      queryClient.invalidateQueries({ queryKey: detailKey })
+    },
+  })
+}
+
+export function useClientUpdateMilestone(commitmentId: string) {
+  const queryClient = useQueryClient()
+  const detailKey = queryKeys.commitments.detail(commitmentId)
+
+  return useMutation({
+    mutationFn: ({
+      milestoneId,
+      data,
+    }: {
+      milestoneId: string
+      data: Partial<MilestoneCreate> & { status?: string }
+    }) =>
+      ClientCommitmentService.updateMilestone(commitmentId, milestoneId, data),
+
+    onMutate: async ({ milestoneId, data }) => {
+      await queryClient.cancelQueries({ queryKey: detailKey })
+      const previous = queryClient.getQueryData(detailKey)
+
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+        return {
+          ...old,
+          milestones: (old.milestones || []).map((m: any) =>
+            m.id === milestoneId
+              ? {
+                  ...m,
+                  ...data,
+                  completed_date:
+                    data.status === 'completed'
+                      ? m.completed_date || new Date().toISOString()
+                      : data.status === 'pending'
+                        ? null
+                        : m.completed_date,
+                  updated_at: new Date().toISOString(),
+                }
+              : m,
+          ),
+        }
+      })
+
+      return { previous }
+    },
+
+    onError: (err, _vars, context) => {
+      if (context?.previous)
+        queryClient.setQueryData(detailKey, context.previous)
+      toast.error('Failed to update milestone', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+      queryClient.invalidateQueries({ queryKey: detailKey })
+    },
+  })
+}
+
+export function useClientDeleteMilestone(commitmentId: string) {
+  const queryClient = useQueryClient()
+  const detailKey = queryKeys.commitments.detail(commitmentId)
+
+  return useMutation({
+    mutationFn: (milestoneId: string) =>
+      ClientCommitmentService.deleteMilestone(commitmentId, milestoneId),
+
+    onMutate: async milestoneId => {
+      await queryClient.cancelQueries({ queryKey: detailKey })
+      const previous = queryClient.getQueryData(detailKey)
+
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+        return {
+          ...old,
+          milestones: (old.milestones || []).filter(
+            (m: any) => m.id !== milestoneId,
+          ),
+        }
+      })
+
+      return { previous }
+    },
+
+    onError: (err, _milestoneId, context) => {
+      if (context?.previous)
+        queryClient.setQueryData(detailKey, context.previous)
+      toast.error('Failed to delete milestone', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+      queryClient.invalidateQueries({ queryKey: detailKey })
+    },
+  })
+}
+
+export function useClientUploadAttachment(commitmentId: string) {
+  const queryClient = useQueryClient()
+  const detailKey = queryKeys.commitments.detail(commitmentId)
+
+  return useMutation({
+    mutationFn: ({
+      file,
+      onProgress,
+    }: {
+      file: File
+      onProgress?: (percent: number) => void
+    }) =>
+      ClientCommitmentService.uploadAttachment(commitmentId, file, onProgress),
+
+    onMutate: async ({ file }) => {
+      await queryClient.cancelQueries({ queryKey: detailKey })
+      const previous = queryClient.getQueryData(detailKey)
+
+      const tempAttachment: CommitmentAttachment & { uploading?: boolean } = {
+        id: `temp-${Date.now()}`,
+        filename: file.name,
+        file_key: '',
+        file_url: '',
+        file_size: file.size,
+        content_type: file.type || 'application/octet-stream',
+        uploaded_by_id: 'current-user',
+        uploaded_at: new Date().toISOString(),
+        uploading: true,
+      }
+
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+        return {
+          ...old,
+          attachments: [...(old.attachments || []), tempAttachment],
+        }
+      })
+
+      return { previous }
+    },
+
+    onError: (err, _vars, context) => {
+      if (context?.previous)
+        queryClient.setQueryData(detailKey, context.previous)
+      toast.error('Failed to upload file', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSuccess: data => {
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+        return {
+          ...old,
+          attachments: [
+            ...(old.attachments || []).filter(
+              (a: any) => !a.id?.startsWith('temp-'),
+            ),
+            data,
+          ],
+        }
+      })
+      toast.success('File uploaded')
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+    },
+  })
+}
+
+export function useClientDeleteAttachment(commitmentId: string) {
+  const queryClient = useQueryClient()
+  const detailKey = queryKeys.commitments.detail(commitmentId)
+
+  return useMutation({
+    mutationFn: (attachmentId: string) =>
+      ClientCommitmentService.deleteAttachment(commitmentId, attachmentId),
+
+    onMutate: async attachmentId => {
+      await queryClient.cancelQueries({ queryKey: detailKey })
+      const previous = queryClient.getQueryData(detailKey)
+
+      queryClient.setQueryData(detailKey, (old: any) => {
+        if (!old) return old
+        return {
+          ...old,
+          attachments: (old.attachments || []).filter(
+            (a: any) => a.id !== attachmentId,
+          ),
+        }
+      })
+
+      return { previous }
+    },
+
+    onError: (err, _attachmentId, context) => {
+      if (context?.previous)
+        queryClient.setQueryData(detailKey, context.previous)
+      toast.error('Failed to remove attachment', {
+        description: err instanceof Error ? err.message : 'Please try again',
+      })
+    },
+
+    onSuccess: () => {
+      toast.success('Attachment removed')
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.commitments.all })
+      queryClient.invalidateQueries({ queryKey: detailKey })
+    },
+  })
+}

--- a/src/services/client-commitment-service.ts
+++ b/src/services/client-commitment-service.ts
@@ -6,9 +6,13 @@
 import { ApiClient } from '@/lib/api-client'
 import {
   Commitment,
+  CommitmentAttachment,
   CommitmentUpdateCreate,
   CommitmentListResponse,
+  Milestone,
+  MilestoneCreate,
 } from '@/types/commitment'
+import authService from '@/services/auth-service'
 
 const BACKEND_URL =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
@@ -122,5 +126,137 @@ export class ClientCommitmentService {
       status: 'completed',
       progress_percentage: 100,
     })
+  }
+
+  static async getCommitment(commitmentId: string): Promise<Commitment> {
+    return ApiClient.get(
+      `${BACKEND_URL}/client-portal/commitments/${commitmentId}`,
+    )
+  }
+
+  static async addMilestone(
+    commitmentId: string,
+    data: MilestoneCreate,
+  ): Promise<Milestone> {
+    return ApiClient.post(
+      `${BACKEND_URL}/client-portal/commitments/${commitmentId}/milestones`,
+      data,
+    )
+  }
+
+  static async updateMilestone(
+    _commitmentId: string,
+    milestoneId: string,
+    data: Partial<MilestoneCreate>,
+  ): Promise<Milestone> {
+    return ApiClient.patch(
+      `${BACKEND_URL}/client-portal/commitments/milestones/${milestoneId}`,
+      data,
+    )
+  }
+
+  static async deleteMilestone(
+    commitmentId: string,
+    milestoneId: string,
+  ): Promise<void> {
+    await ApiClient.delete(
+      `${BACKEND_URL}/client-portal/commitments/${commitmentId}/milestones/${milestoneId}`,
+    )
+  }
+
+  static async completeMilestone(milestoneId: string): Promise<Milestone> {
+    return ApiClient.post(
+      `${BACKEND_URL}/client-portal/commitments/milestones/${milestoneId}/complete`,
+      {},
+    )
+  }
+
+  static async uploadAttachment(
+    commitmentId: string,
+    file: File,
+    onProgress?: (percent: number) => void,
+  ): Promise<CommitmentAttachment> {
+    const token = authService.getToken()
+    const formData = new FormData()
+    formData.append('file', file)
+
+    const viewAsClient =
+      typeof window !== 'undefined'
+        ? sessionStorage.getItem('view_as_client_id')
+        : null
+
+    if (onProgress) {
+      return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest()
+        xhr.open(
+          'POST',
+          `${BACKEND_URL}/client-portal/commitments/${commitmentId}/attachments`,
+        )
+        if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`)
+        if (viewAsClient) xhr.setRequestHeader('X-View-As-Client', viewAsClient)
+
+        xhr.upload.onprogress = e => {
+          if (e.lengthComputable) {
+            onProgress(Math.round((e.loaded / e.total) * 100))
+          }
+        }
+
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve(JSON.parse(xhr.responseText))
+          } else {
+            try {
+              const error = JSON.parse(xhr.responseText)
+              reject(new Error(error.detail || 'Failed to upload attachment'))
+            } catch {
+              reject(new Error('Upload failed'))
+            }
+          }
+        }
+
+        xhr.onerror = () => reject(new Error('Network error during upload'))
+        xhr.send(formData)
+      })
+    }
+
+    const response = await fetch(
+      `${BACKEND_URL}/client-portal/commitments/${commitmentId}/attachments`,
+      {
+        method: 'POST',
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(viewAsClient ? { 'X-View-As-Client': viewAsClient } : {}),
+        },
+        body: formData,
+      },
+    )
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ detail: 'Upload failed' }))
+      throw new Error(error.detail || 'Failed to upload attachment')
+    }
+
+    return response.json()
+  }
+
+  static async deleteAttachment(
+    commitmentId: string,
+    attachmentId: string,
+  ): Promise<void> {
+    await ApiClient.delete(
+      `${BACKEND_URL}/client-portal/commitments/${commitmentId}/attachments/${attachmentId}`,
+    )
+  }
+
+  static async refreshAttachmentUrl(
+    commitmentId: string,
+    attachmentId: string,
+  ): Promise<CommitmentAttachment> {
+    return ApiClient.post(
+      `${BACKEND_URL}/client-portal/commitments/${commitmentId}/attachments/${attachmentId}/refresh-url`,
+      {},
+    )
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `clientMode` prop to `CommitmentDetailPanel` mirroring the existing `guestContext` pattern. When set, every mutation (update, delete, progress, milestone CRUD, attachment upload/delete/refresh) routes through `/client-portal/commitments/*` instead of the coach-only `/commitments/*` endpoints — fixes the bug where a logged-in client opening the detail panel from the client portal dashboard got 401/403 on every action.
- Extends `ClientCommitmentService` with 8 matching methods (raw-fetch upload injects `X-View-As-Client` for super-admin impersonation).
- Adds `src/hooks/mutations/use-client-commitment-mutations.ts` mirroring the 8 coach hooks the panel uses, with the same optimistic-update + toast + cache-invalidation logic and the same `queryKeys.commitments.*` keys for cache coherence.
- Wires `clientMode` on the client portal dashboard's `CommitmentDetailPanel`.
- Hides `LinkedOutcomesSection` in client mode (no client-portal `TargetService` yet — same pattern guest mode uses for attachments/milestones).

Pairs with backend PR ainovusdev/coach-sidekick-backend#45.

## Test plan
- [ ] Logged in as a client, open a commitment from the dashboard; edit fields, add progress updates, add/complete/delete milestones, upload/refresh/delete attachments, and delete a self-created commitment. All network requests should hit `/client-portal/commitments/...`.
- [ ] Try deleting a coach-created commitment as a client → backend returns 403, panel surfaces toast.
- [ ] Coach regression: open any commitment from the coach portal (`/commitments`, `/clients/[id]`, etc.) and verify all mutations still hit `/commitments/...` and behave unchanged.

## Known follow-up (out of scope)
- `CommitmentCreatePanel` still imports the coach `useCreateCommitment` hook, so creating a new commitment from the client portal dashboard still hits the coach endpoint. Separate PR.