### PR TITLE
Fix dropdown/select/popover z-index inside commitment detail panel

### DIFF
--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -457,7 +457,7 @@ function PanelHeader({
               <MoreVertical className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent align="end" className="z-[80]">
             <DropdownMenuItem onClick={onDelete} className="text-vermillion">
               <Trash2 className="h-4 w-4 mr-2" />
               Delete
@@ -537,7 +537,7 @@ function FieldsGrid({
             <SelectTrigger className="h-9 text-sm">
               <SelectValue />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="z-[80]">
               <SelectItem value="low">
                 <div className="flex items-center gap-2">
                   <div className={cn('w-2 h-2 rounded-full', 'bg-line')} />
@@ -590,7 +590,7 @@ function FieldsGrid({
                   : 'Set date'}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="start">
+            <PopoverContent className="w-auto p-0 z-[80]" align="start">
               <Calendar
                 mode="single"
                 selected={


### PR DESCRIPTION
## Summary
- The commitment detail panel container is `z-[70]`, but `DropdownMenuContent` defaults to `z-[60]`, `SelectContent` to `z-50`, and `PopoverContent` to `z-[70]` — so the three-dot menu, Priority select, and Due Date calendar popover open *behind* the panel and are invisible/uninteractable.
- Bumps all three to `z-[80]` at the call sites in `commitment-detail-panel.tsx`.

Pre-existing bug exposed by the panel container's z-index; affects both coach and client portals.

## Test plan
- [ ] Open a commitment from the client portal dashboard → click three-dot menu → "Delete" appears and works.
- [ ] Change Priority via the Select inside the same panel.
- [ ] Pick a Due Date via the calendar popover.
- [ ] Coach portal regression: same actions work from `/commitments` and `/clients/[id]`.