### PR TITLE
Remove confirmation dialog when deleting a commitment

### DIFF
--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -183,7 +183,6 @@ export function CommitmentDetailPanel({
     : coachDiscardCommitment
   const queryClient = useQueryClient()
 
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const panelRef = useRef<HTMLDivElement>(null)
 
   // Close on Escape
@@ -260,7 +259,6 @@ export function CommitmentDetailPanel({
         },
       })
     }
-    setDeleteDialogOpen(false)
   }
 
   const isOpen = !!commitmentId
@@ -295,7 +293,7 @@ export function CommitmentDetailPanel({
                   commitment={commitment}
                   onClose={onClose}
                   onFieldUpdate={handleFieldUpdate}
-                  onDelete={() => setDeleteDialogOpen(true)}
+                  onDelete={handleDelete}
                 />
 
                 {/* Fields Grid */}
@@ -359,28 +357,6 @@ export function CommitmentDetailPanel({
           )}
         </div>
       </div>
-
-      {/* Delete Confirmation */}
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Commitment</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete &ldquo;{commitment?.title}
-              &rdquo;? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-vermillion hover:bg-vermillion"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Removes the "Delete Commitment" AlertDialog from `CommitmentDetailPanel`. The three-dot menu's Delete item now calls `handleDelete` directly.
- The mutation hooks already show a success toast and optimistically remove the commitment from the list, so the user gets clear feedback without an extra modal.
- Drops the now-unused `deleteDialogOpen` state.

## Test plan
- [ ] Client portal: open a commitment, click three-dot → Delete → panel closes, commitment disappears from list, success toast appears.
- [ ] Coach portal regression: same flow from `/commitments` and `/clients/[id]`.
- [ ] Live-meeting guest flow still works (separate path through `LiveMeetingService.deleteCommitment`).