### PR TITLE
Allow commitment title to wrap in detail panel

### DIFF
--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -417,7 +417,7 @@ function PanelHeader({
           />
         ) : (
           <h2
-            className="text-xl font-bold text-ink cursor-pointer hover:bg-surface-3 rounded px-2 py-1 -mx-2 truncate"
+            className="text-xl font-bold text-ink cursor-pointer hover:bg-surface-3 rounded px-2 py-1 -mx-2 break-words"
             onClick={() => setIsEditingTitle(true)}
           >
             {commitment.title}


### PR DESCRIPTION
Replaces `truncate` with `break-words` on the commitment detail panel title so long titles wrap to multiple lines instead of being cut off with an ellipsis.