### PR TITLE
Admin data-analyst agent UI

### DIFF
--- a/src/app/admin/agent/page.tsx
+++ b/src/app/admin/agent/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Sparkles } from 'lucide-react'
+import { PageHeader } from '@/components/ui/page-header'
+import { AgentChat } from '@/components/admin/agent/agent-chat'
+
+export default function AdminAgentPage() {
+  return (
+    <div>
+      <PageHeader
+        title="AI Agent"
+        description="Ask questions about coaches, clients, sessions, and analytics. The agent queries the live database, builds charts, and explains what it finds."
+        icon={Sparkles}
+      />
+      <AgentChat />
+    </div>
+  )
+}

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Network,
   FolderKanban,
   BookOpen,
+  Sparkles,
 } from 'lucide-react'
 import { useAuth } from '@/contexts/auth-context'
 
@@ -24,6 +25,12 @@ const menuItems = [
     href: '/admin/dashboard',
     icon: LayoutDashboard,
     requiredRole: ['admin', 'super_admin'],
+  },
+  {
+    title: 'AI Agent',
+    href: '/admin/agent',
+    icon: Sparkles,
+    requiredRole: ['super_admin'],
   },
   {
     title: 'Users',

--- a/src/components/admin/agent/agent-activity-bar.tsx
+++ b/src/components/admin/agent/agent-activity-bar.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { MessageBlock, ToolName } from '@/types/agent'
+
+/**
+ * Live status bar shown while the agent is mid-thought. Sits at the top of
+ * the streaming assistant turn and updates with the current tool's intent.
+ *
+ * Purpose: make it instantly obvious this isn't a chatbot — it's an agent
+ * that's actively running queries, searching transcripts, and composing
+ * answers across many steps.
+ */
+
+interface Props {
+  /** Blocks of the currently-streaming assistant message. Most-recent last. */
+  blocks: MessageBlock[]
+  /** Whether the stream is still active. */
+  streaming: boolean
+}
+
+const TOOL_VERB: Record<ToolName, string> = {
+  run_sql_query: 'Running SQL',
+  describe_schema: 'Inspecting schema',
+  generate_chart: 'Rendering chart',
+  search_conversations: 'Searching transcripts',
+  get_session_transcript: 'Reading transcript',
+}
+
+export function AgentActivityBar({ blocks, streaming }: Props) {
+  if (!streaming) return null
+
+  const status = deriveStatus(blocks)
+  if (!status) return null
+
+  return (
+    <div className="mx-auto mt-2 flex max-w-4xl items-center gap-2 rounded-md border border-line bg-ds-accent-bg px-3 py-1.5 text-xs text-ink-2 shadow-sm">
+      <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-ds-accent" />
+      <span className="font-medium text-ink">{status.verb}</span>
+      {status.detail ? (
+        <span className="truncate text-ink-3">{status.detail}</span>
+      ) : null}
+      {status.stepLabel ? (
+        <span className="ml-auto shrink-0 rounded bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ds-accent">
+          {status.stepLabel}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+interface DerivedStatus {
+  verb: string
+  detail: string | null
+  stepLabel: string | null
+}
+
+function deriveStatus(blocks: MessageBlock[]): DerivedStatus | null {
+  if (blocks.length === 0) {
+    return { verb: 'Thinking', detail: null, stepLabel: null }
+  }
+
+  // The most recent running tool dominates the status.
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i]
+    if (b.kind === 'tool_call' && b.status === 'running') {
+      return {
+        verb: TOOL_VERB[b.name] ?? b.name,
+        detail: extractToolDetail(b),
+        stepLabel: buildStepLabel(blocks),
+      }
+    }
+  }
+
+  // No running tool — find the last completed tool, otherwise we're composing text.
+  const lastCompleted = [...blocks]
+    .reverse()
+    .find(b => b.kind === 'tool_call' && b.status === 'done')
+  if (lastCompleted && lastCompleted.kind === 'tool_call') {
+    return {
+      verb: 'Composing answer',
+      detail: `after ${TOOL_VERB[lastCompleted.name] ?? lastCompleted.name}`,
+      stepLabel: buildStepLabel(blocks),
+    }
+  }
+
+  // No tools yet — probably text streaming or thinking.
+  return { verb: 'Composing answer', detail: null, stepLabel: null }
+}
+
+function extractToolDetail(
+  block: Extract<MessageBlock, { kind: 'tool_call' }>,
+): string | null {
+  const input = block.input
+  // Prefer the model-supplied explanation when present.
+  if (typeof input.explanation === 'string' && input.explanation.trim()) {
+    return input.explanation.trim()
+  }
+  if (block.name === 'run_sql_query') {
+    const q = (input.query as string | undefined) || block.partialInput
+    return q ? truncate(q.replace(/\s+/g, ' '), 100) : null
+  }
+  if (block.name === 'describe_schema') {
+    const table = (input.table as string | undefined) || 'all tables'
+    return `for ${table}`
+  }
+  if (block.name === 'search_conversations') {
+    const q = (input.query as string | undefined) || null
+    if (!q) return null
+    const scope = input.coach_id
+      ? ' (one coach)'
+      : input.client_id
+        ? ' (one client)'
+        : ''
+    return `"${truncate(q, 80)}"${scope}`
+  }
+  if (block.name === 'get_session_transcript') {
+    const id = (input.session_id as string | undefined) || ''
+    return id ? `session ${id.slice(0, 8)}…` : null
+  }
+  if (block.name === 'generate_chart') {
+    const title = (input.title as string | undefined) || null
+    return title ? truncate(title, 80) : null
+  }
+  return null
+}
+
+function buildStepLabel(blocks: MessageBlock[]): string | null {
+  const total = blocks.filter(b => b.kind === 'tool_call').length
+  if (total === 0) return null
+  return `Step ${total}`
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1) + '…'
+}
+
+// `cn` is imported above but our minimal class strings don't need it; keeping
+// the import so future variants can use it without re-adding.
+void cn

--- a/src/components/admin/agent/agent-chart.tsx
+++ b/src/components/admin/agent/agent-chart.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { ChartSpec } from '@/types/agent'
+
+const COLORS = [
+  '#3b82f6',
+  '#ef4444',
+  '#10b981',
+  '#f59e0b',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+]
+
+interface AgentChartProps {
+  spec: ChartSpec
+}
+
+export function AgentChart({ spec }: AgentChartProps) {
+  const { chart_type, title, description, data, x_key, y_keys } = spec
+  const safeData = Array.isArray(data) ? data : []
+
+  return (
+    <div className="my-3 rounded-lg border border-line bg-surface-1 p-4">
+      <div className="mb-3">
+        <h4 className="text-sm font-semibold text-ink">{title}</h4>
+        {description ? (
+          <p className="mt-0.5 text-xs text-ink-3">{description}</p>
+        ) : null}
+      </div>
+      <div className="h-72 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          {renderChart(chart_type, safeData, x_key, y_keys)}
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+function renderChart(
+  type: ChartSpec['chart_type'],
+  data: Array<Record<string, unknown>>,
+  xKey: string,
+  yKeys: string[],
+) {
+  switch (type) {
+    case 'line':
+      return (
+        <LineChart
+          data={data}
+          margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis dataKey={xKey} tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          {yKeys.map((k, i) => (
+            <Line
+              key={k}
+              type="monotone"
+              dataKey={k}
+              stroke={COLORS[i % COLORS.length]}
+              strokeWidth={2}
+              dot={{ r: 3 }}
+            />
+          ))}
+        </LineChart>
+      )
+    case 'bar':
+      return (
+        <BarChart
+          data={data}
+          margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis dataKey={xKey} tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          {yKeys.map((k, i) => (
+            <Bar key={k} dataKey={k} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </BarChart>
+      )
+    case 'area':
+      return (
+        <AreaChart
+          data={data}
+          margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis dataKey={xKey} tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          {yKeys.map((k, i) => (
+            <Area
+              key={k}
+              type="monotone"
+              dataKey={k}
+              stroke={COLORS[i % COLORS.length]}
+              fill={COLORS[i % COLORS.length]}
+              fillOpacity={0.2}
+            />
+          ))}
+        </AreaChart>
+      )
+    case 'pie': {
+      const valueKey = yKeys[0]
+      return (
+        <PieChart>
+          <Tooltip />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          <Pie
+            data={data}
+            dataKey={valueKey}
+            nameKey={xKey}
+            outerRadius={100}
+            label={entry => `${entry[xKey]}`}
+          >
+            {data.map((_entry, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+        </PieChart>
+      )
+    }
+    case 'scatter':
+      return (
+        <ScatterChart margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis dataKey={xKey} type="number" tick={{ fontSize: 11 }} />
+          <YAxis dataKey={yKeys[0]} type="number" tick={{ fontSize: 11 }} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          <Scatter data={data} fill={COLORS[0]} />
+        </ScatterChart>
+      )
+    default:
+      return (
+        <div className="flex h-full items-center justify-center text-sm text-ink-3">
+          Unsupported chart type: {type}
+        </div>
+      )
+  }
+}

--- a/src/components/admin/agent/agent-chat.tsx
+++ b/src/components/admin/agent/agent-chat.tsx
@@ -1,0 +1,455 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import {
+  Sparkles,
+  RotateCcw,
+  Database,
+  MessagesSquare,
+  ShieldCheck,
+  Zap,
+} from 'lucide-react'
+import { AgentMessage } from './agent-message'
+import { AgentComposer } from './agent-composer'
+import { AgentActivityBar } from './agent-activity-bar'
+import { fetchModels, streamAgent } from '@/services/agent-service'
+import type {
+  AgentEvent,
+  AgentMessage as AgentMessageType,
+  MessageBlock,
+  ModelOption,
+  ToolName,
+} from '@/types/agent'
+
+const STARTERS = [
+  'How many active coaches do we have right now?',
+  'Plot coaching sessions per week over the last 3 months.',
+  'Find the top 5 coaches by avg coaching scores, then quote a moment of strong coaching from each.',
+  'Top 5 most common primary goals across all client personas.',
+  'Find 3 examples in our transcripts where a coach helps a client reframe a stuck mindset.',
+  'Compare average session length for 1-on-1 vs group sessions.',
+]
+
+export function AgentChat() {
+  const [model, setModel] = useState<string>('claude-opus-4-7')
+  const [models, setModels] = useState<ModelOption[]>([])
+  const [messages, setMessages] = useState<AgentMessageType[]>([])
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState(false)
+  // Captured from the SDK's first `session_init` event; sent back as
+  // `resume_session_id` on follow-up turns so the agent keeps prior tool
+  // history in working memory. Cleared by the "New" button.
+  const [sdkSessionId, setSdkSessionId] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+
+  // Fetch model picker options once.
+  useEffect(() => {
+    let cancelled = false
+    fetchModels()
+      .then(res => {
+        if (cancelled) return
+        setModels(res.models)
+        if (res.default) setModel(res.default)
+      })
+      .catch(err => {
+        if (cancelled) return
+        // Non-fatal — the picker stays at its default.
+
+        console.warn('Failed to fetch agent models', err)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Auto-scroll to bottom as messages grow.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  })
+
+  const handleCancel = useCallback(() => {
+    abortRef.current?.abort()
+    abortRef.current = null
+    setStreaming(false)
+  }, [])
+
+  const handleReset = useCallback(() => {
+    if (streaming) handleCancel()
+    setMessages([])
+    setSdkSessionId(null)
+  }, [streaming, handleCancel])
+
+  const handleSend = useCallback(
+    async (questionOverride?: string) => {
+      const question = (questionOverride ?? input).trim()
+      if (!question || streaming) return
+
+      const userMsg: AgentMessageType = {
+        id: crypto.randomUUID(),
+        role: 'user',
+        blocks: [{ kind: 'text', text: question }],
+      }
+      const assistantMsg: AgentMessageType = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        blocks: [],
+      }
+      const historyForBackend = buildBackendHistory([...messages, userMsg])
+
+      setMessages(prev => [...prev, userMsg, assistantMsg])
+      setInput('')
+      setStreaming(true)
+
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      try {
+        for await (const event of streamAgent({
+          messages: historyForBackend,
+          model,
+          resume_session_id: sdkSessionId,
+          signal: controller.signal,
+        })) {
+          if (event.type === 'session_init' && event.session_id) {
+            // Capture the SDK session id on the first turn; the next turn
+            // sends it back as resume_session_id.
+            setSdkSessionId(event.session_id)
+          }
+          setMessages(prev => applyEvent(prev, assistantMsg.id, event))
+          if (event.type === 'done') break
+        }
+      } catch (e: unknown) {
+        const err = e as { name?: string; message?: string }
+        if (err.name === 'AbortError') {
+          // Silent — user pressed Stop.
+        } else {
+          const message = err.message || 'Agent request failed'
+          toast.error('Agent error', { description: message })
+          setMessages(prev =>
+            applyEvent(prev, assistantMsg.id, {
+              type: 'error',
+              message,
+            } as AgentEvent),
+          )
+        }
+      } finally {
+        abortRef.current = null
+        setStreaming(false)
+      }
+    },
+    [input, model, messages, streaming, sdkSessionId],
+  )
+
+  const showStarters = messages.length === 0 && !streaming
+
+  const modelOptions = useMemo<ModelOption[]>(() => {
+    if (models.length > 0) return models
+    return [
+      {
+        id: 'claude-opus-4-7',
+        label: 'Claude Opus 4.7',
+        description: 'Strongest reasoning',
+      },
+    ]
+  }, [models])
+
+  // The blocks of the latest assistant message — feed to the activity bar so
+  // it knows what tool is currently running.
+  const liveAssistantBlocks: MessageBlock[] =
+    streaming &&
+    messages.length > 0 &&
+    messages[messages.length - 1].role === 'assistant'
+      ? messages[messages.length - 1].blocks
+      : []
+  const totalToolCalls = useMemo(
+    () =>
+      messages.reduce(
+        (n, m) => n + m.blocks.filter(b => b.kind === 'tool_call').length,
+        0,
+      ),
+    [messages],
+  )
+  const userTurns = useMemo(
+    () => messages.filter(m => m.role === 'user').length,
+    [messages],
+  )
+
+  return (
+    <div className="flex h-[calc(100vh-8rem)] flex-col overflow-hidden rounded-lg border border-line-strong bg-paper shadow-sm">
+      {/* Analyst console header — distinguishes this from regular chat. */}
+      <div className="border-b border-line bg-surface-1">
+        <div className="flex items-center gap-3 px-4 py-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-ds-accent text-ink-on-dark shadow-sm">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold tracking-tight text-ink">
+                Data Analyst Agent
+              </span>
+              <span className="rounded bg-ds-accent-bg px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-ds-accent">
+                Agent · Admin
+              </span>
+            </div>
+            <span className="text-[11px] text-ink-3">
+              Reasons across the live database and session transcripts. Strictly
+              read-only.
+            </span>
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <Select value={model} onValueChange={setModel} disabled={streaming}>
+              <SelectTrigger className="h-8 w-[180px] text-xs">
+                {/* Render only the model label in the trigger; the description
+                    only belongs in the open menu. Passing children to SelectValue
+                    overrides the default which would echo the full SelectItem
+                    children (label + description) and overflow the row. */}
+                <SelectValue placeholder="Pick a model">
+                  {modelOptions.find(m => m.id === model)?.label ?? model}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {modelOptions.map(m => (
+                  <SelectItem key={m.id} value={m.id} className="text-xs">
+                    <div className="flex flex-col">
+                      <span>{m.label}</span>
+                      <span className="text-[10px] text-ink-3">
+                        {m.description}
+                      </span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleReset}
+              disabled={messages.length === 0}
+              className="gap-1.5"
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+              New
+            </Button>
+          </div>
+        </div>
+        {/* Capability strip — surfaces what the agent has access to. */}
+        <div className="flex items-center gap-3 border-t border-line bg-ds-accent-bg px-4 py-1.5 text-[11px] text-ink-2">
+          <span className="inline-flex items-center gap-1">
+            <Database className="h-3 w-3" />
+            Postgres
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <MessagesSquare className="h-3 w-3" />
+            Transcripts (Weaviate)
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Zap className="h-3 w-3" />
+            Charts
+          </span>
+          <span className="inline-flex items-center gap-1 text-forest">
+            <ShieldCheck className="h-3 w-3" />
+            Read-only
+          </span>
+          <span className="ml-auto flex items-center gap-3 font-mono text-[10px] text-ink-3">
+            {sdkSessionId ? (
+              <span title={sdkSessionId}>
+                session {sdkSessionId.slice(0, 8)}…
+              </span>
+            ) : null}
+            {userTurns > 0 ? (
+              <span>
+                {userTurns} turn{userTurns === 1 ? '' : 's'} · {totalToolCalls}{' '}
+                tool call
+                {totalToolCalls === 1 ? '' : 's'}
+              </span>
+            ) : null}
+          </span>
+        </div>
+      </div>
+
+      {/* Live activity bar — only visible while streaming. */}
+      <div className="px-4">
+        <AgentActivityBar blocks={liveAssistantBlocks} streaming={streaming} />
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto flex max-w-4xl flex-col gap-4">
+          {showStarters ? (
+            <EmptyState onPick={q => handleSend(q)} />
+          ) : (
+            messages.map(m => <AgentMessage key={m.id} message={m} />)
+          )}
+        </div>
+      </div>
+
+      <AgentComposer
+        value={input}
+        onChange={setInput}
+        onSend={() => handleSend()}
+        onCancel={handleCancel}
+        streaming={streaming}
+      />
+    </div>
+  )
+}
+
+function EmptyState({ onPick }: { onPick: (q: string) => void }) {
+  return (
+    <div className="mx-auto max-w-2xl py-10 text-center">
+      <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-ds-accent text-ink-on-dark shadow-md">
+        <Sparkles className="h-7 w-7" />
+      </div>
+      <h2 className="text-lg font-semibold text-ink">
+        Ask the agent anything about your data
+      </h2>
+      <p className="mt-1.5 text-sm text-ink-3">
+        Unlike the per-client chat, this agent reasons across <em>all</em>
+        coaches, clients, sessions, and transcripts. It writes SQL, searches
+        transcripts semantically, and builds charts — chaining steps as needed.
+      </p>
+      <div className="mt-6 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {STARTERS.map(q => (
+          <button
+            key={q}
+            type="button"
+            onClick={() => onPick(q)}
+            className="group rounded-lg border border-line bg-paper px-3 py-2 text-left text-xs text-ink-2 transition hover:-translate-y-px hover:border-line-strong hover:bg-ds-accent-bg hover:text-ink hover:shadow-sm"
+          >
+            {q}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// State reduction: turn streamed AgentEvents into the message block tree.
+// ---------------------------------------------------------------------------
+
+function applyEvent(
+  messages: AgentMessageType[],
+  assistantId: string,
+  event: AgentEvent,
+): AgentMessageType[] {
+  return messages.map(m => {
+    if (m.id !== assistantId) return m
+    // The `done` event carries metrics; stash them on the message for the footer.
+    if (event.type === 'done' && event.metrics) {
+      return {
+        ...m,
+        metrics: event.metrics,
+        blocks: reduceBlocks(m.blocks, event),
+      }
+    }
+    return { ...m, blocks: reduceBlocks(m.blocks, event) }
+  })
+}
+
+function reduceBlocks(
+  blocks: MessageBlock[],
+  event: AgentEvent,
+): MessageBlock[] {
+  switch (event.type) {
+    case 'assistant_text_delta': {
+      const last = blocks[blocks.length - 1]
+      if (last && last.kind === 'text') {
+        const updated = { ...last, text: last.text + event.text }
+        return [...blocks.slice(0, -1), updated]
+      }
+      return [...blocks, { kind: 'text', text: event.text }]
+    }
+    case 'tool_use_start':
+      return [
+        ...blocks,
+        {
+          kind: 'tool_call',
+          id: event.id,
+          name: event.name as ToolName,
+          input: {},
+          partialInput: '',
+          status: 'running',
+        },
+      ]
+    case 'tool_input_delta':
+      return blocks.map(b =>
+        b.kind === 'tool_call' && b.id === event.id
+          ? { ...b, partialInput: b.partialInput + event.partial_json }
+          : b,
+      )
+    case 'tool_use_end':
+      return blocks.map(b =>
+        b.kind === 'tool_call' && b.id === event.id
+          ? { ...b, input: event.input || {} }
+          : b,
+      )
+    case 'tool_result':
+      return blocks.map(b => {
+        if (b.kind !== 'tool_call' || b.id !== event.id) return b
+        const isError =
+          event.result &&
+          typeof event.result === 'object' &&
+          'error' in event.result
+        return {
+          ...b,
+          result: event.result,
+          status: isError ? 'error' : 'done',
+        }
+      })
+    case 'chart':
+      return [...blocks, { kind: 'chart', spec: event.spec }]
+    case 'error':
+      return [
+        ...blocks,
+        { kind: 'text', text: `\n\n_Error: ${event.message}_` },
+      ]
+    case 'session_init':
+    case 'assistant_thinking':
+    case 'message_start':
+    case 'message_stop':
+    case 'done':
+    default:
+      return blocks
+  }
+}
+
+/**
+ * Convert UI message history to the {role, content} pairs the backend expects.
+ * Assistant messages send only their concatenated text (we don't replay tool
+ * exchanges across turns — that happens within a single request's agent loop).
+ */
+function buildBackendHistory(
+  messages: AgentMessageType[],
+): Array<{ role: 'user' | 'assistant'; content: string }> {
+  const out: Array<{ role: 'user' | 'assistant'; content: string }> = []
+  for (const m of messages) {
+    if (m.role === 'user') {
+      const text = m.blocks
+        .filter(b => b.kind === 'text')
+        .map(b => (b as { kind: 'text'; text: string }).text)
+        .join('\n')
+      if (text.trim()) out.push({ role: 'user', content: text })
+    } else {
+      const text = m.blocks
+        .filter(b => b.kind === 'text')
+        .map(b => (b as { kind: 'text'; text: string }).text)
+        .join('\n')
+      // Skip empty placeholder assistant turns (e.g. the one we're streaming into).
+      if (text.trim()) out.push({ role: 'assistant', content: text })
+    }
+  }
+  return out
+}

--- a/src/components/admin/agent/agent-composer.tsx
+++ b/src/components/admin/agent/agent-composer.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useRef, KeyboardEvent } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Send, Square } from 'lucide-react'
+
+interface Props {
+  value: string
+  onChange: (next: string) => void
+  onSend: () => void
+  onCancel: () => void
+  streaming: boolean
+  disabled?: boolean
+}
+
+export function AgentComposer({
+  value,
+  onChange,
+  onSend,
+  onCancel,
+  streaming,
+  disabled,
+}: Props) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Cmd/Ctrl+Enter to send.
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      if (!streaming && value.trim()) onSend()
+    }
+  }
+
+  return (
+    <div className="border-t border-line bg-paper px-4 py-3">
+      <div className="mx-auto flex max-w-4xl items-end gap-2">
+        <Textarea
+          ref={ref}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask anything about coaches, clients, sessions, scores…"
+          rows={2}
+          className="min-h-[60px] resize-none"
+          disabled={disabled}
+        />
+        {streaming ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={onCancel}
+            className="gap-2"
+          >
+            <Square className="h-4 w-4" />
+            Stop
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="lg"
+            onClick={onSend}
+            disabled={disabled || !value.trim()}
+            className="gap-2"
+          >
+            <Send className="h-4 w-4" />
+            Send
+          </Button>
+        )}
+      </div>
+      <p className="mx-auto mt-1.5 max-w-4xl text-[11px] text-ink-3">
+        Press <kbd className="rounded border border-line px-1">⌘</kbd>+
+        <kbd className="rounded border border-line px-1">Enter</kbd> to send.
+      </p>
+    </div>
+  )
+}

--- a/src/components/admin/agent/agent-message.tsx
+++ b/src/components/admin/agent/agent-message.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { ChatMarkdown } from '@/components/ui/chat-markdown'
+import { cn } from '@/lib/utils'
+import { Sparkles, User } from 'lucide-react'
+import { AgentChart } from './agent-chart'
+import { AgentToolCallCard } from './agent-tool-call-card'
+import type { AgentMessage as AgentMessageType } from '@/types/agent'
+
+interface Props {
+  message: AgentMessageType
+}
+
+export function AgentMessage({ message }: Props) {
+  const isUser = message.role === 'user'
+
+  return (
+    <div
+      className={cn(
+        'flex w-full gap-3',
+        isUser ? 'flex-row-reverse' : 'flex-row',
+      )}
+    >
+      <div
+        className={cn(
+          'mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg shadow-sm',
+          isUser ? 'bg-ink text-paper' : 'bg-ds-accent text-ink-on-dark',
+        )}
+      >
+        {isUser ? (
+          <User className="h-4 w-4" />
+        ) : (
+          <Sparkles className="h-3.5 w-3.5" />
+        )}
+      </div>
+      <div
+        className={cn(
+          'min-w-0 max-w-[85%] space-y-1',
+          isUser && 'flex flex-col items-end',
+        )}
+      >
+        {message.blocks.length === 0 ? (
+          <div className="px-3 py-2 text-sm text-ink-3 italic">Thinking…</div>
+        ) : (
+          message.blocks.map((block, i) => {
+            if (block.kind === 'text') {
+              if (!block.text) return null
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    'rounded-lg px-3 py-2',
+                    isUser ? 'bg-ink text-paper' : 'bg-transparent text-ink',
+                  )}
+                >
+                  {isUser ? (
+                    <p className="whitespace-pre-wrap text-sm">{block.text}</p>
+                  ) : (
+                    <ChatMarkdown content={block.text} />
+                  )}
+                </div>
+              )
+            }
+            if (block.kind === 'tool_call') {
+              return <AgentToolCallCard key={i} block={block} />
+            }
+            if (block.kind === 'chart') {
+              return <AgentChart key={i} spec={block.spec} />
+            }
+            return null
+          })
+        )}
+        {!isUser && message.metrics ? (
+          <MetricsFooter metrics={message.metrics} />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function MetricsFooter({
+  metrics,
+}: {
+  metrics: NonNullable<AgentMessageType['metrics']>
+}) {
+  const parts: string[] = []
+  if (typeof metrics.total_cost_usd === 'number') {
+    parts.push(`$${metrics.total_cost_usd.toFixed(4)}`)
+  }
+  if (typeof metrics.duration_ms === 'number') {
+    parts.push(`${(metrics.duration_ms / 1000).toFixed(1)}s`)
+  }
+  if (typeof metrics.num_turns === 'number') {
+    parts.push(`${metrics.num_turns} turn${metrics.num_turns === 1 ? '' : 's'}`)
+  }
+  if (parts.length === 0) return null
+  return (
+    <div className="px-3 pt-1 text-[10px] text-ink-3">{parts.join(' · ')}</div>
+  )
+}

--- a/src/components/admin/agent/agent-tool-call-card.tsx
+++ b/src/components/admin/agent/agent-tool-call-card.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import {
+  ChevronRight,
+  Loader2,
+  Database,
+  BookOpen,
+  BarChart3,
+  AlertCircle,
+  CheckCircle2,
+  MessagesSquare,
+  FileText,
+} from 'lucide-react'
+import type {
+  MessageBlock,
+  SqlResult,
+  ToolName,
+  ToolResultPayload,
+} from '@/types/agent'
+
+const TOOL_META: Record<ToolName, { label: string; icon: typeof Database }> = {
+  run_sql_query: { label: 'SQL query', icon: Database },
+  describe_schema: { label: 'Schema lookup', icon: BookOpen },
+  generate_chart: { label: 'Chart', icon: BarChart3 },
+  search_conversations: { label: 'Conversation search', icon: MessagesSquare },
+  get_session_transcript: { label: 'Session transcript', icon: FileText },
+}
+
+interface Props {
+  block: Extract<MessageBlock, { kind: 'tool_call' }>
+}
+
+export function AgentToolCallCard({ block }: Props) {
+  const meta = TOOL_META[block.name] ?? {
+    label: block.name,
+    icon: Database,
+  }
+  const Icon = meta.icon
+  const [open, setOpen] = useState(false)
+
+  const isError =
+    block.status === 'error' ||
+    (block.result &&
+      typeof block.result === 'object' &&
+      'error' in block.result)
+
+  const statusBadge = (() => {
+    if (block.status === 'running') {
+      return (
+        <Badge variant="secondary" className="gap-1">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Running
+        </Badge>
+      )
+    }
+    if (isError) {
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <AlertCircle className="h-3 w-3" />
+          Error
+        </Badge>
+      )
+    }
+    return (
+      <Badge variant="outline" className="gap-1">
+        <CheckCircle2 className="h-3 w-3" />
+        Done
+      </Badge>
+    )
+  })()
+
+  return (
+    <div className="my-2 rounded-lg border border-line bg-surface-1">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-surface-2/50">
+          <ChevronRight
+            className={cn(
+              'h-4 w-4 text-ink-3 transition-transform',
+              open && 'rotate-90',
+            )}
+          />
+          <Icon className="h-4 w-4 text-ink-3" />
+          <span className="text-sm font-medium text-ink">{meta.label}</span>
+          <span className="ml-auto flex items-center gap-2">
+            <ToolInputSummary block={block} />
+            {statusBadge}
+          </span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="border-t border-line px-3 py-3">
+          <ToolInputDetails block={block} />
+          {block.result ? <ToolResultDetails result={block.result} /> : null}
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  )
+}
+
+function ToolInputSummary({
+  block,
+}: {
+  block: Extract<MessageBlock, { kind: 'tool_call' }>
+}) {
+  if (block.name === 'run_sql_query') {
+    const explanation = (block.input.explanation as string) || ''
+    return (
+      <span className="hidden md:inline text-xs text-ink-3 truncate max-w-[40ch]">
+        {explanation || '…'}
+      </span>
+    )
+  }
+  if (block.name === 'describe_schema') {
+    const table = (block.input.table as string) || 'all tables'
+    return <span className="text-xs text-ink-3">{table}</span>
+  }
+  if (block.name === 'generate_chart') {
+    const title = (block.input.title as string) || ''
+    return (
+      <span className="hidden md:inline text-xs text-ink-3 truncate max-w-[40ch]">
+        {title}
+      </span>
+    )
+  }
+  return null
+}
+
+function ToolInputDetails({
+  block,
+}: {
+  block: Extract<MessageBlock, { kind: 'tool_call' }>
+}) {
+  if (block.name === 'run_sql_query') {
+    const query = (block.input.query as string) || block.partialInput
+    return (
+      <div className="space-y-2">
+        {block.input.explanation ? (
+          <p className="text-xs text-ink-2">
+            {block.input.explanation as string}
+          </p>
+        ) : null}
+        <pre className="overflow-x-auto rounded bg-surface-2 p-2 text-xs text-ink whitespace-pre-wrap break-words">
+          {query || '...'}
+        </pre>
+      </div>
+    )
+  }
+  return (
+    <pre className="overflow-x-auto rounded bg-surface-2 p-2 text-xs text-ink whitespace-pre-wrap break-words">
+      {JSON.stringify(block.input, null, 2) || block.partialInput || '...'}
+    </pre>
+  )
+}
+
+function ToolResultDetails({ result }: { result: ToolResultPayload }) {
+  if (!result || typeof result !== 'object') return null
+  if ('error' in result) {
+    return (
+      <div className="mt-3 rounded border border-vermillion/40 bg-vermillion/10 p-2 text-xs text-vermillion">
+        <strong className="font-medium">
+          {(result as { error: string }).error}:
+        </strong>{' '}
+        {(result as { message?: string }).message}
+      </div>
+    )
+  }
+  if ('columns' in result && 'rows' in result) {
+    return <SqlResultTable result={result as SqlResult} />
+  }
+  if ('description' in result) {
+    return (
+      <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded bg-surface-2 p-2 text-xs text-ink">
+        {(result as { description: string }).description}
+      </pre>
+    )
+  }
+  if ('tables' in result) {
+    return (
+      <div className="mt-3 flex flex-wrap gap-1">
+        {(result as { tables: string[] }).tables.map(t => (
+          <Badge key={t} variant="outline" className="font-mono text-[10px]">
+            {t}
+          </Badge>
+        ))}
+      </div>
+    )
+  }
+  return null
+}
+
+function SqlResultTable({ result }: { result: SqlResult }) {
+  const previewRows = result.rows.slice(0, 50)
+  const moreRows = result.rows.length - previewRows.length
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="flex items-center gap-3 text-[11px] text-ink-3">
+        <span>
+          {result.row_count} row{result.row_count === 1 ? '' : 's'}
+          {result.truncated ? ' (capped at 1000)' : ''}
+        </span>
+        <span>· {result.duration_ms} ms</span>
+      </div>
+      <div className="overflow-x-auto rounded border border-line">
+        <table className="w-full border-collapse text-xs">
+          <thead className="bg-surface-2">
+            <tr>
+              {result.columns.map(c => (
+                <th
+                  key={c}
+                  className="border-b border-line px-2 py-1.5 text-left font-medium text-ink"
+                >
+                  {c}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {previewRows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={result.columns.length || 1}
+                  className="px-2 py-3 text-center text-ink-3"
+                >
+                  No rows
+                </td>
+              </tr>
+            ) : (
+              previewRows.map((row, i) => (
+                <tr key={i} className="even:bg-surface-1">
+                  {row.map((v, j) => (
+                    <td
+                      key={j}
+                      className="border-b border-line/60 px-2 py-1 align-top text-ink-2"
+                    >
+                      {formatCell(v)}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {moreRows > 0 ? (
+        <p className="text-[11px] text-ink-3">
+          + {moreRows} more row{moreRows === 1 ? '' : 's'} not shown
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function formatCell(v: unknown): string {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -1,0 +1,131 @@
+/**
+ * SSE client for the admin data-analyst agent.
+ *
+ * The standard ApiClient doesn't support streaming, so we use raw fetch + ReadableStream
+ * and inject the Bearer token manually.
+ */
+
+import authService from '@/services/auth-service'
+import type { AgentEvent, ModelsResponse } from '@/types/agent'
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+export interface StreamAgentArgs {
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>
+  model: string
+  /** If set, the Agent SDK resumes that conversation — tool history from prior turns is preserved. */
+  resume_session_id?: string | null
+  signal?: AbortSignal
+}
+
+export async function fetchModels(): Promise<ModelsResponse> {
+  const token = authService.getToken()
+  if (!token) throw new Error('Not authenticated')
+  const res = await fetch(`${API_BASE}/admin/agent/models`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) {
+    throw new Error(`Failed to load models: ${res.status}`)
+  }
+  return (await res.json()) as ModelsResponse
+}
+
+/**
+ * Open a streaming agent run. Yields parsed AgentEvent objects until the stream ends
+ * or the AbortSignal fires.
+ */
+export async function* streamAgent({
+  messages,
+  model,
+  resume_session_id,
+  signal,
+}: StreamAgentArgs): AsyncGenerator<AgentEvent, void, unknown> {
+  const token = authService.getToken()
+  if (!token) throw new Error('Not authenticated')
+
+  const body: Record<string, unknown> = { messages, model }
+  if (resume_session_id) body.resume_session_id = resume_session_id
+
+  const res = await fetch(`${API_BASE}/admin/agent/stream`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      Accept: 'text/event-stream',
+    },
+    body: JSON.stringify(body),
+    signal,
+  })
+
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`
+    try {
+      const j = await res.json()
+      if (j?.detail)
+        detail =
+          typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail)
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail)
+  }
+
+  if (!res.body) {
+    throw new Error('No response body')
+  }
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+
+      // SSE messages are separated by blank lines.
+      let sep = buffer.indexOf('\n\n')
+      while (sep !== -1) {
+        const raw = buffer.slice(0, sep)
+        buffer = buffer.slice(sep + 2)
+        const parsed = parseSseChunk(raw)
+        if (parsed) yield parsed
+        sep = buffer.indexOf('\n\n')
+      }
+    }
+    // Flush any trailing chunk (rare).
+    if (buffer.trim()) {
+      const parsed = parseSseChunk(buffer)
+      if (parsed) yield parsed
+    }
+  } finally {
+    try {
+      reader.releaseLock()
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function parseSseChunk(raw: string): AgentEvent | null {
+  let event = 'message'
+  const dataLines: string[] = []
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('event:')) {
+      event = line.slice(6).trim()
+    } else if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trim())
+    }
+    // ignore comments (lines starting with ":") and id: lines
+  }
+  if (dataLines.length === 0) return null
+  const data = dataLines.join('\n')
+  try {
+    const payload = JSON.parse(data) as Record<string, unknown>
+    return { type: event, ...payload } as AgentEvent
+  } catch {
+    return null
+  }
+}

--- a/src/services/client-commitment-service.ts
+++ b/src/services/client-commitment-service.ts
@@ -110,7 +110,7 @@ export class ClientCommitmentService {
   }
 
   /**
-   * Delete a commitment (only client-created ones)
+   * Delete a commitment owned by the current client
    */
   static async deleteCommitment(commitmentId: string): Promise<void> {
     await ApiClient.delete(

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,0 +1,148 @@
+/**
+ * Types for the admin data-analyst agent.
+ *
+ * The server streams typed SSE events as the agent thinks and uses tools.
+ * The frontend accumulates these into `AgentMessage` records for rendering.
+ */
+
+export type ChartType = 'line' | 'bar' | 'area' | 'pie' | 'scatter'
+
+export interface ChartSpec {
+  chart_type: ChartType
+  title: string
+  description?: string | null
+  data: Array<Record<string, unknown>>
+  x_key: string
+  y_keys: string[]
+}
+
+export interface SqlResult {
+  columns: string[]
+  rows: Array<Array<unknown>>
+  row_count: number
+  truncated: boolean
+  duration_ms: number
+  final_query: string
+}
+
+export interface SchemaListResult {
+  tables: string[]
+}
+
+export interface SchemaDescribeResult {
+  description: string
+}
+
+export interface ToolError {
+  error: string
+  message: string
+}
+
+export interface TranscriptChunk {
+  content: string
+  session_id?: string
+  client_id?: string
+  client_name?: string
+  coach_name?: string
+  session_date?: string
+  topics?: string[]
+  score?: number
+  chunk_index?: number
+}
+
+export interface SearchConversationsResult {
+  chunks: TranscriptChunk[]
+  result_count: number
+  scope?: string
+  truncated?: boolean
+}
+
+export interface SessionTranscriptResult {
+  session_id: string
+  session_meta: Record<string, unknown>
+  chunks: TranscriptChunk[]
+  chunk_count: number
+  truncated?: boolean
+}
+
+export type ToolResultPayload =
+  | SqlResult
+  | SchemaListResult
+  | SchemaDescribeResult
+  | SearchConversationsResult
+  | SessionTranscriptResult
+  | ToolError
+  | { ok: boolean; rendered?: boolean }
+  | Record<string, unknown>
+
+export interface AgentMetrics {
+  total_cost_usd?: number
+  duration_ms?: number
+  num_turns?: number
+}
+
+/** SSE event payloads emitted by the backend. */
+export type AgentEvent =
+  | { type: 'session_init'; session_id: string }
+  | { type: 'message_start'; iteration?: number }
+  | { type: 'assistant_text_delta'; text: string }
+  | { type: 'assistant_thinking'; text: string }
+  | { type: 'tool_use_start'; id: string; name: ToolName }
+  | { type: 'tool_input_delta'; id: string; partial_json: string }
+  | {
+      type: 'tool_use_end'
+      id: string
+      name: ToolName
+      input: Record<string, unknown>
+    }
+  | {
+      type: 'tool_result'
+      id: string
+      result: ToolResultPayload
+      is_error?: boolean
+    }
+  | { type: 'chart'; spec: ChartSpec }
+  | { type: 'message_stop'; stop_reason: string }
+  | { type: 'error'; message: string }
+  | { type: 'done'; session_id?: string; metrics?: AgentMetrics }
+
+export type ToolName =
+  | 'run_sql_query'
+  | 'describe_schema'
+  | 'generate_chart'
+  | 'search_conversations'
+  | 'get_session_transcript'
+
+/** A block within an assistant message, in render order. */
+export type MessageBlock =
+  | { kind: 'text'; text: string }
+  | {
+      kind: 'tool_call'
+      id: string
+      name: ToolName
+      input: Record<string, unknown>
+      partialInput: string
+      status: 'running' | 'done' | 'error'
+      result?: ToolResultPayload
+    }
+  | { kind: 'chart'; spec: ChartSpec }
+
+export interface AgentMessage {
+  /** Stable id for React keying. */
+  id: string
+  role: 'user' | 'assistant'
+  blocks: MessageBlock[]
+  /** Populated when the assistant turn ends; renders a small footer in the UI. */
+  metrics?: AgentMetrics
+}
+
+export interface ModelOption {
+  id: string
+  label: string
+  description: string
+}
+
+export interface ModelsResponse {
+  models: ModelOption[]
+  default: string
+}


### PR DESCRIPTION
## Summary
- New `/admin/agent` surface (super_admin only) pairing with the backend's Claude Agent SDK driver.
- **Distinctive analyst-console shell** — solid `bg-ds-accent` icon, "AGENT · ADMIN" pill, capability strip (Postgres · Transcripts · Charts · Read-only) with live session-id + turn/tool-call counters. DS tokens only — no gradients.
- **Live activity bar** while streaming — bordered status row shows the current tool's intent (`Running SQL: …`, `Searching transcripts: '…' (one coach)`, `Reading transcript: session a1b2c3d4…`, `Composing answer after …`) with a `Step N` counter.
- **Tool-call cards** with collapsible details: SQL result tables (capped at 50 rows in preview), transcript search results, per-table schema descriptions.
- **Recharts** renderer (line/bar/area/pie/scatter).
- **Multi-turn SDK session resume** — captures `session_id` from first `session_init` SSE event, passes back as `resume_session_id` until "New".
- **Metrics footer** per assistant turn (`$cost · duration · turns`) from `ResultMessage`.
- Sidebar nav entry for super_admin only.

## Test plan
- [x] TypeScript clean (`pnpm tsc --noEmit` — only pre-existing vitest test-file error)
- [x] Pre-commit: ESLint clean (all DS-token compliant, no gradients), prettier formatted
- [x] Frontend smoke test against local backend: `session_init` → tool flow → `done` event rendered, metrics footer shown
- [ ] Production smoke test after merge: load `/admin/agent` as super_admin, ask "How many active coaches?" — expect activity bar streaming, tool card with SQL + result table, final answer with `$cost · duration · turns` footer

## Note
This PR depends on backend [coach-sidekick-backend#47](https://github.com/ainovusdev/coach-sidekick-backend/pull/47) (merged). Before this is usable in prod, the operator must mirror `READONLY_DATABASE_URL` into the Railway service env — the deployed backend will refuse to start the agent otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)