### PR TITLE
Agent UI: Download Report card for generate_report results

### DIFF
--- a/src/components/admin/agent/agent-activity-bar.tsx
+++ b/src/components/admin/agent/agent-activity-bar.tsx
@@ -26,6 +26,7 @@ const TOOL_VERB: Record<ToolName, string> = {
   generate_chart: 'Rendering chart',
   search_conversations: 'Searching transcripts',
   get_session_transcript: 'Reading transcript',
+  generate_report: 'Composing PDF report',
 }
 
 export function AgentActivityBar({ blocks, streaming }: Props) {
@@ -120,6 +121,10 @@ function extractToolDetail(
     return id ? `session ${id.slice(0, 8)}…` : null
   }
   if (block.name === 'generate_chart') {
+    const title = (input.title as string | undefined) || null
+    return title ? truncate(title, 80) : null
+  }
+  if (block.name === 'generate_report') {
     const title = (input.title as string | undefined) || null
     return title ? truncate(title, 80) : null
   }

--- a/src/components/admin/agent/agent-chat.tsx
+++ b/src/components/admin/agent/agent-chat.tsx
@@ -396,19 +396,56 @@ function reduceBlocks(
           ? { ...b, input: event.input || {} }
           : b,
       )
-    case 'tool_result':
-      return blocks.map(b => {
+    case 'tool_result': {
+      const isError =
+        event.result &&
+        typeof event.result === 'object' &&
+        'error' in event.result
+      const matching = blocks.find(
+        b => b.kind === 'tool_call' && b.id === event.id,
+      )
+      const updated = blocks.map(b => {
         if (b.kind !== 'tool_call' || b.id !== event.id) return b
-        const isError =
-          event.result &&
-          typeof event.result === 'object' &&
-          'error' in event.result
         return {
           ...b,
           result: event.result,
           status: isError ? 'error' : 'done',
-        }
+        } as MessageBlock
       })
+      if (
+        !isError &&
+        matching?.kind === 'tool_call' &&
+        matching.name === 'generate_report' &&
+        event.result &&
+        typeof event.result === 'object' &&
+        'url' in event.result &&
+        typeof (event.result as { url?: unknown }).url === 'string'
+      ) {
+        const r = event.result as {
+          url: string
+          filename: string
+          title: string
+          size_bytes: number
+          page_count: number
+          expires_at: string
+        }
+        return [
+          ...updated,
+          {
+            kind: 'report',
+            spec: {
+              url: r.url,
+              filename: r.filename,
+              title: r.title,
+              size_bytes: r.size_bytes,
+              page_count: r.page_count,
+              expires_at: r.expires_at,
+            },
+          } as MessageBlock,
+        ]
+      }
+      return updated
+    }
     case 'chart':
       return [...blocks, { kind: 'chart', spec: event.spec }]
     case 'error':

--- a/src/components/admin/agent/agent-message.tsx
+++ b/src/components/admin/agent/agent-message.tsx
@@ -4,6 +4,7 @@ import { ChatMarkdown } from '@/components/ui/chat-markdown'
 import { cn } from '@/lib/utils'
 import { Sparkles, User } from 'lucide-react'
 import { AgentChart } from './agent-chart'
+import { AgentReportCard } from './agent-report-card'
 import { AgentToolCallCard } from './agent-tool-call-card'
 import type { AgentMessage as AgentMessageType } from '@/types/agent'
 
@@ -66,6 +67,9 @@ export function AgentMessage({ message }: Props) {
             }
             if (block.kind === 'chart') {
               return <AgentChart key={i} spec={block.spec} />
+            }
+            if (block.kind === 'report') {
+              return <AgentReportCard key={i} spec={block.spec} />
             }
             return null
           })

--- a/src/components/admin/agent/agent-report-card.tsx
+++ b/src/components/admin/agent/agent-report-card.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Download, FileText } from 'lucide-react'
+import type { ReportSpec } from '@/types/agent'
+
+interface Props {
+  spec: ReportSpec
+}
+
+export function AgentReportCard({ spec }: Props) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-line-strong bg-paper p-3 shadow-sm">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-ds-accent-bg text-ds-accent">
+        <FileText className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-ink">
+          {spec.title}
+        </div>
+        <div className="truncate text-xs text-ink-3">
+          {spec.filename} · {spec.page_count} page
+          {spec.page_count === 1 ? '' : 's'} · {formatBytes(spec.size_bytes)}
+        </div>
+      </div>
+      <a
+        href={spec.url}
+        download={spec.filename}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-line bg-paper px-3 py-1.5 text-xs font-medium text-ink-2 transition-colors hover:bg-ds-accent-bg hover:text-ds-accent"
+      >
+        <Download className="h-3.5 w-3.5" />
+        Download
+      </a>
+    </div>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/src/components/admin/agent/agent-tool-call-card.tsx
+++ b/src/components/admin/agent/agent-tool-call-card.tsx
@@ -18,6 +18,7 @@ import {
   CheckCircle2,
   MessagesSquare,
   FileText,
+  FileDown,
 } from 'lucide-react'
 import type {
   MessageBlock,
@@ -32,6 +33,7 @@ const TOOL_META: Record<ToolName, { label: string; icon: typeof Database }> = {
   generate_chart: { label: 'Chart', icon: BarChart3 },
   search_conversations: { label: 'Conversation search', icon: MessagesSquare },
   get_session_transcript: { label: 'Session transcript', icon: FileText },
+  generate_report: { label: 'PDF report', icon: FileDown },
 }
 
 interface Props {
@@ -128,6 +130,14 @@ function ToolInputSummary({
       </span>
     )
   }
+  if (block.name === 'generate_report') {
+    const title = (block.input.title as string) || ''
+    return (
+      <span className="hidden md:inline text-xs text-ink-3 truncate max-w-[40ch]">
+        {title}
+      </span>
+    )
+  }
   return null
 }
 
@@ -148,6 +158,33 @@ function ToolInputDetails({
         <pre className="overflow-x-auto rounded bg-surface-2 p-2 text-xs text-ink whitespace-pre-wrap break-words">
           {query || '...'}
         </pre>
+      </div>
+    )
+  }
+  if (block.name === 'generate_report') {
+    const title = (block.input.title as string) || ''
+    const subtitle = (block.input.subtitle as string) || ''
+    const explanation = (block.input.explanation as string) || ''
+    const markdownBytes = ((block.input.markdown as string) || '').length
+    return (
+      <div className="space-y-2 text-xs">
+        {title ? (
+          <div>
+            <span className="text-ink-3">Title: </span>
+            <span className="text-ink">{title}</span>
+          </div>
+        ) : null}
+        {subtitle ? (
+          <div>
+            <span className="text-ink-3">Subtitle: </span>
+            <span className="text-ink-2">{subtitle}</span>
+          </div>
+        ) : null}
+        {explanation ? <p className="text-ink-2">{explanation}</p> : null}
+        <div className="text-ink-3">
+          Markdown body: {markdownBytes.toLocaleString()} chars · download card
+          will appear below when ready.
+        </div>
       </div>
     )
   }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -65,12 +65,32 @@ export interface SessionTranscriptResult {
   truncated?: boolean
 }
 
+export interface ReportSpec {
+  url: string
+  filename: string
+  title: string
+  size_bytes: number
+  page_count: number
+  expires_at: string
+}
+
+export interface ReportToolResult {
+  ok: true
+  url: string
+  filename: string
+  title: string
+  size_bytes: number
+  page_count: number
+  expires_at: string
+}
+
 export type ToolResultPayload =
   | SqlResult
   | SchemaListResult
   | SchemaDescribeResult
   | SearchConversationsResult
   | SessionTranscriptResult
+  | ReportToolResult
   | ToolError
   | { ok: boolean; rendered?: boolean }
   | Record<string, unknown>
@@ -112,6 +132,7 @@ export type ToolName =
   | 'generate_chart'
   | 'search_conversations'
   | 'get_session_transcript'
+  | 'generate_report'
 
 /** A block within an assistant message, in render order. */
 export type MessageBlock =
@@ -126,6 +147,7 @@ export type MessageBlock =
       result?: ToolResultPayload
     }
   | { kind: 'chart'; spec: ChartSpec }
+  | { kind: 'report'; spec: ReportSpec }
 
 export interface AgentMessage {
   /** Stable id for React keying. */


### PR DESCRIPTION
## Summary

Companion to backend PR ainovusdev/coach-sidekick-backend#48. When the data-analyst agent's new `generate_report` MCP tool returns a result carrying `{url, filename, title, size_bytes, page_count, expires_at}`, the chat now renders a Download Report card inline.

- New `agent-report-card.tsx`: FileText icon + title + "filename · N pages · KB" meta + Download button (`<a download>` with the presigned URL — no fetch).
- `agent-chat.tsx` reducer: when a `tool_result` event lands and the matching `tool_use` was `generate_report` with a `url` in the result, push a `kind: 'report'` block. **No new SSE event** — the existing `tool_result` carries everything.
- `agent-message.tsx` adds the render branch.
- `agent-activity-bar.tsx` shows "Composing PDF report" while it streams; detail shows the title.
- `agent-tool-call-card.tsx` adds the FileDown icon, a "PDF report" label, and a clean details view (title, subtitle, explanation, markdown size — never dumps the body).
- `types/agent.ts` adds `ReportSpec`, `ReportToolResult`, `'generate_report'` ToolName, `kind: 'report'` MessageBlock.

## Test plan

- [ ] After backend merges, ask the agent for a "PDF report on client X"
- [ ] Confirm the activity bar shows "Composing PDF report"
- [ ] Confirm the Download Report card appears inline once the tool returns
- [ ] Click Download — PDF downloads, opens, text is selectable