### PR TITLE
Admin Data Analyst Agent: thread sidebar + URL-driven hydration

### DIFF
--- a/src/components/admin/agent/agent-chat.tsx
+++ b/src/components/admin/agent/agent-chat.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import {
   Select,
@@ -21,7 +23,10 @@ import {
 import { AgentMessage } from './agent-message'
 import { AgentComposer } from './agent-composer'
 import { AgentActivityBar } from './agent-activity-bar'
+import { AgentThreadSidebar } from './agent-thread-sidebar'
 import { fetchModels, streamAgent } from '@/services/agent-service'
+import { useAgentThread } from '@/hooks/queries/use-agent-threads'
+import { queryKeys } from '@/lib/query-client'
 import type {
   AgentEvent,
   AgentMessage as AgentMessageType,
@@ -40,17 +45,56 @@ const STARTERS = [
 ]
 
 export function AgentChat() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const queryClient = useQueryClient()
+
+  // Source-of-truth for "which thread is open" lives in the URL (?thread=…)
+  // so refresh and back/forward navigation round-trip cleanly.
+  const threadIdFromUrl = searchParams.get('thread')
+
   const [model, setModel] = useState<string>('claude-opus-4-7')
   const [models, setModels] = useState<ModelOption[]>([])
   const [messages, setMessages] = useState<AgentMessageType[]>([])
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
   // Captured from the SDK's first `session_init` event; sent back as
-  // `resume_session_id` on follow-up turns so the agent keeps prior tool
-  // history in working memory. Cleared by the "New" button.
+  // `resume_session_id` on follow-up turns so the agent's cached subprocess
+  // (or a fresh-spawn fallback) reattaches to prior tool history.
   const [sdkSessionId, setSdkSessionId] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
+
+  // Hydration: if the URL points at a thread we haven't loaded, fetch it and
+  // replace local message state with the persisted version.
+  const { data: hydratedThread } = useAgentThread(threadIdFromUrl, {
+    // We only need this on entry / navigation — once messages are local,
+    // further updates come from the stream, not from re-fetching.
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+
+  // Track which thread the local state belongs to so we don't re-hydrate
+  // over a fresh-streamed conversation.
+  const loadedThreadIdRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!threadIdFromUrl) {
+      // URL cleared — caller hit "New chat". Reset to empty state.
+      if (loadedThreadIdRef.current !== null) {
+        setMessages([])
+        setSdkSessionId(null)
+        loadedThreadIdRef.current = null
+      }
+      return
+    }
+    if (loadedThreadIdRef.current === threadIdFromUrl) return
+    if (!hydratedThread) return
+    setMessages(hydratedThread.messages ?? [])
+    setModel(hydratedThread.model)
+    setSdkSessionId(null) // Cold load — let the server build a fresh SDK session.
+    loadedThreadIdRef.current = threadIdFromUrl
+  }, [threadIdFromUrl, hydratedThread])
 
   // Fetch model picker options once.
   useEffect(() => {
@@ -59,12 +103,13 @@ export function AgentChat() {
       .then(res => {
         if (cancelled) return
         setModels(res.models)
-        if (res.default) setModel(res.default)
+        // Only overwrite the picker default if we're not in a loaded thread
+        // (loaded threads carry their own last-used model).
+        if (res.default && !loadedThreadIdRef.current) setModel(res.default)
       })
       .catch(err => {
         if (cancelled) return
         // Non-fatal — the picker stays at its default.
-
         console.warn('Failed to fetch agent models', err)
       })
     return () => {
@@ -85,11 +130,24 @@ export function AgentChat() {
     setStreaming(false)
   }, [])
 
-  const handleReset = useCallback(() => {
+  const handleNewThread = useCallback(() => {
     if (streaming) handleCancel()
     setMessages([])
     setSdkSessionId(null)
-  }, [streaming, handleCancel])
+    loadedThreadIdRef.current = null
+    // Strip ?thread=… without a navigation event so we stay on the page.
+    router.replace(pathname, { scroll: false })
+  }, [streaming, handleCancel, router, pathname])
+
+  const handleSelectThread = useCallback(
+    (threadId: string) => {
+      if (threadId === threadIdFromUrl) return
+      if (streaming) handleCancel()
+      // The useEffect above (keyed on threadIdFromUrl) does the hydration.
+      router.replace(`${pathname}?thread=${threadId}`, { scroll: false })
+    },
+    [threadIdFromUrl, streaming, handleCancel, router, pathname],
+  )
 
   const handleSend = useCallback(
     async (questionOverride?: string) => {
@@ -120,12 +178,18 @@ export function AgentChat() {
           messages: historyForBackend,
           model,
           resume_session_id: sdkSessionId,
+          thread_id: threadIdFromUrl,
           signal: controller.signal,
         })) {
           if (event.type === 'session_init' && event.session_id) {
-            // Capture the SDK session id on the first turn; the next turn
-            // sends it back as resume_session_id.
             setSdkSessionId(event.session_id)
+          }
+          if (event.type === 'thread_init') {
+            // Brand-new thread — pin it to the URL so reload / share works.
+            loadedThreadIdRef.current = event.thread_id
+            router.replace(`${pathname}?thread=${event.thread_id}`, {
+              scroll: false,
+            })
           }
           setMessages(prev => applyEvent(prev, assistantMsg.id, event))
           if (event.type === 'done') break
@@ -147,9 +211,24 @@ export function AgentChat() {
       } finally {
         abortRef.current = null
         setStreaming(false)
+        // Refresh the sidebar so the just-touched thread floats to the top
+        // and its "last activity" timestamp is current.
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.agentThreads.list(),
+        })
       }
     },
-    [input, model, messages, streaming, sdkSessionId],
+    [
+      input,
+      model,
+      messages,
+      streaming,
+      sdkSessionId,
+      threadIdFromUrl,
+      router,
+      pathname,
+      queryClient,
+    ],
   )
 
   const showStarters = messages.length === 0 && !streaming
@@ -187,121 +266,135 @@ export function AgentChat() {
   )
 
   return (
-    <div className="flex h-[calc(100vh-8rem)] flex-col overflow-hidden rounded-lg border border-line-strong bg-paper shadow-sm">
-      {/* Analyst console header — distinguishes this from regular chat. */}
-      <div className="border-b border-line bg-surface-1">
-        <div className="flex items-center gap-3 px-4 py-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-ds-accent text-ink-on-dark shadow-sm">
-            <Sparkles className="h-4 w-4" />
-          </div>
-          <div className="flex flex-col">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold tracking-tight text-ink">
-                Data Analyst Agent
-              </span>
-              <span className="rounded bg-ds-accent-bg px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-ds-accent">
-                Agent · Admin
+    <div className="flex h-[calc(100vh-8rem)] overflow-hidden rounded-lg border border-line-strong bg-paper shadow-sm">
+      <AgentThreadSidebar
+        activeThreadId={threadIdFromUrl}
+        onSelectThread={handleSelectThread}
+        onNewThread={handleNewThread}
+      />
+      <div className="flex flex-1 min-w-0 flex-col">
+        {/* Analyst console header — distinguishes this from regular chat. */}
+        <div className="border-b border-line bg-surface-1">
+          <div className="flex items-center gap-3 px-4 py-2.5">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-ds-accent text-ink-on-dark shadow-sm">
+              <Sparkles className="h-4 w-4" />
+            </div>
+            <div className="flex flex-col">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold tracking-tight text-ink">
+                  Data Analyst Agent
+                </span>
+                <span className="rounded bg-ds-accent-bg px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-ds-accent">
+                  Agent · Admin
+                </span>
+              </div>
+              <span className="text-[11px] text-ink-3">
+                Reasons across the live database and session transcripts.
+                Strictly read-only.
               </span>
             </div>
-            <span className="text-[11px] text-ink-3">
-              Reasons across the live database and session transcripts. Strictly
-              read-only.
-            </span>
-          </div>
-          <div className="ml-auto flex items-center gap-2">
-            <Select value={model} onValueChange={setModel} disabled={streaming}>
-              <SelectTrigger className="h-8 w-[180px] text-xs">
-                {/* Render only the model label in the trigger; the description
+            <div className="ml-auto flex items-center gap-2">
+              <Select
+                value={model}
+                onValueChange={setModel}
+                disabled={streaming}
+              >
+                <SelectTrigger className="h-8 w-[180px] text-xs">
+                  {/* Render only the model label in the trigger; the description
                     only belongs in the open menu. Passing children to SelectValue
                     overrides the default which would echo the full SelectItem
                     children (label + description) and overflow the row. */}
-                <SelectValue placeholder="Pick a model">
-                  {modelOptions.find(m => m.id === model)?.label ?? model}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {modelOptions.map(m => (
-                  <SelectItem key={m.id} value={m.id} className="text-xs">
-                    <div className="flex flex-col">
-                      <span>{m.label}</span>
-                      <span className="text-[10px] text-ink-3">
-                        {m.description}
-                      </span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleReset}
-              disabled={messages.length === 0}
-              className="gap-1.5"
-            >
-              <RotateCcw className="h-3.5 w-3.5" />
-              New
-            </Button>
+                  <SelectValue placeholder="Pick a model">
+                    {modelOptions.find(m => m.id === model)?.label ?? model}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {modelOptions.map(m => (
+                    <SelectItem key={m.id} value={m.id} className="text-xs">
+                      <div className="flex flex-col">
+                        <span>{m.label}</span>
+                        <span className="text-[10px] text-ink-3">
+                          {m.description}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleNewThread}
+                disabled={messages.length === 0 && !threadIdFromUrl}
+                className="gap-1.5"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                New
+              </Button>
+            </div>
+          </div>
+          {/* Capability strip — surfaces what the agent has access to. */}
+          <div className="flex items-center gap-3 border-t border-line bg-ds-accent-bg px-4 py-1.5 text-[11px] text-ink-2">
+            <span className="inline-flex items-center gap-1">
+              <Database className="h-3 w-3" />
+              Postgres
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <MessagesSquare className="h-3 w-3" />
+              Transcripts (Weaviate)
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Zap className="h-3 w-3" />
+              Charts
+            </span>
+            <span className="inline-flex items-center gap-1 text-forest">
+              <ShieldCheck className="h-3 w-3" />
+              Read-only
+            </span>
+            <span className="ml-auto flex items-center gap-3 font-mono text-[10px] text-ink-3">
+              {sdkSessionId ? (
+                <span title={sdkSessionId}>
+                  session {sdkSessionId.slice(0, 8)}…
+                </span>
+              ) : null}
+              {userTurns > 0 ? (
+                <span>
+                  {userTurns} turn{userTurns === 1 ? '' : 's'} ·{' '}
+                  {totalToolCalls} tool call
+                  {totalToolCalls === 1 ? '' : 's'}
+                </span>
+              ) : null}
+            </span>
           </div>
         </div>
-        {/* Capability strip — surfaces what the agent has access to. */}
-        <div className="flex items-center gap-3 border-t border-line bg-ds-accent-bg px-4 py-1.5 text-[11px] text-ink-2">
-          <span className="inline-flex items-center gap-1">
-            <Database className="h-3 w-3" />
-            Postgres
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <MessagesSquare className="h-3 w-3" />
-            Transcripts (Weaviate)
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <Zap className="h-3 w-3" />
-            Charts
-          </span>
-          <span className="inline-flex items-center gap-1 text-forest">
-            <ShieldCheck className="h-3 w-3" />
-            Read-only
-          </span>
-          <span className="ml-auto flex items-center gap-3 font-mono text-[10px] text-ink-3">
-            {sdkSessionId ? (
-              <span title={sdkSessionId}>
-                session {sdkSessionId.slice(0, 8)}…
-              </span>
-            ) : null}
-            {userTurns > 0 ? (
-              <span>
-                {userTurns} turn{userTurns === 1 ? '' : 's'} · {totalToolCalls}{' '}
-                tool call
-                {totalToolCalls === 1 ? '' : 's'}
-              </span>
-            ) : null}
-          </span>
+
+        {/* Live activity bar — only visible while streaming. */}
+        <div className="px-4">
+          <AgentActivityBar
+            blocks={liveAssistantBlocks}
+            streaming={streaming}
+          />
         </div>
-      </div>
 
-      {/* Live activity bar — only visible while streaming. */}
-      <div className="px-4">
-        <AgentActivityBar blocks={liveAssistantBlocks} streaming={streaming} />
-      </div>
-
-      {/* Messages */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
-        <div className="mx-auto flex max-w-4xl flex-col gap-4">
-          {showStarters ? (
-            <EmptyState onPick={q => handleSend(q)} />
-          ) : (
-            messages.map(m => <AgentMessage key={m.id} message={m} />)
-          )}
+        {/* Messages */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
+          <div className="mx-auto flex max-w-4xl flex-col gap-4">
+            {showStarters ? (
+              <EmptyState onPick={q => handleSend(q)} />
+            ) : (
+              messages.map(m => <AgentMessage key={m.id} message={m} />)
+            )}
+          </div>
         </div>
-      </div>
 
-      <AgentComposer
-        value={input}
-        onChange={setInput}
-        onSend={() => handleSend()}
-        onCancel={handleCancel}
-        streaming={streaming}
-      />
+        <AgentComposer
+          value={input}
+          onChange={setInput}
+          onSend={() => handleSend()}
+          onCancel={handleCancel}
+          streaming={streaming}
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/admin/agent/agent-thread-sidebar.tsx
+++ b/src/components/admin/agent/agent-thread-sidebar.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronLeft, ChevronRight, Plus, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
+import { useAgentThreads } from '@/hooks/queries/use-agent-threads'
+import { useDeleteAgentThread } from '@/hooks/mutations/use-agent-thread-mutations'
+import { cn } from '@/lib/utils'
+import type { AgentThreadSummary } from '@/types/agent'
+
+interface AgentThreadSidebarProps {
+  /** Currently-open thread id (from URL), or null on a fresh /admin/agent visit. */
+  activeThreadId: string | null
+  /** Open a thread — parent pushes ?thread=<id> to the URL. */
+  onSelectThread: (threadId: string) => void
+  /** Clear chat state and URL. */
+  onNewThread: () => void
+}
+
+const COLLAPSED_KEY = 'admin-agent-sidebar-collapsed'
+
+function loadCollapsed(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(COLLAPSED_KEY) === '1'
+}
+
+function persistCollapsed(collapsed: boolean) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(COLLAPSED_KEY, collapsed ? '1' : '0')
+}
+
+export function AgentThreadSidebar({
+  activeThreadId,
+  onSelectThread,
+  onNewThread,
+}: AgentThreadSidebarProps) {
+  const [collapsed, setCollapsed] = useState<boolean>(loadCollapsed)
+  const [confirmDelete, setConfirmDelete] = useState<AgentThreadSummary | null>(
+    null,
+  )
+
+  const { data, isLoading } = useAgentThreads()
+  const threads = data?.threads ?? []
+  const deleteMutation = useDeleteAgentThread()
+
+  const toggleCollapsed = () => {
+    const next = !collapsed
+    setCollapsed(next)
+    persistCollapsed(next)
+  }
+
+  if (collapsed) {
+    return (
+      <div className="flex w-12 flex-col items-center gap-2 border-r border-line bg-surface-1 py-3">
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={toggleCollapsed}
+          aria-label="Expand thread list"
+          title="Expand thread list"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={onNewThread}
+          aria-label="New conversation"
+          title="New conversation"
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex w-64 flex-shrink-0 flex-col border-r border-line bg-surface-1">
+        <div className="flex items-center justify-between gap-2 border-b border-line px-3 py-2">
+          <Button
+            size="sm"
+            variant="default"
+            onClick={onNewThread}
+            className="flex-1 justify-start gap-2"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New chat
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={toggleCollapsed}
+            aria-label="Collapse thread list"
+            title="Collapse"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto py-1">
+          {isLoading ? (
+            <div className="px-3 py-2 text-xs text-ink-3">Loading…</div>
+          ) : threads.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-ink-3">
+              Your saved conversations will appear here.
+            </div>
+          ) : (
+            <ul className="flex flex-col">
+              {threads.map(t => (
+                <ThreadRow
+                  key={t.id}
+                  thread={t}
+                  active={t.id === activeThreadId}
+                  onClick={() => onSelectThread(t.id)}
+                  onDelete={() => setConfirmDelete(t)}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <ConfirmationDialog
+        open={!!confirmDelete}
+        onOpenChange={open => {
+          if (!open) setConfirmDelete(null)
+        }}
+        title="Delete this conversation?"
+        description={
+          confirmDelete
+            ? `"${confirmDelete.title}" will be permanently removed. This can't be undone.`
+            : ''
+        }
+        confirmText="Delete"
+        variant="destructive"
+        onConfirm={() => {
+          if (!confirmDelete) return
+          deleteMutation.mutate(confirmDelete.id)
+          setConfirmDelete(null)
+        }}
+      />
+    </>
+  )
+}
+
+interface ThreadRowProps {
+  thread: AgentThreadSummary
+  active: boolean
+  onClick: () => void
+  onDelete: () => void
+}
+
+function ThreadRow({ thread, active, onClick, onDelete }: ThreadRowProps) {
+  return (
+    <li className="group relative">
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-xs transition',
+          active
+            ? 'bg-ds-accent-bg text-ink'
+            : 'text-ink-2 hover:bg-ds-accent-bg/60 hover:text-ink',
+        )}
+      >
+        <span className="line-clamp-1 w-full pr-7 font-medium">
+          {thread.title}
+        </span>
+        <span className="text-[10px] text-ink-3">
+          {formatRelative(thread.last_message_at)}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={e => {
+          e.stopPropagation()
+          onDelete()
+        }}
+        aria-label={`Delete ${thread.title}`}
+        title="Delete conversation"
+        className="absolute right-1.5 top-1.5 hidden rounded p-1 text-ink-3 hover:bg-paper hover:text-vermillion group-hover:block"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </li>
+  )
+}
+
+/**
+ * Compact relative time: "just now" / "5m ago" / "2h ago" / "yesterday" /
+ * "3d ago" / a date. Calculated client-side — no need for a library.
+ */
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const diffMs = Date.now() - then
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days === 1) return 'yesterday'
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/src/hooks/mutations/use-agent-thread-mutations.ts
+++ b/src/hooks/mutations/use-agent-thread-mutations.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { queryKeys } from '@/lib/query-client'
+import { deleteAgentThread } from '@/services/agent-service'
+import type { AgentThreadListResponse } from '@/types/agent'
+
+/**
+ * Delete an admin agent thread.
+ * Optimistically removes the row from the sidebar list.
+ */
+export function useDeleteAgentThread() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (threadId: string) => deleteAgentThread(threadId),
+
+    onMutate: async (threadId: string) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.admin.agentThreads.all,
+      })
+      const previous = queryClient.getQueryData<AgentThreadListResponse>(
+        queryKeys.admin.agentThreads.list(),
+      )
+      if (previous) {
+        queryClient.setQueryData<AgentThreadListResponse>(
+          queryKeys.admin.agentThreads.list(),
+          {
+            ...previous,
+            threads: previous.threads.filter(t => t.id !== threadId),
+          },
+        )
+      }
+      return { previous }
+    },
+
+    onError: (error: unknown, _threadId, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queryKeys.admin.agentThreads.list(),
+          context.previous,
+        )
+      }
+      const msg =
+        error instanceof Error ? error.message : 'Failed to delete thread'
+      toast.error(msg)
+    },
+
+    onSuccess: (_data, threadId) => {
+      // Also drop the cached detail so a stale render can't re-populate the list.
+      queryClient.removeQueries({
+        queryKey: queryKeys.admin.agentThreads.detail(threadId),
+      })
+      toast.success('Conversation deleted')
+    },
+  })
+}

--- a/src/hooks/queries/use-agent-threads.ts
+++ b/src/hooks/queries/use-agent-threads.ts
@@ -1,0 +1,47 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+
+import { queryKeys } from '@/lib/query-client'
+import { getAgentThread, listAgentThreads } from '@/services/agent-service'
+import type { AgentThreadDetail, AgentThreadListResponse } from '@/types/agent'
+
+/**
+ * List the current admin's saved Data Analyst Agent threads.
+ * Fed into the left-rail sidebar in /admin/agent.
+ */
+export function useAgentThreads(
+  options?: Omit<
+    UseQueryOptions<AgentThreadListResponse, Error>,
+    'queryKey' | 'queryFn'
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.admin.agentThreads.list(),
+    queryFn: listAgentThreads,
+    // Refetched after each /stream completes (in agent-chat.tsx) so the
+    // "last activity" sort stays current; we keep a short stale window so
+    // tab-focus refetches don't thrash.
+    staleTime: 30 * 1000,
+    ...options,
+  })
+}
+
+/**
+ * Load one thread for hydration. Disabled until a threadId is set.
+ */
+export function useAgentThread(
+  threadId: string | null,
+  options?: Omit<
+    UseQueryOptions<AgentThreadDetail, Error>,
+    'queryKey' | 'queryFn'
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.admin.agentThreads.detail(threadId || ''),
+    queryFn: () => getAgentThread(threadId as string),
+    enabled: !!threadId,
+    // The thread is only ever fully refreshed via the stream endpoint, so
+    // this query mainly serves the initial hydration on URL nav / reload.
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -317,6 +317,14 @@ export const queryKeys = {
         [...queryKeys.admin.clients.all, 'detail', id] as const,
       stats: () => [...queryKeys.admin.clients.all, 'stats'] as const,
     },
+
+    // Data Analyst Agent threads
+    agentThreads: {
+      all: ['admin', 'agent-threads'] as const,
+      list: () => [...queryKeys.admin.agentThreads.all, 'list'] as const,
+      detail: (id: string) =>
+        [...queryKeys.admin.agentThreads.all, 'detail', id] as const,
+    },
   },
 } as const
 

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -6,7 +6,12 @@
  */
 
 import authService from '@/services/auth-service'
-import type { AgentEvent, ModelsResponse } from '@/types/agent'
+import type {
+  AgentEvent,
+  AgentThreadDetail,
+  AgentThreadListResponse,
+  ModelsResponse,
+} from '@/types/agent'
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
@@ -16,14 +21,74 @@ export interface StreamAgentArgs {
   model: string
   /** If set, the Agent SDK resumes that conversation — tool history from prior turns is preserved. */
   resume_session_id?: string | null
+  /** DB-backed thread id. Omitted on the first turn; the server creates a thread and emits `thread_init`. */
+  thread_id?: string | null
   signal?: AbortSignal
 }
 
-export async function fetchModels(): Promise<ModelsResponse> {
+function authHeader(): Record<string, string> {
   const token = authService.getToken()
   if (!token) throw new Error('Not authenticated')
+  return { Authorization: `Bearer ${token}` }
+}
+
+async function unwrapError(res: Response, fallback: string): Promise<string> {
+  try {
+    const j = await res.json()
+    if (j?.detail) {
+      return typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail)
+    }
+  } catch {
+    /* ignore */
+  }
+  return fallback
+}
+
+// ---------------------------------------------------------------------------
+// Thread persistence
+// ---------------------------------------------------------------------------
+
+export async function listAgentThreads(): Promise<AgentThreadListResponse> {
+  const res = await fetch(`${API_BASE}/admin/agent/threads`, {
+    headers: authHeader(),
+  })
+  if (!res.ok) {
+    throw new Error(
+      await unwrapError(res, `Failed to load threads: ${res.status}`),
+    )
+  }
+  return (await res.json()) as AgentThreadListResponse
+}
+
+export async function getAgentThread(
+  threadId: string,
+): Promise<AgentThreadDetail> {
+  const res = await fetch(`${API_BASE}/admin/agent/threads/${threadId}`, {
+    headers: authHeader(),
+  })
+  if (!res.ok) {
+    throw new Error(
+      await unwrapError(res, `Failed to load thread: ${res.status}`),
+    )
+  }
+  return (await res.json()) as AgentThreadDetail
+}
+
+export async function deleteAgentThread(threadId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/admin/agent/threads/${threadId}`, {
+    method: 'DELETE',
+    headers: authHeader(),
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(
+      await unwrapError(res, `Failed to delete thread: ${res.status}`),
+    )
+  }
+}
+
+export async function fetchModels(): Promise<ModelsResponse> {
   const res = await fetch(`${API_BASE}/admin/agent/models`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeader(),
   })
   if (!res.ok) {
     throw new Error(`Failed to load models: ${res.status}`)
@@ -39,19 +104,18 @@ export async function* streamAgent({
   messages,
   model,
   resume_session_id,
+  thread_id,
   signal,
 }: StreamAgentArgs): AsyncGenerator<AgentEvent, void, unknown> {
-  const token = authService.getToken()
-  if (!token) throw new Error('Not authenticated')
-
   const body: Record<string, unknown> = { messages, model }
   if (resume_session_id) body.resume_session_id = resume_session_id
+  if (thread_id) body.thread_id = thread_id
 
   const res = await fetch(`${API_BASE}/admin/agent/stream`, {
     method: 'POST',
     headers: {
+      ...authHeader(),
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
       Accept: 'text/event-stream',
     },
     body: JSON.stringify(body),
@@ -59,16 +123,7 @@ export async function* streamAgent({
   })
 
   if (!res.ok) {
-    let detail = `HTTP ${res.status}`
-    try {
-      const j = await res.json()
-      if (j?.detail)
-        detail =
-          typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail)
-    } catch {
-      /* ignore */
-    }
-    throw new Error(detail)
+    throw new Error(await unwrapError(res, `HTTP ${res.status}`))
   }
 
   if (!res.body) {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -104,6 +104,8 @@ export interface AgentMetrics {
 /** SSE event payloads emitted by the backend. */
 export type AgentEvent =
   | { type: 'session_init'; session_id: string }
+  /** First event of a brand-new thread — carries the DB id the FE pins in the URL. */
+  | { type: 'thread_init'; thread_id: string; title: string }
   | { type: 'message_start'; iteration?: number }
   | { type: 'assistant_text_delta'; text: string }
   | { type: 'assistant_thinking'; text: string }
@@ -167,4 +169,33 @@ export interface ModelOption {
 export interface ModelsResponse {
   models: ModelOption[]
   default: string
+}
+
+// ---------------------------------------------------------------------------
+// Thread persistence (sidebar history)
+// ---------------------------------------------------------------------------
+
+/** Sidebar row — what the thread-list endpoint returns per thread. */
+export interface AgentThreadSummary {
+  id: string
+  title: string
+  model: string
+  last_message_at: string
+  created_at: string
+  message_count: number
+}
+
+/** Full thread payload returned when loading a single thread for hydration. */
+export interface AgentThreadDetail {
+  id: string
+  title: string
+  model: string
+  last_message_at: string
+  created_at: string
+  /** Messages in the same {id, role, blocks, metrics?} shape the chat already renders. */
+  messages: AgentMessage[]
+}
+
+export interface AgentThreadListResponse {
+  threads: AgentThreadSummary[]
 }


### PR DESCRIPTION
## Summary

ChatGPT-style left rail at `/admin/agent` so saved conversations don't vanish on refresh.

- New `agent-thread-sidebar.tsx` (~210 lines): 256 px collapsible left rail persisted to `localStorage['admin-agent-sidebar-collapsed']`, **+ New chat** button pinned at top, flat list of summaries ordered server-side by `last_message_at DESC`, each row shows title + a relative timestamp (`just now` / `Nm ago` / `Nh ago` / `yesterday` / `Nd ago` / locale date). Hover reveals a trash button → `ConfirmationDialog` (destructive variant) → optimistic delete with rollback. Collapsed state renders a 48 px rail with expand + new-chat icons.
- `agent-chat.tsx` rewrapped in a 2-column flex. The URL `?thread=<uuid>` is the source of truth via Next.js `useSearchParams` / `usePathname` / `router.replace(…, { scroll: false })` — refresh and back/forward round-trip cleanly. `useAgentThread(threadIdFromUrl)` hydrates the message tree on cold loads; a `loadedThreadIdRef` guard prevents the hydration effect from clobbering a fresh-streamed conversation. On the new `thread_init` SSE event the FE pins the server-issued id to the URL. After every stream completes, the threads-list query is invalidated so the touched thread floats to top.
- `types/agent.ts` gains `thread_init` + `AgentThreadSummary` / `Detail` / `ListResponse`. `services/agent-service.ts` gains `listAgentThreads` / `getAgentThread` / `deleteAgentThread` (raw fetch + bearer auth, matching the existing `fetchModels` / `streamAgent` pattern) and forwards `thread_id` in `streamAgent`. `lib/query-client.ts` adds `admin.agentThreads.{list, detail}` keys.

Pairs with backend PR for the persistence + cache + RO role + heartbeat work.

## Test plan

- [ ] Cold load \`/admin/agent\` → sidebar lists recent threads with relative timestamps. Click a thread → URL becomes \`?thread=…\` and chat hydrates. **+ New chat** → URL clears, composer focused.
- [ ] Send a message in a new thread → \`thread_init\` arrives, URL pins to \`?thread=…\`. Reload page → conversation restored. Continue sending — sidebar item floats to top.
- [ ] Hover any thread row → trash icon appears. Click → confirm → row vanishes (optimistic). On simulated failure → rollback restores the row.
- [ ] Collapse the rail → state persists across refreshes. Expand → list still loads.
- [ ] No console errors. Existing \`/admin/agent\` flows (model picker, activity bar, tool cards, charts, report card) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)