### PR TITLE
Rebrand admin agent as Sidekick Agent + remove duplicate header

### DIFF
--- a/src/app/admin/agent/page.tsx
+++ b/src/app/admin/agent/page.tsx
@@ -1,17 +1,10 @@
 'use client'
 
-import { Sparkles } from 'lucide-react'
-import { PageHeader } from '@/components/ui/page-header'
 import { AgentChat } from '@/components/admin/agent/agent-chat'
 
 export default function AdminAgentPage() {
   return (
-    <div>
-      <PageHeader
-        title="AI Agent"
-        description="Ask questions about coaches, clients, sessions, and analytics. The agent queries the live database, builds charts, and explains what it finds."
-        icon={Sparkles}
-      />
+    <div className="-mx-6 -my-8 h-[calc(100vh-4rem)]">
       <AgentChat />
     </div>
   )

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -27,7 +27,7 @@ const menuItems = [
     requiredRole: ['admin', 'super_admin'],
   },
   {
-    title: 'AI Agent',
+    title: 'Sidekick Agent',
     href: '/admin/agent',
     icon: Sparkles,
     requiredRole: ['super_admin'],

--- a/src/components/admin/agent/agent-chat.tsx
+++ b/src/components/admin/agent/agent-chat.tsx
@@ -266,7 +266,7 @@ export function AgentChat() {
   )
 
   return (
-    <div className="flex h-[calc(100vh-8rem)] overflow-hidden rounded-lg border border-line-strong bg-paper shadow-sm">
+    <div className="flex h-full overflow-hidden border-0 bg-paper">
       <AgentThreadSidebar
         activeThreadId={threadIdFromUrl}
         onSelectThread={handleSelectThread}
@@ -282,15 +282,14 @@ export function AgentChat() {
             <div className="flex flex-col">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-semibold tracking-tight text-ink">
-                  Data Analyst Agent
+                  Sidekick Agent
                 </span>
                 <span className="rounded bg-ds-accent-bg px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-ds-accent">
-                  Agent · Admin
+                  Admin
                 </span>
               </div>
               <span className="text-[11px] text-ink-3">
-                Reasons across the live database and session transcripts.
-                Strictly read-only.
+                Queries the live database and session transcripts. Read-only.
               </span>
             </div>
             <div className="ml-auto flex items-center gap-2">
@@ -406,12 +405,11 @@ function EmptyState({ onPick }: { onPick: (q: string) => void }) {
         <Sparkles className="h-7 w-7" />
       </div>
       <h2 className="text-lg font-semibold text-ink">
-        Ask the agent anything about your data
+        Ask Sidekick anything about your data
       </h2>
       <p className="mt-1.5 text-sm text-ink-3">
-        Unlike the per-client chat, this agent reasons across <em>all</em>
-        coaches, clients, sessions, and transcripts. It writes SQL, searches
-        transcripts semantically, and builds charts — chaining steps as needed.
+        Reasons across every coach, client, session, and transcript — writing
+        SQL, searching transcripts, and building charts as needed.
       </p>
       <div className="mt-6 grid grid-cols-1 gap-2 sm:grid-cols-2">
         {STARTERS.map(q => (

--- a/src/hooks/queries/use-agent-threads.ts
+++ b/src/hooks/queries/use-agent-threads.ts
@@ -5,7 +5,7 @@ import { getAgentThread, listAgentThreads } from '@/services/agent-service'
 import type { AgentThreadDetail, AgentThreadListResponse } from '@/types/agent'
 
 /**
- * List the current admin's saved Data Analyst Agent threads.
+ * List the current admin's saved Sidekick Agent threads.
  * Fed into the left-rail sidebar in /admin/agent.
  */
 export function useAgentThreads(

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -318,7 +318,7 @@ export const queryKeys = {
       stats: () => [...queryKeys.admin.clients.all, 'stats'] as const,
     },
 
-    // Data Analyst Agent threads
+    // Sidekick Agent threads
     agentThreads: {
       all: ['admin', 'agent-threads'] as const,
       list: () => [...queryKeys.admin.agentThreads.all, 'list'] as const,


### PR DESCRIPTION
## Summary
- Rename "Data Analyst Agent" → **Sidekick Agent** across the chat header, empty-state copy, admin sidebar nav, and stale doc comments.
- Remove the redundant outer `PageHeader` from `/admin/agent` (the inner chat-shell header already carries the title and model picker).
- Page now wraps `<AgentChat />` in a full-bleed container (`-mx-6 -my-8 h-[calc(100vh-4rem)]`) that escapes the admin layout's `px-6 py-8` and recovers ~4rem of vertical space; the inner chat shell drops its rounded card chrome to sit flush against the admin chrome.
- Slim "Agent · Admin" badge to **Admin** (the route already implies admin), tighten the subtitle to one line, and reword the empty-state heading to "Ask Sidekick anything about your data".

## Test plan
- [ ] Visit `/admin/agent` as super_admin — confirm only one header (the inner chat-shell one), no big "AI Agent" title above.
- [ ] Confirm chat shell fills the viewport area edge-to-edge under the AdminHeader (no rounded card, no `py-8` padding).
- [ ] Confirm inner header reads "Sidekick Agent" with the leaner "Admin" badge and one-line subtitle.
- [ ] Confirm empty-state reads "Ask Sidekick anything about your data" and the 6 starter buttons still work.
- [ ] Confirm admin sidebar nav item reads "Sidekick Agent" and routes correctly.
- [ ] Open an existing thread from the left rail → loads in the full-bleed shell; collapse the rail → chat expands smoothly.
- [ ] Send a quick prompt → activity bar appears, composer anchored to bottom.