### PR TITLE
Show the Sidekick Agent thread sidebar

### DIFF
--- a/src/components/admin/agent/agent-chat.tsx
+++ b/src/components/admin/agent/agent-chat.tsx
@@ -44,10 +44,10 @@ const STARTERS = [
   'Compare average session length for 1-on-1 vs group sessions.',
 ]
 
-// Flip to `true` to bring back the thread-history UI (sidebar, ?thread= URL,
-// refresh-hydration). Backend persistence runs regardless — rows keep being
-// written to `agent_threads`; we just don't surface them.
-const SHOW_THREAD_HISTORY = false
+// The thread-history UI (sidebar, ?thread= URL, refresh-hydration) is on.
+// Backend persistence runs regardless — rows are written to `agent_threads`
+// either way; this flips whether the user sees them.
+const SHOW_THREAD_HISTORY = true
 
 export function AgentChat() {
   const router = useRouter()
@@ -156,11 +156,11 @@ export function AgentChat() {
   }, [streaming, handleCancel, router, pathname])
 
   const handleSelectThread = useCallback(
-    (threadId: string) => {
-      if (threadId === threadId) return
+    (nextThreadId: string) => {
+      if (nextThreadId === threadId) return
       if (streaming) handleCancel()
       // The useEffect above (keyed on threadId) does the hydration.
-      router.replace(`${pathname}?thread=${threadId}`, { scroll: false })
+      router.replace(`${pathname}?thread=${nextThreadId}`, { scroll: false })
     },
     [threadId, streaming, handleCancel, router, pathname],
   )


### PR DESCRIPTION
## Summary

Brings the thread-history sidebar — already mounted as the `AgentThreadSidebar` component and backed by the persisted `agent_threads` table — out of the dark.

## Changes

- `SHOW_THREAD_HISTORY` flag flipped from `false` to `true`. The sidebar, `?thread=<id>` URL routing, and refresh hydration all light up.
- **Latent bug fix** in `handleSelectThread`: the function parameter `threadId` shadowed the outer `threadId`, so `if (threadId === threadId) return` was always true and clicking a thread row silently no-op'd. Renamed the param to `nextThreadId`. This is almost certainly why the sidebar was gated off — the click handler was dead.

## Test plan

- [ ] Open `/admin/agent` — 256px left rail shows past conversations ordered by last_message_at.
- [ ] Click a thread → URL updates to `?thread=<id>`, messages hydrate.
- [ ] Click "New chat" → URL `?thread` stripped, message panel clears.
- [ ] Collapse the rail via the chevron — persists in localStorage.
- [ ] Refresh on `?thread=<id>` — same conversation rehydrates.