### PR TITLE
Thrill Form card: 'awaiting response' state + Resend

### DIFF
--- a/src/app/sessions/[sessionId]/components/thrill-form-responses.tsx
+++ b/src/app/sessions/[sessionId]/components/thrill-form-responses.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { Sparkles, CheckCircle2, Clock } from 'lucide-react'
+import { Sparkles, CheckCircle2, Clock, Send, Loader2 } from 'lucide-react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { useThrillFormResponses } from '@/hooks/queries/use-questionnaire'
+import { Button } from '@/components/ui/button'
+import { useThrillForm } from '@/hooks/queries/use-questionnaire'
+import { useSendThrillForm } from '@/hooks/mutations/use-questionnaire-mutations'
 import { format } from 'date-fns'
 
 interface ThrillFormResponsesProps {
@@ -38,50 +40,100 @@ export function ThrillFormResponses({
   sessionId,
   clientId,
 }: ThrillFormResponsesProps) {
-  const { data: responses, isLoading } = useThrillFormResponses(
-    sessionId,
-    clientId,
+  const { data, isLoading } = useThrillForm(sessionId, clientId)
+  const sendThrillForm = useSendThrillForm()
+
+  // Never sent (or no access) → render nothing, exactly as before.
+  if (isLoading || !data || data.status === 'not_sent') return null
+
+  const isCompleted = data.status === 'completed'
+  // For a sent-but-not-completed form, resend needs a client id; fall back to
+  // the one attached to the token if the caller didn't pass one.
+  const resendClientId = clientId || data.client_id || undefined
+
+  const header = (
+    <CardHeader className="pb-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-app-secondary" />
+          <h3 className="text-sm font-semibold text-app-primary">
+            Thrill Form
+          </h3>
+        </div>
+        {isCompleted ? (
+          <Badge
+            variant="secondary"
+            className="bg-forest-bg text-forest border-forest text-xs"
+          >
+            <CheckCircle2 className="h-3 w-3 mr-1" />
+            Completed
+            {data.completed_at &&
+              ` ${format(new Date(data.completed_at), 'MMM d')}`}
+          </Badge>
+        ) : data.status === 'in_progress' ? (
+          <Badge
+            variant="secondary"
+            className="bg-amber-token-bg text-amber-token border-amber-token text-xs"
+          >
+            <Clock className="h-3 w-3 mr-1" />
+            In Progress
+          </Badge>
+        ) : (
+          <Badge
+            variant="secondary"
+            className="bg-amber-token-bg text-amber-token border-amber-token text-xs"
+          >
+            <Clock className="h-3 w-3 mr-1" />
+            Awaiting response
+          </Badge>
+        )}
+      </div>
+    </CardHeader>
   )
 
-  if (isLoading || !responses || responses.length === 0) return null
+  // Sent, but the client hasn't opened/completed it yet — surface it (instead
+  // of silently showing nothing) so the coach knows it's pending and can resend.
+  if (data.status === 'sent') {
+    const who = data.client_name || 'Your client'
+    return (
+      <Card className="border-app-border shadow-sm">
+        {header}
+        <CardContent className="pt-0">
+          <p className="text-sm text-app-secondary leading-relaxed">
+            {who} hasn&apos;t completed the Thrill Form yet
+            {data.sent_at &&
+              ` — sent ${format(new Date(data.sent_at), 'MMM d')}`}
+            .
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            disabled={!resendClientId || sendThrillForm.isPending}
+            onClick={() =>
+              resendClientId &&
+              sendThrillForm.mutate({ sessionId, clientId: resendClientId })
+            }
+          >
+            {sendThrillForm.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+            ) : (
+              <Send className="h-3.5 w-3.5 mr-1.5" />
+            )}
+            Resend Thrill Form
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
 
-  const response = responses[0]
-  const isCompleted = response.status === 'completed'
-
+  // Completed / in-progress → show the answers.
   return (
     <Card className="border-app-border shadow-sm">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-app-secondary" />
-            <h3 className="text-sm font-semibold text-app-primary">
-              Thrill Form
-            </h3>
-          </div>
-          {isCompleted ? (
-            <Badge
-              variant="secondary"
-              className="bg-forest-bg text-forest border-forest text-xs"
-            >
-              <CheckCircle2 className="h-3 w-3 mr-1" />
-              Completed
-              {response.completed_at &&
-                ` ${format(new Date(response.completed_at), 'MMM d')}`}
-            </Badge>
-          ) : (
-            <Badge
-              variant="secondary"
-              className="bg-amber-token-bg text-amber-token border-amber-token text-xs"
-            >
-              <Clock className="h-3 w-3 mr-1" />
-              In Progress
-            </Badge>
-          )}
-        </div>
-      </CardHeader>
+      {header}
       <CardContent className="pt-0">
         <div className="space-y-4">
-          {response.responses.map((qa, idx) => {
+          {data.responses.map((qa, idx) => {
             const formatted = formatAnswer(qa.question_text, qa.answer)
             const compact = isShortAnswer(qa.answer)
             return (
@@ -98,7 +150,7 @@ export function ThrillFormResponses({
                     {formatted}
                   </p>
                 )}
-                {idx < response.responses.length - 1 && (
+                {idx < data.responses.length - 1 && (
                   <div className="border-b border-app-border mt-4" />
                 )}
               </div>

--- a/src/hooks/mutations/use-questionnaire-mutations.ts
+++ b/src/hooks/mutations/use-questionnaire-mutations.ts
@@ -91,7 +91,8 @@ export function useSendThrillForm() {
       queryClient.invalidateQueries({
         predicate: query =>
           query.queryKey[0] === 'questionnaire' &&
-          query.queryKey[1] === 'thrill-form-responses' &&
+          (query.queryKey[1] === 'thrill-form-responses' ||
+            query.queryKey[1] === 'thrill-form') &&
           query.queryKey[2] === sessionId,
       })
       toast.success('Thrill Form sent')

--- a/src/hooks/queries/use-questionnaire.ts
+++ b/src/hooks/queries/use-questionnaire.ts
@@ -3,6 +3,7 @@ import { QuestionnaireService } from '@/services/questionnaire-service'
 import type {
   ScheduledSession,
   QuestionnaireResponseView,
+  ThrillFormStatusView,
 } from '@/types/questionnaire'
 
 export const questionnaireKeys = {
@@ -12,6 +13,8 @@ export const questionnaireKeys = {
     ['questionnaire', 'responses', sessionId, clientId] as const,
   thrillFormResponses: (sessionId: string, clientId?: string) =>
     ['questionnaire', 'thrill-form-responses', sessionId, clientId] as const,
+  thrillForm: (sessionId: string, clientId?: string) =>
+    ['questionnaire', 'thrill-form', sessionId, clientId] as const,
 }
 
 export function useUpcomingSessions(clientId?: string) {
@@ -43,6 +46,21 @@ export function useThrillFormResponses(
     queryKey: questionnaireKeys.thrillFormResponses(sessionId || '', clientId),
     queryFn: () =>
       QuestionnaireService.getResponses(sessionId!, clientId, 'post_session'),
+    enabled: !!sessionId,
+    staleTime: 60 * 1000,
+  })
+}
+
+// Thrill Form status — includes the "sent but not yet completed" state that the
+// raw responses list can't express (no response row exists until the client
+// opens the form).
+export function useThrillForm(
+  sessionId: string | undefined,
+  clientId?: string,
+) {
+  return useQuery<ThrillFormStatusView>({
+    queryKey: questionnaireKeys.thrillForm(sessionId || '', clientId),
+    queryFn: () => QuestionnaireService.getThrillForm(sessionId!, clientId),
     enabled: !!sessionId,
     staleTime: 60 * 1000,
   })

--- a/src/services/questionnaire-service.ts
+++ b/src/services/questionnaire-service.ts
@@ -4,6 +4,7 @@ import type {
   ScheduledSession,
   QuestionnaireValidation,
   QuestionnaireResponseView,
+  ThrillFormStatusView,
   QuestionnaireTokenResponse,
   StartBotResponse,
 } from '@/types/questionnaire'
@@ -69,6 +70,18 @@ export class QuestionnaireService {
     const qs = search.toString()
     return ApiClient.get(
       `${BACKEND_URL}/questionnaire/sessions/${sessionId}/responses${qs ? `?${qs}` : ''}`,
+    )
+  }
+
+  static async getThrillForm(
+    sessionId: string,
+    clientId?: string,
+  ): Promise<ThrillFormStatusView> {
+    const search = new URLSearchParams()
+    if (clientId) search.set('client_id', clientId)
+    const qs = search.toString()
+    return ApiClient.get(
+      `${BACKEND_URL}/questionnaire/sessions/${sessionId}/thrill-form${qs ? `?${qs}` : ''}`,
     )
   }
 

--- a/src/types/questionnaire.ts
+++ b/src/types/questionnaire.ts
@@ -72,6 +72,17 @@ export interface QuestionAnswerPair {
   answer: string
 }
 
+export type ThrillFormStatus = 'not_sent' | 'sent' | 'in_progress' | 'completed'
+
+export interface ThrillFormStatusView {
+  status: ThrillFormStatus
+  sent_at: string | null
+  completed_at: string | null
+  client_id: string | null
+  client_name: string | null
+  responses: QuestionAnswerPair[]
+}
+
 export interface QuestionnaireTokenResponse {
   token: string
   questionnaire_url: string


### PR DESCRIPTION
## What

When a Thrill Form was **sent but not yet completed**, the coach saw nothing — the card returned `null` whenever no response row existed (a row is only created once the client opens the form). Now it surfaces a pending state with a resend action.

### Changes
- `ThrillFormStatusView` type, `QuestionnaireService.getThrillForm`, `useThrillForm` hook.
- `ThrillFormResponses` card renders by status:
  - `not_sent` → nothing (unchanged, no clutter)
  - `completed` / `in_progress` → answers as before
  - **`sent`** → amber 'Awaiting response' card with 'sent {date}' + a **Resend** button (reuses `useSendThrillForm`, falls back to the token's client_id)
- `useSendThrillForm` invalidation extended to the new `thrill-form` query key.

Pairs with backend PR ainovusdev/coach-sidekick-backend#55 (status endpoint). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)