### PR TITLE
Show "View Client Portal" for clients a coach owns

### DIFF
--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -353,20 +353,21 @@ export default function ClientDetailPage({
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back to Clients
               </Button>
-              {client && hasClientAccess(client.id) && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    sessionStorage.setItem('view_as_client_id', client.id)
-                    sessionStorage.setItem('view_as_client_name', client.name)
-                    router.push('/client-portal/dashboard')
-                  }}
-                >
-                  <Eye className="h-4 w-4 mr-2" />
-                  View Client Portal
-                </Button>
-              )}
+              {client &&
+                (hasClientAccess(client.id) || client.coach_id === userId) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      sessionStorage.setItem('view_as_client_id', client.id)
+                      sessionStorage.setItem('view_as_client_name', client.name)
+                      router.push('/client-portal/dashboard')
+                    }}
+                  >
+                    <Eye className="h-4 w-4 mr-2" />
+                    View Client Portal
+                  </Button>
+                )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
The **View Client Portal** button gate only checked `ClientAccess` grants, but coaches own clients via `clients.coach_id` — so coaches couldn't preview the portals of clients they own.

Button now shows when `hasClientAccess(id) || client.coach_id === userId`, mirroring the backend impersonation change (BE #56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)