### PR TITLE
Timezone display fix + session UX improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.525.0",
     "next": "15.3.6",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ dependencies:
   date-fns:
     specifier: ^4.1.0
     version: 4.1.0
+  date-fns-tz:
+    specifier: ^3.2.0
+    version: 3.2.0(date-fns@4.1.0)
   lucide-react:
     specifier: ^0.525.0
     version: 0.525.0(react@19.1.0)
@@ -3762,6 +3765,14 @@ packages:
 
   /date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+    dev: false
+
+  /date-fns-tz@3.2.0(date-fns@4.1.0):
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
+    dependencies:
+      date-fns: 4.1.0
     dev: false
 
   /date-fns@4.1.0:

--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { ClientLastSessionInsights } from '@/components/client-portal/client-las
 import { UpcomingTasksWidget } from '@/components/client-portal/upcoming-tasks-widget'
 import { RecentResourcesWidget } from '@/components/client-portal/recent-resources-widget'
 import { AgentInsight } from '@/components/agent/agent-insight'
+import { PreSessionPrep } from '@/components/client-portal/pre-session-prep'
 import { clientNextSessionPrepPrompt } from '@/lib/agent-insight-prompts'
 import { GoalsTreeView } from '@/app/clients/[clientId]/components/goals-tree-view'
 import { GoalFormModal } from '@/components/goals/goal-form-modal'
@@ -24,6 +25,7 @@ import { TargetService } from '@/services/target-service'
 import { SprintService } from '@/services/sprint-service'
 import { useGoals } from '@/hooks/queries/use-goals'
 import { useSprints } from '@/hooks/queries/use-sprints'
+import { useClientPreSession } from '@/hooks/queries/use-questionnaire'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-client'
 import { toast } from 'sonner'
@@ -121,6 +123,10 @@ export default function ClientDashboard() {
   const { data: sprints = [] } = useSprints(
     clientId ? { client_id: clientId, status: 'active' } : undefined,
   )
+
+  // Next-session prep — also supplies the meeting link for the Join button.
+  const { data: preSession } = useClientPreSession()
+  const nextSessionMeetingUrl = preSession?.session?.meeting_url || null
 
   useEffect(() => {
     fetchDashboardData()
@@ -344,18 +350,23 @@ export default function ClientDashboard() {
                   {formatRelativeTime(nextSession)}
                 </p>
               </div>
-              <div className="flex flex-wrap gap-3 shrink-0">
-                <Button className="bg-ink text-ink-on-dark hover:bg-ink-2 h-9 px-3.5 text-[13px] font-medium">
-                  <Video className="h-3.5 w-3.5" />
-                  Join when ready
-                </Button>
-                <Button
-                  variant="outline"
-                  className="border-line bg-surface-1 text-ink hover:bg-surface-3 h-9 px-3.5 text-[13px] font-medium"
-                >
-                  Reschedule
-                </Button>
-              </div>
+              {nextSessionMeetingUrl && (
+                <div className="flex flex-wrap gap-3 shrink-0">
+                  <Button
+                    onClick={() =>
+                      window.open(
+                        nextSessionMeetingUrl,
+                        '_blank',
+                        'noopener,noreferrer',
+                      )
+                    }
+                    className="bg-ink text-ink-on-dark hover:bg-ink-2 h-9 px-3.5 text-[13px] font-medium"
+                  >
+                    <Video className="h-3.5 w-3.5" />
+                    Join when ready
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
           {/* Your prep — AI-generated, scoped to this client */}
@@ -371,6 +382,9 @@ export default function ClientDashboard() {
           </div>
         </div>
       )}
+
+      {/* Pre-session prep — prominent standalone card (hidden when no session) */}
+      <PreSessionPrep />
 
       {/* Active Sessions Banner */}
       <div className="mb-6">

--- a/src/app/client-portal/persona/page.tsx
+++ b/src/app/client-portal/persona/page.tsx
@@ -35,7 +35,7 @@ import {
   ArrowRight,
   CheckCircle2,
 } from 'lucide-react'
-import { formatDate } from '@/lib/date-utils'
+import { formatDate, formatDateOnly } from '@/lib/date-utils'
 import { Progress } from '@/components/ui/progress'
 import Link from 'next/link'
 
@@ -337,7 +337,7 @@ export default function ClientPersonaPage() {
                               ? 'First Session'
                               : `${milestone.count} Sessions`}
                             {milestone.date &&
-                              ` - ${formatDate(milestone.date, 'MMM d')}`}
+                              ` - ${formatDateOnly(milestone.date, 'MMM d')}`}
                           </span>
                         </div>
                       </div>
@@ -365,7 +365,7 @@ export default function ClientPersonaPage() {
                               ? 'bg-amber-token '
                               : 'bg-line '
                         }`}
-                        title={`${formatDate(entry.date, 'MMM d')} - ${entry.sentiment || 'neutral'}`}
+                        title={`${formatDateOnly(entry.date, 'MMM d')} - ${entry.sentiment || 'neutral'}`}
                       />
                     ))}
                   </div>

--- a/src/app/client-portal/sessions/[id]/components/client-session-overview.tsx
+++ b/src/app/client-portal/sessions/[id]/components/client-session-overview.tsx
@@ -44,7 +44,7 @@ import {
   StickyNote,
 } from 'lucide-react'
 import { NotesList } from '@/components/session-notes/notes-list'
-import { formatDate } from '@/lib/date-utils'
+import { formatDate, formatDateOnly } from '@/lib/date-utils'
 import { CommitmentService } from '@/services/commitment-service'
 import { commitmentTypeLabels } from '@/types/commitment'
 import { toast } from 'sonner'
@@ -304,7 +304,7 @@ function CommitmentItem({
                     <span>
                       Due:{' '}
                       <strong>
-                        {formatDate(commitment.target_date, 'MMM d, yyyy')}
+                        {formatDateOnly(commitment.target_date, 'MMM d, yyyy')}
                       </strong>
                     </span>
                   )}

--- a/src/app/clients/[clientId]/components/active-commitments-card.tsx
+++ b/src/app/clients/[clientId]/components/active-commitments-card.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Skeleton } from '@/components/ui/skeleton'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 
 interface ActiveCommitmentsCardProps {
   clientId: string
@@ -156,7 +156,10 @@ export function ActiveCommitmentsCard({
                                 ? `Overdue by ${Math.abs(daysUntilDeadline!)} days`
                                 : isDueSoon
                                   ? `Due in ${daysUntilDeadline} days`
-                                  : formatDate(commitment.target_date, 'MMM d')}
+                                  : formatDateOnly(
+                                      commitment.target_date,
+                                      'MMM d',
+                                    )}
                             </span>
                           </div>
                         )}

--- a/src/app/clients/[clientId]/components/client-persona.tsx
+++ b/src/app/clients/[clientId]/components/client-persona.tsx
@@ -24,7 +24,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { PersonaService, type ClientPersona } from '@/services/persona-service'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 
 interface ClientPersonaProps {
   clientId: string
@@ -118,7 +118,7 @@ export function ClientPersonaDisplay({ clientId }: ClientPersonaProps) {
                   Last Updated
                 </p>
                 <p className="text-sm text-ink-2">
-                  {formatDate(persona.metadata.last_updated)}
+                  {formatDateOnly(persona.metadata.last_updated)}
                 </p>
               </div>
             )}

--- a/src/app/clients/[clientId]/components/client-upcoming-sessions.tsx
+++ b/src/app/clients/[clientId]/components/client-upcoming-sessions.tsx
@@ -2,27 +2,20 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { format, formatDistanceToNow, isPast, startOfDay } from 'date-fns'
+import { isPast } from 'date-fns'
 import {
   CalendarClock,
   ArrowRight,
   Send,
   CheckCircle2,
-  Clock,
   Mail,
-  CalendarIcon,
   Pencil,
   Loader2,
   RotateCw,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { Calendar } from '@/components/ui/calendar'
+import { ReschedulePopover } from '@/components/sessions/reschedule-popover'
 import { useUpcomingSessions } from '@/hooks/queries/use-questionnaire'
 import {
   useSendQuestionnaire,
@@ -42,7 +35,6 @@ export function ClientUpcomingSessions({
   const sendQuestionnaire = useSendQuestionnaire()
   const reschedule = useRescheduleSession()
   const updateSession = useUpdateSession()
-  const [openCalendarId, setOpenCalendarId] = useState<string | null>(null)
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null)
   const [editingTitle, setEditingTitle] = useState('')
   const titleInputRef = useRef<HTMLInputElement>(null)
@@ -55,17 +47,6 @@ export function ClientUpcomingSessions({
   }, [editingTitleId])
 
   if (isLoading || !sessions || sessions.length === 0) return null
-
-  const handleReschedule = (sessionId: string, newDate: Date | undefined) => {
-    if (!newDate) return
-    const session = sessions.find(s => s.id === sessionId)
-    if (session?.scheduled_for) {
-      const original = new Date(session.scheduled_for)
-      newDate.setHours(original.getHours(), original.getMinutes(), 0, 0)
-    }
-    reschedule.mutate({ sessionId, scheduledFor: newDate.toISOString() })
-    setOpenCalendarId(null)
-  }
 
   const handleTitleSave = (sessionId: string) => {
     const trimmed = editingTitle.trim()
@@ -129,36 +110,17 @@ export function ClientUpcomingSessions({
               </div>
 
               {/* Date (reschedule) */}
-              <Popover
-                open={openCalendarId === session.id}
-                onOpenChange={open =>
-                  setOpenCalendarId(open ? session.id : null)
+              <ReschedulePopover
+                scheduledFor={session.scheduled_for}
+                isOverdue={isOverdue}
+                isPending={reschedule.isPending}
+                onConfirm={iso =>
+                  reschedule.mutate({
+                    sessionId: session.id,
+                    scheduledFor: iso,
+                  })
                 }
-              >
-                <PopoverTrigger asChild>
-                  <button
-                    className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
-                      isOverdue ? 'text-vermillion' : 'text-ink-3 '
-                    }`}
-                    title="Click to reschedule"
-                  >
-                    <Clock className="h-3 w-3" />
-                    {scheduledDate
-                      ? `${format(scheduledDate, 'MMM d, h:mm a')} (${formatDistanceToNow(scheduledDate, { addSuffix: true })})`
-                      : 'No date'}
-                    <CalendarIcon className="h-2.5 w-2.5 opacity-0 group-hover:opacity-50 transition-opacity" />
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="end">
-                  <Calendar
-                    mode="single"
-                    selected={scheduledDate || undefined}
-                    onSelect={date => handleReschedule(session.id, date)}
-                    disabled={date => date < startOfDay(new Date())}
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
+              />
 
               {/* Q&A status + resend */}
               <div className="flex items-center gap-1.5 shrink-0">

--- a/src/app/clients/[clientId]/components/end-sprint-modal.tsx
+++ b/src/app/clients/[clientId]/components/end-sprint-modal.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { SprintService } from '@/services/sprint-service'
 import { toast } from 'sonner'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 import { AlertTriangle, Loader2 } from 'lucide-react'
 import { queryKeys } from '@/lib/query-client'
 
@@ -86,8 +86,8 @@ export function EndSprintModal({
             <div className="bg-paper rounded-lg p-3 text-sm text-ink-2">
               <p>
                 <strong>Sprint Period:</strong>{' '}
-                {formatDate(sprint.start_date, 'MMM d, yyyy')} -{' '}
-                {formatDate(sprint.end_date, 'MMM d, yyyy')}
+                {formatDateOnly(sprint.start_date, 'MMM d, yyyy')} -{' '}
+                {formatDateOnly(sprint.end_date, 'MMM d, yyyy')}
               </p>
               <p className="mt-1">
                 <strong>Duration:</strong> {sprint.duration_weeks} weeks

--- a/src/app/clients/[clientId]/components/last-session-insights-card.tsx
+++ b/src/app/clients/[clientId]/components/last-session-insights-card.tsx
@@ -34,7 +34,7 @@ import {
   PlayCircle,
   CheckCircle2,
 } from 'lucide-react'
-import { formatDate } from '@/lib/date-utils'
+import { formatDate, formatDateOnly } from '@/lib/date-utils'
 import { useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
 
@@ -265,7 +265,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
               <span>
                 Due:{' '}
                 <strong>
-                  {formatDate(commitment.target_date, 'MMM d, yyyy')}
+                  {formatDateOnly(commitment.target_date, 'MMM d, yyyy')}
                 </strong>
               </span>
             )}

--- a/src/app/clients/[clientId]/components/sprint-kanban-section.tsx
+++ b/src/app/clients/[clientId]/components/sprint-kanban-section.tsx
@@ -21,7 +21,7 @@ import {
   CheckCircle2,
 } from 'lucide-react'
 import { differenceInDays, isAfter, isBefore } from 'date-fns'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 import { toast } from 'sonner'
 import { useConfetti } from '@/hooks/use-confetti'
 
@@ -141,8 +141,8 @@ function SprintAccordionItem({
               <div className="flex items-center gap-2 text-sm text-ink-3 mb-2">
                 <Calendar className="h-3.5 w-3.5" />
                 <span>
-                  {formatDate(sprint.start_date, 'MMM d')} -{' '}
-                  {formatDate(sprint.end_date, 'MMM d, yyyy')}
+                  {formatDateOnly(sprint.start_date, 'MMM d')} -{' '}
+                  {formatDateOnly(sprint.end_date, 'MMM d, yyyy')}
                 </span>
                 {!isUpcoming && !isEnded && (
                   <>

--- a/src/app/clients/[clientId]/page.tsx
+++ b/src/app/clients/[clientId]/page.tsx
@@ -471,6 +471,7 @@ export default function ClientDetailPage({
                     <AgentInsight
                       scope="coach"
                       title="Prep for next session"
+                      manual
                       prompt={prepPrompt}
                       expandPrompt={prepDeepPrompt}
                       expandLabel="Open full prep"

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -43,7 +43,7 @@ import {
   useBulkConfirmCommitments,
   useBulkDiscardCommitments,
 } from '@/hooks/mutations/use-commitment-mutations'
-import { formatDate } from '@/lib/date-utils'
+import { formatDate, formatDateOnly } from '@/lib/date-utils'
 import { isPast, parseISO, differenceInDays } from 'date-fns'
 import PageLayout from '@/components/layout/page-layout'
 import {
@@ -307,7 +307,7 @@ function CommitmentRow({
               {commitment.target_date
                 ? isOverdue
                   ? `${Math.abs(daysUntil!)}d overdue`
-                  : formatDate(commitment.target_date, 'MMM d')
+                  : formatDateOnly(commitment.target_date, 'MMM d')
                 : 'Set date'}
             </button>
           </PopoverTrigger>

--- a/src/app/components/my-commitments.tsx
+++ b/src/app/components/my-commitments.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { CheckSquare, Calendar, ArrowRight, User } from 'lucide-react'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 import Link from 'next/link'
 
 export function MyCommitments() {
@@ -112,11 +112,11 @@ export function MyCommitments() {
                         {new Date(commitment.target_date) < now ? (
                           <span className="text-vermillion font-medium">
                             Overdue -{' '}
-                            {formatDate(commitment.target_date, 'MMM d')}
+                            {formatDateOnly(commitment.target_date, 'MMM d')}
                           </span>
                         ) : (
                           <span>
-                            {formatDate(commitment.target_date, 'MMM d')}
+                            {formatDateOnly(commitment.target_date, 'MMM d')}
                           </span>
                         )}
                       </>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { WebSocketProvider } from '@/contexts/websocket-context'
 import { ProcessingProvider } from '@/contexts/processing-context'
 import { QueryProvider } from '@/components/providers/query-provider'
 import { ThemeProvider } from '@/components/providers/theme-provider'
+import { TimezoneInitializer } from '@/components/providers/timezone-initializer'
 import { AgentModalProvider } from '@/components/agent/agent-modal'
 import { Toaster } from 'sonner'
 import './globals.css'
@@ -39,6 +40,7 @@ export default function RootLayout({
         <ThemeProvider>
           <QueryProvider>
             <AuthProvider>
+              <TimezoneInitializer />
               <PermissionProvider>
                 <WebSocketProvider>
                   <ProcessingProvider>

--- a/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-complete.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { format } from 'date-fns'
+import { formatDate } from '@/lib/date-utils'
 import { CheckCircle2 } from 'lucide-react'
 import Image from 'next/image'
 
@@ -32,7 +32,7 @@ export function QuestionnaireComplete({
 
   const dateInfo =
     kind === 'pre_session' && scheduledFor
-      ? format(new Date(scheduledFor), "EEEE, MMMM d 'at' h:mm a")
+      ? formatDate(scheduledFor, "EEEE, MMMM d 'at' h:mm a")
       : null
   const isThrillForm = kind === 'post_session'
 

--- a/src/app/sessions/[sessionId]/components/session-commitments-list.tsx
+++ b/src/app/sessions/[sessionId]/components/session-commitments-list.tsx
@@ -34,7 +34,7 @@ import {
   Plus,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 import { cn } from '@/lib/utils'
 
 interface CommitmentItemProps {
@@ -311,7 +311,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
                 <span>
                   Due:{' '}
                   <strong>
-                    {formatDate(commitment.target_date, 'MMM d, yyyy')}
+                    {formatDateOnly(commitment.target_date, 'MMM d, yyyy')}
                   </strong>
                 </span>
               )}
@@ -500,7 +500,7 @@ function CommitmentItem({ commitment, onUpdate }: CommitmentItemProps) {
               <span>
                 Due:{' '}
                 <strong>
-                  {formatDate(commitment.target_date, 'MMM d, yyyy')}
+                  {formatDateOnly(commitment.target_date, 'MMM d, yyyy')}
                 </strong>
               </span>
             )}

--- a/src/app/sessions/[sessionId]/components/start-bot-card.tsx
+++ b/src/app/sessions/[sessionId]/components/start-bot-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { format } from 'date-fns'
+import { formatDate } from '@/lib/date-utils'
 import {
   Play,
   Link2,
@@ -159,7 +159,7 @@ export function StartBotCard({
           {scheduledFor && (
             <div className="flex items-center justify-center gap-1.5 text-sm text-app-secondary mb-6">
               <CalendarClock className="h-4 w-4" />
-              {format(new Date(scheduledFor), "EEEE, MMMM d 'at' h:mm a")}
+              {formatDate(scheduledFor, "EEEE, MMMM d 'at' h:mm a")}
             </div>
           )}
 

--- a/src/components/agent/agent-insight.tsx
+++ b/src/components/agent/agent-insight.tsx
@@ -31,6 +31,13 @@ interface AgentInsightProps {
   /** Gate generation explicitly (e.g. `enabled={!!client}`). Defaults to true. */
   enabled?: boolean
   /**
+   * On-demand mode: don't generate on mount. Render a CTA button instead, and
+   * only fire the prompt once the user clicks it. Defaults to false (auto).
+   */
+  manual?: boolean
+  /** CTA label for `manual` mode. Defaults to "Prepare for next session". */
+  manualLabel?: string
+  /**
    * When set, shows an "open full" affordance that pops the agent modal
    * pre-seeded with this (usually deeper) prompt — depth on demand.
    */
@@ -62,6 +69,8 @@ export function AgentInsight({
   title,
   icon: Icon = Sparkles,
   enabled = true,
+  manual = false,
+  manualLabel = 'Prepare for next session',
   expandPrompt,
   expandLabel = 'Open full prep',
   collapsible = false,
@@ -69,13 +78,14 @@ export function AgentInsight({
   bare = false,
   className,
 }: AgentInsightProps) {
-  const active = !!prompt && enabled
   const [collapsed, setCollapsed] = useState(collapsible && defaultCollapsed)
+  const [triggered, setTriggered] = useState(!manual)
+  const active = !!prompt && enabled && triggered
   const { openAgent } = useAgentModal()
   const { data, isError, isFetching, regenerate } = useAgentInsight(
     prompt,
     scope,
-    { enabled: enabled && !collapsed },
+    { enabled: enabled && !collapsed && triggered },
   )
 
   if (bare) {
@@ -195,6 +205,22 @@ export function AgentInsight({
                   Try again
                 </button>
               </div>
+            </div>
+          ) : manual && !triggered && !isFetching ? (
+            <div className="flex flex-col items-center gap-2.5 py-4 text-center">
+              <p className="max-w-sm text-sm text-ink-3">
+                Generate a quick, AI-prepared brief for this client&rsquo;s next
+                session.
+              </p>
+              <button
+                type="button"
+                onClick={() => setTriggered(true)}
+                disabled={!prompt || !enabled}
+                className="inline-flex items-center gap-2 rounded-lg bg-ds-accent px-3.5 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Sparkles className="h-4 w-4" />
+                {manualLabel}
+              </button>
             </div>
           ) : data ? (
             <>

--- a/src/components/client-portal/client-last-session-insights.tsx
+++ b/src/components/client-portal/client-last-session-insights.tsx
@@ -30,7 +30,11 @@ import {
   PlayCircle,
   CheckCircle2,
 } from 'lucide-react'
-import { formatDate, formatRelativeTime } from '@/lib/date-utils'
+import {
+  formatDate,
+  formatDateOnly,
+  formatRelativeTime,
+} from '@/lib/date-utils'
 import { cn } from '@/lib/utils'
 
 interface SessionData {
@@ -168,7 +172,7 @@ function SessionCommitmentItem({
               <span>
                 Due:{' '}
                 <strong>
-                  {formatDate(commitment.target_date, 'MMM d, yyyy')}
+                  {formatDateOnly(commitment.target_date, 'MMM d, yyyy')}
                 </strong>
               </span>
             )}

--- a/src/components/client-portal/pre-session-prep.tsx
+++ b/src/components/client-portal/pre-session-prep.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ClipboardList, Check, ArrowRight, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { useClientPreSession } from '@/hooks/queries/use-questionnaire'
+import { useSubmitClientPreSession } from '@/hooks/mutations/use-questionnaire-mutations'
+
+/**
+ * Prominent pre-session prep card for the client portal dashboard.
+ *
+ * Surfaces the same 5 prep questions that are sent by email — answers here write
+ * to the same response and notify the coach. Rendered as a standalone, tinted
+ * card below the next-session hero. Hidden entirely when there is no upcoming
+ * session to prep for.
+ */
+export function PreSessionPrep() {
+  const { data } = useClientPreSession()
+  const submit = useSubmitClientPreSession()
+
+  const [open, setOpen] = useState(false)
+  const [answers, setAnswers] = useState<Record<number, string>>({})
+
+  const session = data?.session ?? null
+  const status = data?.status ?? 'not_started'
+
+  // Seed the form from any answers the client already saved (via portal or
+  // email) each time the dialog opens.
+  useEffect(() => {
+    if (open && data) {
+      const seeded: Record<number, string> = {}
+      for (const a of data.existing_answers) {
+        seeded[a.question_index] = a.answer
+      }
+      setAnswers(seeded)
+    }
+  }, [open, data])
+
+  if (!session) return null
+
+  const questions = [...(data?.questions ?? [])].sort(
+    (a, b) => a.index - b.index,
+  )
+  const total = questions.length
+  const answeredCount = (data?.existing_answers ?? []).filter(
+    a => (a.answer ?? '').trim().length > 0,
+  ).length
+
+  const completed = status === 'completed'
+  const inProgress = status === 'in_progress'
+
+  const ctaLabel = completed
+    ? 'Edit answers'
+    : inProgress
+      ? 'Continue'
+      : 'Answer questions'
+
+  const handleSave = async () => {
+    await submit.mutateAsync({
+      sessionId: session.id,
+      answers: questions.map(q => ({
+        question_index: q.index,
+        answer: (answers[q.index] ?? '').trim(),
+      })),
+    })
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <div
+        className={cn(
+          'mb-6 rounded-[10px] border p-5 sm:p-6',
+          completed
+            ? 'border-forest/20 bg-forest-bg'
+            : 'border-indigo/20 bg-indigo-bg',
+        )}
+      >
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-4">
+            <span
+              className={cn(
+                'flex h-10 w-10 shrink-0 items-center justify-center rounded-full',
+                completed
+                  ? 'bg-forest/10 text-forest'
+                  : 'bg-indigo/10 text-indigo',
+              )}
+            >
+              {completed ? (
+                <Check className="h-5 w-5" />
+              ) : (
+                <ClipboardList className="h-5 w-5" />
+              )}
+            </span>
+            <div className="min-w-0">
+              <h3 className="m-0 text-[15px] font-semibold tracking-tight text-ink">
+                {completed
+                  ? "You're prepped for your session"
+                  : 'Prepare for your session'}
+              </h3>
+              <p className="m-0 mt-1 text-[13px] text-ink-2">
+                {completed
+                  ? 'Your answers are with your coach. You can still edit them before the session.'
+                  : inProgress
+                    ? `${answeredCount} of ${total} answered — finish so your coach can prepare.`
+                    : `${total} quick questions so your coach can make the most of your time.`}
+              </p>
+            </div>
+          </div>
+
+          <Button
+            onClick={() => setOpen(true)}
+            variant={completed ? 'outline' : 'default'}
+            className="shrink-0 self-start sm:self-auto"
+          >
+            {ctaLabel}
+            {!completed && <ArrowRight className="h-3.5 w-3.5" />}
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Prepare for your next session</DialogTitle>
+            <DialogDescription>
+              Your answers go straight to your coach to help them prepare. You
+              can update them anytime before the session.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-5 py-1">
+            {questions.map((q, i) => (
+              <div key={q.index} className="space-y-2">
+                <label className="block text-[13px] font-medium text-ink">
+                  {i + 1}. {q.text}
+                </label>
+                <Textarea
+                  value={answers[q.index] ?? ''}
+                  onChange={e =>
+                    setAnswers(prev => ({ ...prev, [q.index]: e.target.value }))
+                  }
+                  placeholder="Type your answer…"
+                  className="min-h-[90px]"
+                />
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={submit.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={submit.isPending}>
+              {submit.isPending && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              )}
+              Save answers
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/client-portal/upcoming-tasks-widget.tsx
+++ b/src/components/client-portal/upcoming-tasks-widget.tsx
@@ -11,7 +11,7 @@ import {
   Circle,
   PlayCircle,
 } from 'lucide-react'
-import { formatDate, isPastDate } from '@/lib/date-utils'
+import { formatDateOnly, isPastDate } from '@/lib/date-utils'
 import { useCommitments } from '@/hooks/queries/use-commitments'
 import { commitmentTypeLabels } from '@/types/commitment'
 import type { Commitment } from '@/types/commitment'
@@ -112,7 +112,7 @@ export function UpcomingTasksWidget({
                           }`}
                         >
                           {isOverdue && <AlertCircle className="h-3 w-3" />}
-                          {formatDate(commitment.target_date, 'MMM d')}
+                          {formatDateOnly(commitment.target_date, 'MMM d')}
                         </span>
                       )}
                     </div>

--- a/src/components/client/current-sprint-widget.tsx
+++ b/src/components/client/current-sprint-widget.tsx
@@ -17,7 +17,7 @@ import {
   Plus,
 } from 'lucide-react'
 import { differenceInDays } from 'date-fns'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 import { toast } from 'sonner'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-client'
@@ -217,10 +217,10 @@ export function CurrentSprintWidget({
         <div className="flex items-center justify-between text-xs text-ink-3 pt-2 border-t border-line">
           <div className="flex items-center gap-1">
             <Calendar className="h-3 w-3" />
-            <span>{formatDate(sprint.start_date, 'MMM d')}</span>
+            <span>{formatDateOnly(sprint.start_date, 'MMM d')}</span>
           </div>
           <TrendingUp className="h-3 w-3" />
-          <span>{formatDate(sprint.end_date, 'MMM d, yyyy')}</span>
+          <span>{formatDateOnly(sprint.end_date, 'MMM d, yyyy')}</span>
         </div>
 
         {/* View Details Button */}

--- a/src/components/commitments/commitment-create-panel.tsx
+++ b/src/components/commitments/commitment-create-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { format } from 'date-fns'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly, parseDateForPicker } from '@/lib/date-utils'
 import { useCreateCommitment } from '@/hooks/mutations/use-commitment-mutations'
 import { useSprints } from '@/hooks/queries/use-sprints'
 import { useTargets } from '@/hooks/queries/use-targets'
@@ -276,14 +276,14 @@ export function CommitmentCreatePanel({
                       >
                         <CalendarIcon className="h-3.5 w-3.5 mr-2" />
                         {targetDate
-                          ? formatDate(targetDate, 'MMM d, yyyy')
+                          ? formatDateOnly(targetDate, 'MMM d, yyyy')
                           : 'Set date'}
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent className="w-auto p-0" align="start">
                       <Calendar
                         mode="single"
-                        selected={targetDate ? new Date(targetDate) : undefined}
+                        selected={parseDateForPicker(targetDate)}
                         onSelect={date => {
                           setTargetDate(
                             date ? format(date, 'yyyy-MM-dd') : undefined,

--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -62,7 +62,11 @@ import {
 import { RichTextEditor } from '@/components/ui/rich-text-editor'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
-import { formatDate } from '@/lib/date-utils'
+import {
+  formatDate,
+  formatDateOnly,
+  parseDateForPicker,
+} from '@/lib/date-utils'
 import {
   X,
   MoreVertical,
@@ -562,18 +566,14 @@ function FieldsGrid({
               >
                 <CalendarIcon className="h-3.5 w-3.5 mr-2" />
                 {commitment.target_date
-                  ? formatDate(commitment.target_date, 'MMM d, yyyy')
+                  ? formatDateOnly(commitment.target_date, 'MMM d, yyyy')
                   : 'Set date'}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0 z-[80]" align="start">
               <Calendar
                 mode="single"
-                selected={
-                  commitment.target_date
-                    ? new Date(commitment.target_date)
-                    : undefined
-                }
+                selected={parseDateForPicker(commitment.target_date)}
                 onSelect={date => {
                   onFieldUpdate(
                     'target_date',
@@ -1343,7 +1343,7 @@ function MilestoneItem({
       )}
       {milestone.target_date && (
         <span className="text-xs text-ink-4 ">
-          {formatDate(milestone.target_date, 'MMM d')}
+          {formatDateOnly(milestone.target_date, 'MMM d')}
         </span>
       )}
       <Button

--- a/src/components/commitments/commitment-kanban-card.tsx
+++ b/src/components/commitments/commitment-kanban-card.tsx
@@ -20,7 +20,7 @@ import {
   Edit,
   Trash2,
 } from 'lucide-react'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 import { cn } from '@/lib/utils'
 
 interface CommitmentKanbanCardProps {
@@ -236,7 +236,7 @@ export function CommitmentKanbanCard({
             >
               {isOverdue && <AlertCircle className="h-3 w-3" />}
               <Calendar className="h-3 w-3" />
-              <span>{formatDate(commitment.target_date, 'MMM d')}</span>
+              <span>{formatDateOnly(commitment.target_date, 'MMM d')}</span>
             </div>
           )}
 

--- a/src/components/commitments/commitment-list-item.tsx
+++ b/src/components/commitments/commitment-list-item.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Pencil, Sparkles } from 'lucide-react'
 import { Commitment, commitmentTypeLabels } from '@/types/commitment'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 interface CommitmentListItemProps {
   commitment: Commitment
   onUpdate?: () => void
@@ -46,7 +46,7 @@ export function CommitmentListItem({
               </Badge>
               {commitment.target_date && (
                 <Badge variant="outline" className="text-xs">
-                  Due: {formatDate(commitment.target_date)}
+                  Due: {formatDateOnly(commitment.target_date)}
                 </Badge>
               )}
               {commitment.progress_percentage > 0 && (

--- a/src/components/commitments/commitment-panel.tsx
+++ b/src/components/commitments/commitment-panel.tsx
@@ -8,7 +8,12 @@
 
 import React, { useState } from 'react'
 import { format, isPast, addDays, addWeeks } from 'date-fns'
-import { formatDate, formatRelativeTime } from '@/lib/date-utils'
+import {
+  formatDate,
+  formatDateOnly,
+  formatRelativeTime,
+  parseDateForPicker,
+} from '@/lib/date-utils'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -153,7 +158,7 @@ function DraftCommitmentCard({
 }) {
   const [editTitle, setEditTitle] = useState(commitment.title)
   const [editDate, setEditDate] = useState<Date | undefined>(
-    commitment.target_date ? new Date(commitment.target_date) : undefined,
+    parseDateForPicker(commitment.target_date),
   )
   const [selectedTargetIds, setSelectedTargetIds] = useState<string[]>([])
   const [showDatePicker, setShowDatePicker] = useState(false)
@@ -438,9 +443,7 @@ export function CommitmentPanel({
   const handleStartEdit = (commitment: PanelCommitment) => {
     setEditingId(commitment.id)
     setEditTitle(commitment.title)
-    setEditDate(
-      commitment.target_date ? new Date(commitment.target_date) : undefined,
-    )
+    setEditDate(parseDateForPicker(commitment.target_date))
   }
 
   const handleCancelEdit = () => {
@@ -759,7 +762,7 @@ export function CommitmentPanel({
                 >
                   <CalendarIcon className="h-3 w-3" />
                   {isOverdue && 'Overdue: '}
-                  {formatDate(commitment.target_date, 'MMM d')}
+                  {formatDateOnly(commitment.target_date, 'MMM d')}
                 </span>
               )}
 
@@ -891,7 +894,7 @@ export function CommitmentPanel({
                       {commitment.target_date && (
                         <span className="text-[10px] text-ink-4 flex items-center gap-0.5">
                           <CalendarIcon className="h-2.5 w-2.5" />
-                          {formatDate(commitment.target_date, 'MMM d')}
+                          {formatDateOnly(commitment.target_date, 'MMM d')}
                         </span>
                       )}
                       {isCoach && commitment.is_coach_commitment && (

--- a/src/components/dashboard/upcoming-sessions.tsx
+++ b/src/components/dashboard/upcoming-sessions.tsx
@@ -2,15 +2,13 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { format, formatDistanceToNow, isPast, startOfDay } from 'date-fns'
+import { isPast } from 'date-fns'
 import {
   CalendarClock,
   ArrowRight,
   Send,
   CheckCircle2,
-  Clock,
   Mail,
-  CalendarIcon,
   Pencil,
   Loader2,
   RotateCw,
@@ -19,12 +17,7 @@ import {
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { Calendar } from '@/components/ui/calendar'
+import { ReschedulePopover } from '@/components/sessions/reschedule-popover'
 import { useUpcomingSessions } from '@/hooks/queries/use-questionnaire'
 import {
   useSendQuestionnaire,
@@ -38,7 +31,6 @@ export function UpcomingSessions() {
   const sendQuestionnaire = useSendQuestionnaire()
   const reschedule = useRescheduleSession()
   const updateSession = useUpdateSession()
-  const [openCalendarId, setOpenCalendarId] = useState<string | null>(null)
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null)
   const [editingTitle, setEditingTitle] = useState('')
   const [expanded, setExpanded] = useState(false)
@@ -53,17 +45,6 @@ export function UpcomingSessions() {
   }, [editingTitleId])
 
   if (isLoading || !sessions || sessions.length === 0) return null
-
-  const handleReschedule = (sessionId: string, newDate: Date | undefined) => {
-    if (!newDate) return
-    const session = sessions.find(s => s.id === sessionId)
-    if (session?.scheduled_for) {
-      const original = new Date(session.scheduled_for)
-      newDate.setHours(original.getHours(), original.getMinutes(), 0, 0)
-    }
-    reschedule.mutate({ sessionId, scheduledFor: newDate.toISOString() })
-    setOpenCalendarId(null)
-  }
 
   const handleTitleSave = (sessionId: string) => {
     const trimmed = editingTitle.trim()
@@ -140,36 +121,17 @@ export function UpcomingSessions() {
                 </div>
 
                 {/* Date (reschedule) */}
-                <Popover
-                  open={openCalendarId === session.id}
-                  onOpenChange={open =>
-                    setOpenCalendarId(open ? session.id : null)
+                <ReschedulePopover
+                  scheduledFor={session.scheduled_for}
+                  isOverdue={isOverdue}
+                  isPending={reschedule.isPending}
+                  onConfirm={iso =>
+                    reschedule.mutate({
+                      sessionId: session.id,
+                      scheduledFor: iso,
+                    })
                   }
-                >
-                  <PopoverTrigger asChild>
-                    <button
-                      className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
-                        isOverdue ? 'text-vermillion' : 'text-ink-3 '
-                      }`}
-                      title="Click to reschedule"
-                    >
-                      <Clock className="h-3 w-3" />
-                      {scheduledDate
-                        ? `${format(scheduledDate, 'MMM d, h:mm a')} (${formatDistanceToNow(scheduledDate, { addSuffix: true })})`
-                        : 'No date'}
-                      <CalendarIcon className="h-2.5 w-2.5 opacity-0 group-hover:opacity-50 transition-opacity" />
-                    </button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="end">
-                    <Calendar
-                      mode="single"
-                      selected={scheduledDate || undefined}
-                      onSelect={date => handleReschedule(session.id, date)}
-                      disabled={date => date < startOfDay(new Date())}
-                      initialFocus
-                    />
-                  </PopoverContent>
-                </Popover>
+                />
 
                 {/* Q&A status + resend */}
                 <div className="flex items-center gap-1.5 shrink-0">

--- a/src/components/programs/program-theme-analysis.tsx
+++ b/src/components/programs/program-theme-analysis.tsx
@@ -28,7 +28,7 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { TrendingUp, TrendingDown, Sparkles, Network } from 'lucide-react'
-import { formatRelativeTime, formatDate } from '@/lib/date-utils'
+import { formatRelativeTime, formatDateOnly } from '@/lib/date-utils'
 
 interface ProgramThemeAnalysisProps {
   programId: string
@@ -222,7 +222,7 @@ export function ProgramThemeAnalysis({ programId }: ProgramThemeAnalysisProps) {
             <div className="space-y-6">
               {themes.trending_themes.slice(0, 3).map(theme => {
                 const chartData = theme.occurrences.map(point => ({
-                  date: formatDate(point.date, 'MMM d'),
+                  date: formatDateOnly(point.date, 'MMM d'),
                   count: point.value,
                 }))
 

--- a/src/components/programs/program-trends.tsx
+++ b/src/components/programs/program-trends.tsx
@@ -30,7 +30,7 @@ import {
   Legend,
 } from 'recharts'
 import { TrendingUp, Calendar, Activity } from 'lucide-react'
-import { formatDate } from '@/lib/date-utils'
+import { formatDateOnly } from '@/lib/date-utils'
 
 interface ProgramTrendsProps {
   programId: string
@@ -64,12 +64,12 @@ export function ProgramTrends({ programId }: ProgramTrendsProps) {
 
   // Format data for charts
   const sessionFrequencyData = trends.session_frequency.map(point => ({
-    date: formatDate(point.date, 'MMM d'),
+    date: formatDateOnly(point.date, 'MMM d'),
     sessions: point.value,
   }))
 
   const completionRateData = trends.completion_rate_trend.map(point => ({
-    date: formatDate(point.date, 'MMM d'),
+    date: formatDateOnly(point.date, 'MMM d'),
     rate: point.value,
   }))
 

--- a/src/components/providers/timezone-initializer.tsx
+++ b/src/components/providers/timezone-initializer.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import { useUserTimezone } from '@/hooks/use-user-timezone'
+import { setActiveTimeZone } from '@/lib/date-utils'
+
+// Surfaces viewed by the client (or by anonymous users) — there the browser
+// zone IS the right zone, so we must NOT pin the coach's saved zone.
+const BROWSER_ZONE_PREFIXES = [
+  '/client-portal',
+  '/client-meeting',
+  '/questionnaire',
+  '/invitations',
+]
+
+/**
+ * Populates the module-level "active" timezone used by `date-utils` INSTANT
+ * formatters with the signed-in coach's saved IANA zone, so timestamps render
+ * in the coach's timezone regardless of the browser's configured zone.
+ *
+ * On client/anonymous surfaces it resets the active zone to null so formatting
+ * falls back to the browser zone (the viewer's own zone).
+ */
+export function TimezoneInitializer() {
+  const pathname = usePathname()
+  const isBrowserZoneSurface = BROWSER_ZONE_PREFIXES.some(
+    prefix => pathname === prefix || pathname?.startsWith(`${prefix}/`),
+  )
+
+  const savedTz = useUserTimezone(!isBrowserZoneSurface)
+
+  useEffect(() => {
+    setActiveTimeZone(isBrowserZoneSurface ? null : savedTz)
+  }, [isBrowserZoneSurface, savedTz])
+
+  return null
+}

--- a/src/components/sessions/reschedule-popover.tsx
+++ b/src/components/sessions/reschedule-popover.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useState } from 'react'
+import { startOfDay } from 'date-fns'
+import { toZonedTime, fromZonedTime } from 'date-fns-tz'
+import { CalendarIcon, Clock, Loader2 } from 'lucide-react'
+import {
+  formatDate,
+  formatRelativeTime,
+  resolveTimeZone,
+} from '@/lib/date-utils'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Calendar } from '@/components/ui/calendar'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+
+const HOURS = Array.from({ length: 12 }, (_, i) => i + 1)
+// 5-minute granularity: 00, 05, 10, … 55
+const MINUTES = Array.from({ length: 12 }, (_, i) =>
+  String(i * 5).padStart(2, '0'),
+)
+
+interface ReschedulePopoverProps {
+  scheduledFor: string | null
+  isOverdue: boolean
+  isPending: boolean
+  onConfirm: (iso: string) => void
+}
+
+function seedFrom(scheduledFor: string | null, tz: string) {
+  // Seed the calendar + time pickers from the instant rendered in the coach's
+  // timezone (not the browser's), so the wall-clock shown matches what they see.
+  const d = scheduledFor ? toZonedTime(new Date(scheduledFor), tz) : null
+  const h24 = d ? d.getHours() : 10
+  const period: 'AM' | 'PM' = h24 >= 12 ? 'PM' : 'AM'
+  let h12 = h24 % 12
+  if (h12 === 0) h12 = 12
+  const mins = d ? d.getMinutes() : 0
+  // snap to nearest 5 (handles off-grid times from Google Calendar sync)
+  const snapped = String((Math.round(mins / 5) % 12) * 5).padStart(2, '0')
+  return {
+    date: d || undefined,
+    hour: String(h12),
+    minute: snapped,
+    period,
+  }
+}
+
+function pad(n: number) {
+  return String(n).padStart(2, '0')
+}
+
+/**
+ * A reschedule control: click the date/time label to open a popover with a
+ * calendar AND a time picker, then "Update" to save both at once. Used by the
+ * dashboard and client-detail upcoming-session lists.
+ */
+export function ReschedulePopover({
+  scheduledFor,
+  isOverdue,
+  isPending,
+  onConfirm,
+}: ReschedulePopoverProps) {
+  const [open, setOpen] = useState(false)
+  const tz = resolveTimeZone()
+  const seed = seedFrom(scheduledFor, tz)
+  const [date, setDate] = useState<Date | undefined>(seed.date)
+  const [hour, setHour] = useState(seed.hour)
+  const [minute, setMinute] = useState(seed.minute)
+  const [period, setPeriod] = useState<'AM' | 'PM'>(seed.period)
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      // re-seed from the latest scheduled value each time we open
+      const s = seedFrom(scheduledFor, tz)
+      setDate(s.date)
+      setHour(s.hour)
+      setMinute(s.minute)
+      setPeriod(s.period)
+    }
+    setOpen(next)
+  }
+
+  const handleUpdate = () => {
+    if (!date) return
+    let h = parseInt(hour)
+    if (period === 'AM' && h === 12) h = 0
+    if (period === 'PM' && h !== 12) h += 12
+    // Interpret the picked calendar day + time as wall-clock in the coach's
+    // timezone, then convert to the absolute UTC instant.
+    const wall = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+      date.getDate(),
+    )}T${pad(h)}:${minute}:00`
+    onConfirm(fromZonedTime(wall, tz).toISOString())
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          className={`flex items-center gap-1 text-xs shrink-0 hover:underline ${
+            isOverdue ? 'text-vermillion' : 'text-ink-3 '
+          }`}
+          title="Click to reschedule"
+        >
+          <Clock className="h-3 w-3" />
+          {scheduledFor
+            ? `${formatDate(scheduledFor, 'MMM d, h:mm a')} (${formatRelativeTime(scheduledFor)})`
+            : 'No date'}
+          <CalendarIcon className="h-2.5 w-2.5 opacity-0 group-hover:opacity-50 transition-opacity" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="end">
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={setDate}
+          disabled={d => d < startOfDay(new Date())}
+          initialFocus
+        />
+        <div className="border-t border-line p-3 space-y-3">
+          <div className="flex items-center gap-2">
+            {/* Hour */}
+            <Select value={hour} onValueChange={setHour}>
+              <SelectTrigger className="w-[72px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <ScrollArea className="h-[200px]">
+                  {HOURS.map(h => (
+                    <SelectItem key={h} value={String(h)}>
+                      {String(h).padStart(2, '0')}
+                    </SelectItem>
+                  ))}
+                </ScrollArea>
+              </SelectContent>
+            </Select>
+
+            <span className="text-lg font-medium text-muted-foreground">:</span>
+
+            {/* Minute */}
+            <Select value={minute} onValueChange={setMinute}>
+              <SelectTrigger className="w-[72px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <ScrollArea className="h-[200px]">
+                  {MINUTES.map(m => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </ScrollArea>
+              </SelectContent>
+            </Select>
+
+            {/* AM/PM toggle */}
+            <div className="flex rounded-lg border border-input overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setPeriod('AM')}
+                className={cn(
+                  'px-3 py-2 text-sm font-medium transition-colors',
+                  period === 'AM'
+                    ? 'bg-ink text-ink-on-dark '
+                    : 'bg-surface-1 text-ink-3 hover:text-ink ',
+                )}
+              >
+                AM
+              </button>
+              <button
+                type="button"
+                onClick={() => setPeriod('PM')}
+                className={cn(
+                  'px-3 py-2 text-sm font-medium transition-colors',
+                  period === 'PM'
+                    ? 'bg-ink text-ink-on-dark '
+                    : 'bg-surface-1 text-ink-3 hover:text-ink ',
+                )}
+              >
+                PM
+              </button>
+            </div>
+          </div>
+
+          <Button
+            size="sm"
+            className="w-full"
+            disabled={!date || isPending}
+            onClick={handleUpdate}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                Updating…
+              </>
+            ) : (
+              'Update'
+            )}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/sessions/schedule-session-modal.tsx
+++ b/src/components/sessions/schedule-session-modal.tsx
@@ -10,6 +10,8 @@ import {
   startOfDay,
   isSameDay,
 } from 'date-fns'
+import { fromZonedTime } from 'date-fns-tz'
+import { resolveTimeZone } from '@/lib/date-utils'
 import { CalendarIcon, Loader2 } from 'lucide-react'
 import {
   Dialog,
@@ -117,12 +119,18 @@ export function ScheduleSessionModal({
     if (period === 'AM' && h === 12) h = 0
     if (period === 'PM' && h !== 12) h += 12
 
-    const scheduledFor = new Date(sessionDate)
-    scheduledFor.setHours(h, parseInt(minute), 0, 0)
+    // Interpret the picked calendar day + time as wall-clock in the coach's
+    // timezone, then convert to the absolute UTC instant we send to the API.
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const tz = resolveTimeZone()
+    const wall = `${sessionDate.getFullYear()}-${pad(
+      sessionDate.getMonth() + 1,
+    )}-${pad(sessionDate.getDate())}T${pad(h)}:${minute}:00`
+    const scheduledForIso = fromZonedTime(wall, tz).toISOString()
 
     const result = await scheduleSession.mutateAsync({
       client_id: clientId,
-      scheduled_for: scheduledFor.toISOString(),
+      scheduled_for: scheduledForIso,
       title: title || undefined,
       meeting_url: meetingUrl || undefined,
       send_questionnaire: sendQuestionnaire,

--- a/src/hooks/mutations/use-questionnaire-mutations.ts
+++ b/src/hooks/mutations/use-questionnaire-mutations.ts
@@ -103,6 +103,31 @@ export function useSendThrillForm() {
   })
 }
 
+export function useSubmitClientPreSession() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      answers,
+    }: {
+      sessionId: string
+      answers: { question_index: number; answer: string }[]
+    }) => QuestionnaireService.submitClientPreSession(sessionId, answers),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: query =>
+          query.queryKey[0] === 'questionnaire' &&
+          query.queryKey[1] === 'client-pre-session',
+      })
+      toast.success('Prep answers saved')
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to save prep answers')
+    },
+  })
+}
+
 export function useStartSessionBot() {
   return useMutation({
     mutationFn: ({

--- a/src/hooks/queries/use-questionnaire.ts
+++ b/src/hooks/queries/use-questionnaire.ts
@@ -4,6 +4,7 @@ import type {
   ScheduledSession,
   QuestionnaireResponseView,
   ThrillFormStatusView,
+  PreSessionPrep,
 } from '@/types/questionnaire'
 
 export const questionnaireKeys = {
@@ -15,6 +16,7 @@ export const questionnaireKeys = {
     ['questionnaire', 'thrill-form-responses', sessionId, clientId] as const,
   thrillForm: (sessionId: string, clientId?: string) =>
     ['questionnaire', 'thrill-form', sessionId, clientId] as const,
+  clientPreSession: () => ['questionnaire', 'client-pre-session'] as const,
 }
 
 export function useUpcomingSessions(clientId?: string) {
@@ -63,5 +65,15 @@ export function useThrillForm(
     queryFn: () => QuestionnaireService.getThrillForm(sessionId!, clientId),
     enabled: !!sessionId,
     staleTime: 60 * 1000,
+  })
+}
+
+// Pre-session prep questions for the logged-in client's next session — powers
+// the on-demand prep form on the client portal dashboard.
+export function useClientPreSession() {
+  return useQuery<PreSessionPrep>({
+    queryKey: questionnaireKeys.clientPreSession(),
+    queryFn: () => QuestionnaireService.getClientPreSession(),
+    staleTime: 30 * 1000,
   })
 }

--- a/src/hooks/use-user-timezone.ts
+++ b/src/hooks/use-user-timezone.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import axios from '@/lib/axios-config'
+import { useAuth } from '@/contexts/auth-context'
+
+/**
+ * Fetch the authenticated coach's saved IANA timezone from `/auth/me`.
+ *
+ * Returns `null` until resolved (or when disabled / unauthenticated), in which
+ * case callers should fall back to the browser zone. The value is cached
+ * indefinitely — the saved zone rarely changes within a session, and
+ * `auth-context` already keeps it in sync with the browser on login.
+ *
+ * @param enabled - Skip the fetch entirely when false (e.g. client-portal /
+ *   public surfaces that should use the browser zone, not the coach's).
+ */
+export function useUserTimezone(enabled: boolean = true): string | null {
+  const { isAuthenticated } = useAuth()
+
+  const { data } = useQuery({
+    queryKey: ['auth', 'me', 'timezone'],
+    queryFn: async (): Promise<string | null> => {
+      const res = await axios.get('/auth/me')
+      return (res.data?.timezone as string | null) ?? null
+    },
+    enabled: enabled && isAuthenticated,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  })
+
+  return data ?? null
+}

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -3,7 +3,17 @@
  *
  * Handles date parsing and formatting consistently across the app.
  * All dates from the backend are treated as UTC.
- * All dates are displayed in UTC to prevent timezone-induced day shifts.
+ *
+ * Two distinct formatting conventions:
+ * - INSTANT fields (timestamps with a meaningful time-of-day: scheduled_for,
+ *   created_at, started_at, session_date, …) are rendered in the user's
+ *   timezone via `formatDate` / `formatTime` / `formatDateTime`. The target
+ *   zone resolves to the saved coach timezone (set once at app root via
+ *   `setActiveTimeZone`) and falls back to the browser's zone.
+ * - DATE-ONLY fields (a calendar day with no time: commitment/sprint
+ *   target_date, start_date, end_date, daily-metric date) must be rendered in
+ *   UTC via `formatDateOnly` / `formatTimeOnly` to avoid timezone-induced day
+ *   shifts (e.g. "2026-06-15" displaying as Jun 14 in a negative-offset zone).
  */
 
 import {
@@ -13,6 +23,41 @@ import {
   isAfter as fnsIsAfter,
   isBefore as fnsIsBefore,
 } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
+
+/**
+ * Module-level "active" timezone for INSTANT formatting. Populated once near
+ * the app root by `useUserTimezone()` with the coach's saved IANA zone, so the
+ * formatters below render in the right zone without threading a tz argument
+ * through every call site. Null until set → callers fall back to browser zone.
+ */
+let activeTimeZone: string | null = null
+
+export function setActiveTimeZone(tz: string | null): void {
+  activeTimeZone = tz
+}
+
+function browserTimeZone(): string {
+  if (typeof Intl === 'undefined') return 'UTC'
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}
+
+/**
+ * Resolve the IANA timezone to render an INSTANT in.
+ * Priority: explicit arg → active (saved coach) zone → browser zone.
+ * Guards SSR with 'UTC' so server and the first client render agree (the
+ * post-mount re-render then applies the real browser/saved zone).
+ */
+export function resolveTimeZone(tz?: string | null): string {
+  if (tz) return tz
+  if (activeTimeZone) return activeTimeZone
+  if (typeof window === 'undefined') return 'UTC'
+  return browserTimeZone()
+}
 
 /**
  * Parse a date string from the API into a Date object.
@@ -31,8 +76,12 @@ export function parseDate(dateString: string | null | undefined): Date | null {
   if (!dateString.endsWith('Z') && !dateString.match(/[+-]\d{2}:\d{2}$/)) {
     // Replace space with T if present (some backends return "2024-01-15 10:30:00")
     normalizedString = dateString.replace(' ', 'T')
-    // Append Z to indicate UTC
-    if (!normalizedString.endsWith('Z')) {
+    // Date-only strings (e.g. "2024-06-15") need a time before the 'Z' suffix —
+    // Safari rejects "2024-06-15Z" as an invalid date.
+    if (/^\d{4}-\d{2}-\d{2}$/.test(normalizedString)) {
+      normalizedString += 'T00:00:00Z'
+    } else if (!normalizedString.endsWith('Z')) {
+      // Append Z to indicate UTC
       normalizedString += 'Z'
     }
   }
@@ -58,6 +107,21 @@ function toUTCLocal(date: Date): Date {
 }
 
 /**
+ * Parse an API date string into a Date that renders the correct calendar day in
+ * LOCAL time (for <Calendar> / date-picker `selected` values). Returns undefined
+ * when the string is missing or unparseable.
+ *
+ * Without this, `new Date("2024-06-15")` parses as UTC midnight, so in a
+ * negative-offset timezone the picker highlights the previous day.
+ */
+export function parseDateForPicker(
+  dateString: string | null | undefined,
+): Date | undefined {
+  const date = parseDate(dateString)
+  return date ? toUTCLocal(date) : undefined
+}
+
+/**
  * Format a date for relative display (e.g., "2 hours ago")
  *
  * @param dateString - Date string from the API
@@ -75,14 +139,71 @@ export function formatRelativeTime(
 }
 
 /**
- * Format a date for display in UTC (e.g., "Jan 15, 2024").
- * Prevents timezone-induced day shifts for date-only values.
+ * Format an INSTANT date in the user's timezone (e.g., "Jan 15, 2024").
+ * Use for timestamps with a meaningful time-of-day. For calendar-day-only
+ * values use `formatDateOnly` instead.
  *
  * @param dateString - Date string from the API
  * @param formatString - date-fns format string (default: 'PPP')
- * @returns Formatted date string in UTC
+ * @param tz - Optional explicit IANA zone; defaults to the resolved user zone
+ * @returns Formatted date string in the resolved timezone
  */
 export function formatDate(
+  dateString: string | null | undefined,
+  formatString: string = 'PPP',
+  tz?: string | null,
+): string {
+  const date = parseDate(dateString)
+  if (!date) return 'Unknown'
+
+  return formatInTimeZone(date, resolveTimeZone(tz), formatString)
+}
+
+/**
+ * Format an INSTANT as time only in the user's timezone (e.g., "2:30 PM").
+ *
+ * @param dateString - Date string from the API
+ * @param tz - Optional explicit IANA zone; defaults to the resolved user zone
+ * @returns Formatted time string in the resolved timezone
+ */
+export function formatTime(
+  dateString: string | null | undefined,
+  tz?: string | null,
+): string {
+  const date = parseDate(dateString)
+  if (!date) return 'Unknown'
+
+  return formatInTimeZone(date, resolveTimeZone(tz), 'p')
+}
+
+/**
+ * Format an INSTANT with date and time in the user's timezone
+ * (e.g., "Jan 15, 2024 at 10:30 AM").
+ *
+ * @param dateString - Date string from the API
+ * @param tz - Optional explicit IANA zone; defaults to the resolved user zone
+ * @returns Formatted date and time string in the resolved timezone
+ */
+export function formatDateTime(
+  dateString: string | null | undefined,
+  tz?: string | null,
+): string {
+  const date = parseDate(dateString)
+  if (!date) return 'Unknown'
+
+  return formatInTimeZone(date, resolveTimeZone(tz), "PPP 'at' p")
+}
+
+/**
+ * Format a DATE-ONLY value in UTC (e.g., "Jan 15, 2024").
+ * Prevents timezone-induced day shifts for calendar-day values that have no
+ * meaningful time-of-day (commitment/sprint dates, daily-metric dates).
+ *
+ * @param dateString - Date string from the API
+ * @param formatString - date-fns format string (default: 'PPP')
+ * @returns Formatted date string rendered as its UTC calendar day
+ */
+export function formatDateOnly(
   dateString: string | null | undefined,
   formatString: string = 'PPP',
 ): string {
@@ -93,29 +214,17 @@ export function formatDate(
 }
 
 /**
- * Format a time only (e.g., "2:30 PM")
+ * Format a DATE-ONLY value's time portion in UTC (e.g., "12:00 AM").
+ * Rarely needed; provided for parity with `formatDateOnly`.
  *
  * @param dateString - Date string from the API
- * @returns Formatted time string
+ * @returns Formatted time string rendered in UTC
  */
-export function formatTime(dateString: string | null | undefined): string {
+export function formatTimeOnly(dateString: string | null | undefined): string {
   const date = parseDate(dateString)
   if (!date) return 'Unknown'
 
   return fnsFormat(toUTCLocal(date), 'p')
-}
-
-/**
- * Format a date with time (e.g., "Jan 15, 2024 at 10:30 AM")
- *
- * @param dateString - Date string from the API
- * @returns Formatted date and time string
- */
-export function formatDateTime(dateString: string | null | undefined): string {
-  const date = parseDate(dateString)
-  if (!date) return 'Unknown'
-
-  return fnsFormat(toUTCLocal(date), "PPP 'at' p")
 }
 
 /**

--- a/src/services/questionnaire-service.ts
+++ b/src/services/questionnaire-service.ts
@@ -7,6 +7,7 @@ import type {
   ThrillFormStatusView,
   QuestionnaireTokenResponse,
   StartBotResponse,
+  PreSessionPrep,
 } from '@/types/questionnaire'
 
 const BACKEND_URL =
@@ -93,6 +94,22 @@ export class QuestionnaireService {
     return ApiClient.post(
       `${BACKEND_URL}/questionnaire/sessions/${sessionId}/start-bot`,
       { meeting_url: meetingUrl, bot_name: botName },
+    )
+  }
+
+  // ---- Authenticated (client portal) ----
+
+  static async getClientPreSession(): Promise<PreSessionPrep> {
+    return ApiClient.get(`${BACKEND_URL}/client/pre-session-questionnaire`)
+  }
+
+  static async submitClientPreSession(
+    sessionId: string,
+    answers: { question_index: number; answer: string }[],
+  ): Promise<{ status: string }> {
+    return ApiClient.post(
+      `${BACKEND_URL}/client/pre-session-questionnaire/submit`,
+      { session_id: sessionId, answers },
     )
   }
 

--- a/src/types/questionnaire.ts
+++ b/src/types/questionnaire.ts
@@ -83,6 +83,20 @@ export interface ThrillFormStatusView {
   responses: QuestionAnswerPair[]
 }
 
+export type PreSessionStatus = 'not_started' | 'in_progress' | 'completed'
+
+export interface PreSessionPrep {
+  session: {
+    id: string
+    title: string | null
+    scheduled_for: string | null
+    meeting_url: string | null
+  } | null
+  questions: QuestionItem[]
+  existing_answers: QuestionAnswerPair[]
+  status: PreSessionStatus
+}
+
 export interface QuestionnaireTokenResponse {
   token: string
   questionnaire_url: string


### PR DESCRIPTION
## Summary
Bundles today's frontend fixes.

- **Timezone display fix (the main one)** — session/appointment times now render in the coach's saved timezone instead of UTC. `date-utils` `formatDate/formatTime/formatDateTime` use `date-fns-tz`; an app-root `TimezoneInitializer` + `useUserTimezone` set the active zone from `/auth/me` (browser fallback; browser zone on client-portal/questionnaire). Date-only fields moved to `formatDateOnly` to avoid day-shifts. Scheduling input + reschedule build the instant in the coach's zone via `fromZonedTime`.
- **Reschedule popover** — change time as well as date (5-min granularity).
- **Coach "Prepare for next session" card** — on-demand button instead of auto-running on page view.
- **Client dashboard hero** — working Join button, prominent prep-questions card.
- **Safari date fix** — commitment dates no longer show "Unknown" in Safari.

## Verification
- `pnpm build` + lint clean.