### PR TITLE
Phase 3: surface pending-login error message

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -180,8 +180,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return { error: null }
     } catch (error) {
       console.error('Sign in error:', error)
+      // Prefer the backend's detail message (e.g. the pending "not activated yet"
+      // 403) over axios's generic "Request failed with status code ..." text.
+      const detail = (error as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail
       const errorMessage =
-        error instanceof Error ? error.message : 'Invalid email or password'
+        detail ||
+        (error instanceof Error ? error.message : 'Invalid email or password')
       toast.error('Login Failed', {
         description: errorMessage,
         duration: 5000,


### PR DESCRIPTION
## What

Frontend half of Phase 3. When a **pending** (invited-but-not-activated) user tries to log in, the backend now returns a 403 with a clear detail message ("This account hasn't been activated yet. Please use your invitation link to set a password."). The axios interceptor only special-cases 401, so that detail wasn't surfacing — the toast showed axios's generic "Request failed with status code 403".

## Change
- `auth-context.tsx` `signIn` catch now prefers `error.response.data.detail` over the generic message.

Pairs with backend PR #63.