### PR TITLE
feat(client-portal): multi-profile switcher (Phase 5c)

### DIFF
--- a/src/app/client-portal/dashboard/page.tsx
+++ b/src/app/client-portal/dashboard/page.tsx
@@ -150,6 +150,10 @@ export default function ClientDashboard() {
       if (viewAsClient) {
         headers['X-View-As-Client'] = viewAsClient
       }
+      const activeClient = sessionStorage.getItem('active_client_id')
+      if (activeClient) {
+        headers['X-Active-Client'] = activeClient
+      }
       const response = await fetch(`${apiUrl}/client/dashboard`, { headers })
 
       if (!response.ok) {

--- a/src/app/client-portal/profile/page.tsx
+++ b/src/app/client-portal/profile/page.tsx
@@ -114,6 +114,10 @@ export default function ClientProfilePage() {
       if (viewAsClient) {
         headers['X-View-As-Client'] = viewAsClient
       }
+      const activeClient = sessionStorage.getItem('active_client_id')
+      if (activeClient) {
+        headers['X-Active-Client'] = activeClient
+      }
       const response = await fetch(`${apiUrl}/client/dashboard`, { headers })
 
       if (response.status === 401) {

--- a/src/components/client-portal/active-sessions-card.tsx
+++ b/src/components/client-portal/active-sessions-card.tsx
@@ -54,6 +54,10 @@ export function ActiveSessionsCard() {
       if (viewAsClient) {
         headers['X-View-As-Client'] = viewAsClient
       }
+      const activeClient = sessionStorage.getItem('active_client_id')
+      if (activeClient) {
+        headers['X-Active-Client'] = activeClient
+      }
       const response = await fetch(`${apiUrl}/client-portal/active-sessions`, {
         headers,
       })

--- a/src/components/client-portal/client-navigation.tsx
+++ b/src/components/client-portal/client-navigation.tsx
@@ -28,6 +28,7 @@ import {
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
 import { RoleSwitcher } from '@/components/auth/role-switcher'
+import { ProfileSwitcher } from '@/components/client-portal/profile-switcher'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 
 const navItems = [
@@ -203,6 +204,9 @@ export function ClientNavigation() {
 
               {/* Role Switcher - Only show if user has other roles */}
               {hasOtherRoles && <RoleSwitcher />}
+
+              {/* Multi-profile switcher - only renders for clients with >1 profile */}
+              <ProfileSwitcher />
 
               {/* User Menu */}
               <DropdownMenu>

--- a/src/components/client-portal/profile-switcher.tsx
+++ b/src/components/client-portal/profile-switcher.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { Check, ChevronsUpDown, Users } from 'lucide-react'
+
+import { useAuth } from '@/contexts/auth-context'
+import {
+  useClientProfiles,
+  type ClientProfile,
+} from '@/hooks/queries/use-client-profiles'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+/**
+ * Multi-profile switcher (Phase 5c). Lets a client coached by more than one
+ * coach switch which profile is "active". Renders NOTHING for a single-profile
+ * client (the 99% case) — zero change for them. Distinct from super-admin
+ * impersonation (the amber "Viewing portal as" banner).
+ */
+export function ProfileSwitcher() {
+  const { isClient } = useAuth()
+  const { data: profiles } = useClientProfiles({ enabled: isClient() })
+
+  // Hidden unless the user genuinely has more than one profile.
+  if (!profiles || profiles.length <= 1) return null
+
+  const active = profiles.find(p => p.is_active) ?? profiles[0]
+  const label = active.coach_name || active.name || 'Profile'
+
+  const switchTo = (profile: ClientProfile) => {
+    if (profile.is_active) return
+    sessionStorage.setItem('active_client_id', profile.client_id)
+    sessionStorage.setItem(
+      'active_client_name',
+      profile.coach_name || profile.name || '',
+    )
+    // Full navigation to the dashboard so EVERY query + raw-fetch page re-reads
+    // the new active profile from sessionStorage (the header is read at request
+    // time, not reactively).
+    window.location.assign('/client-portal/dashboard')
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 gap-2 px-2.5 text-[13px] font-medium"
+          aria-label="Switch coaching profile"
+        >
+          <Users className="h-3.5 w-3.5 text-ink-3" strokeWidth={1.75} />
+          <span className="hidden sm:inline max-w-[120px] truncate">
+            {label}
+          </span>
+          <ChevronsUpDown
+            className="h-3.5 w-3.5 text-ink-3 opacity-70"
+            strokeWidth={1.75}
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+          Coaching profile
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {profiles.map(profile => (
+          <DropdownMenuItem
+            key={profile.client_id}
+            onSelect={() => switchTo(profile)}
+            className="cursor-pointer gap-2"
+          >
+            <div className="flex flex-col min-w-0">
+              <span className="truncate text-sm">
+                {profile.coach_name || 'Coach'}
+              </span>
+              {profile.name && (
+                <span className="truncate text-xs text-muted-foreground">
+                  {profile.name}
+                </span>
+              )}
+            </div>
+            {profile.is_active && (
+              <Check className="ml-auto h-4 w-4 shrink-0" strokeWidth={2} />
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/hooks/queries/use-client-profiles.ts
+++ b/src/hooks/queries/use-client-profiles.ts
@@ -1,0 +1,36 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import { ApiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-client'
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+export interface ClientProfile {
+  client_id: string
+  name: string | null
+  email: string | null
+  coach_name: string | null
+  is_active: boolean
+}
+
+/**
+ * Every coaching profile the logged-in user owns as a coachee (Phase 5c).
+ *
+ * A user coached by more than one coach has several profiles; single-profile
+ * users get a one-item list and the switcher renders nothing. ApiClient injects
+ * the X-Active-Client header, so `is_active` reflects the current selection.
+ */
+export function useClientProfiles(
+  options?: Omit<UseQueryOptions<ClientProfile[]>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: [...queryKeys.clientPortal.all, 'profiles'] as const,
+    queryFn: () =>
+      ApiClient.get(`${API_URL}/client-portal/profiles`) as Promise<
+        ClientProfile[]
+      >,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/hooks/queries/use-client-sessions.ts
+++ b/src/hooks/queries/use-client-sessions.ts
@@ -16,6 +16,10 @@ function getAuthHeaders(): Record<string, string> {
     if (viewAsClient) {
       headers['X-View-As-Client'] = viewAsClient
     }
+    const activeClient = sessionStorage.getItem('active_client_id')
+    if (activeClient) {
+      headers['X-Active-Client'] = activeClient
+    }
   }
   return headers
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -110,6 +110,13 @@ export class ApiClient {
       if (viewAsCoach) {
         headers['X-View-As-Coach'] = viewAsCoach
       }
+      // Multi-profile switch (Phase 5c): a client choosing among their OWN
+      // profiles. Distinct from impersonation above — the backend honors it only
+      // on the no-impersonation path.
+      const activeClient = sessionStorage.getItem('active_client_id')
+      if (activeClient) {
+        headers['X-Active-Client'] = activeClient
+      }
     }
 
     return headers

--- a/src/lib/axios-config.ts
+++ b/src/lib/axios-config.ts
@@ -74,6 +74,12 @@ axiosInstance.interceptors.request.use(
       if (viewAsCoach && !config.url?.includes('/admin/')) {
         config.headers['X-View-As-Coach'] = viewAsCoach
       }
+      // Multi-profile switch (Phase 5c): a client choosing among their OWN
+      // profiles (distinct from impersonation above).
+      const activeClient = sessionStorage.getItem('active_client_id')
+      if (activeClient) {
+        config.headers['X-Active-Client'] = activeClient
+      }
     }
 
     return config

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -57,6 +57,8 @@ function viewAsHeaders(): Record<string, string> {
   if (viewAsClient) headers['X-View-As-Client'] = viewAsClient
   const viewAsCoach = sessionStorage.getItem('view_as_coach_id')
   if (viewAsCoach) headers['X-View-As-Coach'] = viewAsCoach
+  const activeClient = sessionStorage.getItem('active_client_id')
+  if (activeClient) headers['X-Active-Client'] = activeClient
   return headers
 }
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -198,6 +198,11 @@ class AuthService {
       // Also clear legacy keys
       localStorage.removeItem('client_auth_token')
       localStorage.removeItem('client_user_data')
+
+      // Phase 5c: drop the multi-profile active selection so a different user
+      // signing in on this tab starts on their own default profile.
+      sessionStorage.removeItem('active_client_id')
+      sessionStorage.removeItem('active_client_name')
     }
   }
 

--- a/src/services/client-commitment-service.ts
+++ b/src/services/client-commitment-service.ts
@@ -184,6 +184,10 @@ export class ClientCommitmentService {
       typeof window !== 'undefined'
         ? sessionStorage.getItem('view_as_client_id')
         : null
+    const activeClient =
+      typeof window !== 'undefined'
+        ? sessionStorage.getItem('active_client_id')
+        : null
 
     if (onProgress) {
       return new Promise((resolve, reject) => {
@@ -194,6 +198,7 @@ export class ClientCommitmentService {
         )
         if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`)
         if (viewAsClient) xhr.setRequestHeader('X-View-As-Client', viewAsClient)
+        if (activeClient) xhr.setRequestHeader('X-Active-Client', activeClient)
 
         xhr.upload.onprogress = e => {
           if (e.lengthComputable) {
@@ -226,6 +231,7 @@ export class ClientCommitmentService {
         headers: {
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
           ...(viewAsClient ? { 'X-View-As-Client': viewAsClient } : {}),
+          ...(activeClient ? { 'X-Active-Client': activeClient } : {}),
         },
         body: formData,
       },


### PR DESCRIPTION
## What
Frontend half of Phase 5c. A client coached by more than one coach can switch which **profile** is active. **Single-profile clients (≈99%) see zero change** — the switcher renders nothing.

Distinct from super-admin impersonation (the amber "Viewing portal as" banner): this is a client choosing among their *own* profiles.

## Changes
- **`X-Active-Client` header** mirrors `X-View-As-Client`, injected at the 2 core sites (`lib/api-client.ts`, `lib/axios-config.ts`) + 6 manual fetch builders (dashboard, profile, active-sessions-card, use-client-sessions, agent-service, client-commitment-service XHR+fetch).
- **`useClientProfiles`** hook → `GET /client-portal/profiles`; **`ProfileSwitcher`** dropdown (renders nothing unless `profiles.length > 1`). On switch: set `active_client_id`/`active_client_name` in sessionStorage + `window.location.assign('/client-portal/dashboard')` so every query + raw-fetch page re-reads the new active profile (the header is read at request time, not reactively).
- Wired into `client-navigation.tsx` before the user menu.
- `auth-service.clearAuthData` clears the active-profile keys on logout (no stale profile across sign-ins on a shared tab).

## Backend
Pairs with `GET /api/v1/client-portal/profiles` (already merged to backend `master`). `tsc --noEmit` clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)