### PR TITLE
chore(admin): remove the dead access_level UI (Phase 6d)

### DIFF
--- a/src/app/admin/access/components/client-access-view.tsx
+++ b/src/app/admin/access/components/client-access-view.tsx
@@ -43,16 +43,7 @@ import { Badge } from '@/components/ui/badge'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Skeleton } from '@/components/ui/skeleton'
-import {
-  Search,
-  Plus,
-  Users,
-  UserPlus,
-  UserMinus,
-  Eye,
-  Edit2,
-  Loader2,
-} from 'lucide-react'
+import { Search, Plus, Users, UserPlus, UserMinus, Loader2 } from 'lucide-react'
 
 interface ClientAccessViewProps {
   users: UserType[]
@@ -83,13 +74,11 @@ export default function ClientAccessView({
   const [grantAccessForm, setGrantAccessForm] = useState({
     client_id: '',
     user_id: '',
-    access_level: 'full' as 'full' | 'readonly',
   })
 
   const [bulkAssignForm, setBulkAssignForm] = useState({
     user_id: '',
     client_ids: [] as string[],
-    access_level: 'full' as 'full' | 'readonly',
   })
 
   // Mutation hooks
@@ -135,7 +124,6 @@ export default function ClientAccessView({
     setGrantAccessForm({
       client_id: '',
       user_id: '',
-      access_level: 'full',
     })
     setSelectedClient(null)
   }
@@ -144,7 +132,6 @@ export default function ClientAccessView({
     setBulkAssignForm({
       user_id: '',
       client_ids: [],
-      access_level: 'full',
     })
   }
 
@@ -346,22 +333,6 @@ export default function ClientAccessView({
                                       {formatRoleName(role)}
                                     </Badge>
                                   ))}
-                                  <Badge
-                                    variant="outline"
-                                    className={cn(
-                                      'text-xs',
-                                      user.access_level === 'full' ? '' : '',
-                                    )}
-                                  >
-                                    {user.access_level === 'full' ? (
-                                      <Edit2 className="h-3 w-3 mr-1" />
-                                    ) : (
-                                      <Eye className="h-3 w-3 mr-1" />
-                                    )}
-                                    {user.access_level === 'full'
-                                      ? 'Full Access'
-                                      : 'Read Only'}
-                                  </Badge>
                                 </div>
                               </div>
                               {!user.is_owner && (
@@ -471,33 +442,6 @@ export default function ClientAccessView({
                 </SelectContent>
               </Select>
             </div>
-            <div>
-              <Label htmlFor="access_level">Access Level</Label>
-              <Select
-                value={grantAccessForm.access_level}
-                onValueChange={(value: 'full' | 'readonly') =>
-                  setGrantAccessForm(prev => ({ ...prev, access_level: value }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="full">
-                    <div className="flex items-center gap-2">
-                      <Edit2 className="h-4 w-4" />
-                      Full Access
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="readonly">
-                    <div className="flex items-center gap-2">
-                      <Eye className="h-4 w-4" />
-                      Read Only
-                    </div>
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
           </div>
           <DialogFooter>
             <Button
@@ -553,33 +497,6 @@ export default function ClientAccessView({
                       {user.email} {user.full_name && `(${user.full_name})`}
                     </SelectItem>
                   ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="bulk-access_level">Access Level</Label>
-              <Select
-                value={bulkAssignForm.access_level}
-                onValueChange={(value: 'full' | 'readonly') =>
-                  setBulkAssignForm(prev => ({ ...prev, access_level: value }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="full">
-                    <div className="flex items-center gap-2">
-                      <Edit2 className="h-4 w-4" />
-                      Full Access
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="readonly">
-                    <div className="flex items-center gap-2">
-                      <Eye className="h-4 w-4" />
-                      Read Only
-                    </div>
-                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/src/app/admin/access/components/hierarchy-view.tsx
+++ b/src/app/admin/access/components/hierarchy-view.tsx
@@ -44,7 +44,6 @@ interface HierarchyNode {
   email?: string
   children: HierarchyNode[]
   roles?: string[]
-  access_level?: string
   is_owner?: boolean
 }
 
@@ -119,7 +118,6 @@ export default function HierarchyView({
                   type: 'client',
                   id: client.client_id,
                   name: client.client_name,
-                  access_level: accessInfo?.access_level,
                   is_owner: accessInfo?.is_owner,
                   children: [],
                 })
@@ -161,7 +159,6 @@ export default function HierarchyView({
                   type: 'client',
                   id: client.client_id,
                   name: client.client_name,
-                  access_level: accessInfo?.access_level,
                   is_owner: accessInfo?.is_owner,
                   children: [],
                 })
@@ -193,7 +190,6 @@ export default function HierarchyView({
                   type: 'client',
                   id: client.client_id,
                   name: client.client_name,
-                  access_level: accessInfo?.access_level,
                   is_owner: accessInfo?.is_owner,
                   children: [],
                 })
@@ -237,7 +233,6 @@ export default function HierarchyView({
               type: 'client',
               id: client.client_id,
               name: client.client_name,
-              access_level: accessInfo?.access_level,
               is_owner: accessInfo?.is_owner,
               children: [],
             })
@@ -469,11 +464,6 @@ export default function HierarchyView({
               {node.is_owner && (
                 <Badge variant="secondary" className="text-xs">
                   Owner
-                </Badge>
-              )}
-              {node.access_level && !node.is_owner && (
-                <Badge variant="outline" className="text-xs">
-                  {node.access_level === 'full' ? 'Full Access' : 'Read Only'}
                 </Badge>
               )}
             </div>

--- a/src/app/admin/access/components/list-view.tsx
+++ b/src/app/admin/access/components/list-view.tsx
@@ -43,7 +43,6 @@ interface AccessRelationship {
   coach?: UserType
   client?: ClientAccessMatrix
   user?: UserType
-  access_level?: string
   is_owner?: boolean
 }
 
@@ -91,7 +90,6 @@ export default function ListView({
             type: 'client_access',
             client,
             user,
-            access_level: assignedUser.access_level,
             is_owner: assignedUser.is_owner,
           })
         }
@@ -457,18 +455,6 @@ export default function ListView({
                                 Owner
                               </Badge>
                             )}
-                            <Badge
-                              variant={
-                                rel.access_level === 'full'
-                                  ? 'default'
-                                  : 'outline'
-                              }
-                              className="text-xs"
-                            >
-                              {rel.access_level === 'full'
-                                ? 'Full Access'
-                                : 'Read Only'}
-                            </Badge>
                           </div>
                         </TableCell>
                       </TableRow>

--- a/src/app/admin/client-access/page.tsx
+++ b/src/app/admin/client-access/page.tsx
@@ -53,8 +53,6 @@ import {
   Users,
   UserPlus,
   UserMinus,
-  Eye,
-  Edit2,
   Shield,
   Network,
   Building,
@@ -70,7 +68,6 @@ interface HierarchyNode {
   email?: string
   children: HierarchyNode[]
   roles?: string[]
-  access_level?: string
 }
 
 export default function ClientAccessPage() {
@@ -87,13 +84,11 @@ export default function ClientAccessPage() {
   const [grantAccessForm, setGrantAccessForm] = useState({
     client_id: '',
     user_id: '',
-    access_level: 'full' as 'full' | 'readonly',
   })
 
   const [bulkAssignForm, setBulkAssignForm] = useState({
     user_id: '',
     client_ids: [] as string[],
-    access_level: 'full' as 'full' | 'readonly',
   })
 
   // React Query hooks - automatic caching!
@@ -166,14 +161,10 @@ export default function ClientAccessPage() {
                 u => u.user_id === coach.id,
               )
               if (coachHasAccess) {
-                const accessInfo = client.assigned_users.find(
-                  u => u.user_id === coach.id,
-                )
                 coachNode.children.push({
                   type: 'client',
                   id: client.client_id,
                   name: client.client_name,
-                  access_level: accessInfo?.access_level,
                   children: [],
                 })
               }
@@ -208,14 +199,10 @@ export default function ClientAccessPage() {
                 u => u.user_id === coach.id,
               )
               if (coachHasAccess) {
-                const accessInfo = client.assigned_users.find(
-                  u => u.user_id === coach.id,
-                )
                 coachNode.children.push({
                   type: 'client',
                   id: client.client_id,
                   name: client.client_name,
-                  access_level: accessInfo?.access_level,
                   children: [],
                 })
               }
@@ -240,14 +227,10 @@ export default function ClientAccessPage() {
               )
 
               if (!alreadyInHierarchy) {
-                const accessInfo = client.assigned_users.find(
-                  u => u.user_id === admin.id,
-                )
                 adminNode.children.push({
                   type: 'client',
                   id: client.client_id,
                   name: client.client_name,
-                  access_level: accessInfo?.access_level,
                   children: [],
                 })
               }
@@ -276,14 +259,10 @@ export default function ClientAccessPage() {
             u => u.user_id === coach.id,
           )
           if (coachHasAccess) {
-            const accessInfo = client.assigned_users.find(
-              u => u.user_id === coach.id,
-            )
             coachNode.children.push({
               type: 'client',
               id: client.client_id,
               name: client.client_name,
-              access_level: accessInfo?.access_level,
               children: [],
             })
           }
@@ -346,7 +325,6 @@ export default function ClientAccessPage() {
     setGrantAccessForm({
       client_id: '',
       user_id: '',
-      access_level: 'full',
     })
     setSelectedClient(null)
   }
@@ -355,7 +333,6 @@ export default function ClientAccessPage() {
     setBulkAssignForm({
       user_id: '',
       client_ids: [],
-      access_level: 'full',
     })
   }
 
@@ -441,19 +418,6 @@ export default function ClientAccessPage() {
               {node.type === 'admin' && !isSuper && (
                 <Badge variant="default" className="text-xs">
                   Admin
-                </Badge>
-              )}
-              {node.access_level && (
-                <Badge
-                  variant="outline"
-                  className={cn(
-                    'text-xs',
-                    node.access_level === 'full'
-                      ? 'bg-forest-bg text-forest border-forest '
-                      : 'bg-amber-token-bg text-amber-token border-amber-token ',
-                  )}
-                >
-                  {node.access_level === 'full' ? 'Full Access' : 'Read Only'}
                 </Badge>
               )}
             </div>
@@ -650,24 +614,6 @@ export default function ClientAccessPage() {
                                   </Badge>
                                 ))}
                               </div>
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  'text-xs',
-                                  user.access_level === 'full'
-                                    ? 'bg-forest-bg text-forest border-forest '
-                                    : 'bg-amber-token-bg text-amber-token border-amber-token ',
-                                )}
-                              >
-                                {user.access_level === 'full' ? (
-                                  <Edit2 className="h-3 w-3 mr-1" />
-                                ) : (
-                                  <Eye className="h-3 w-3 mr-1" />
-                                )}
-                                {user.access_level === 'full'
-                                  ? 'Full Access'
-                                  : 'Read Only'}
-                              </Badge>
                             </div>
                             <Button
                               variant="ghost"
@@ -770,33 +716,6 @@ export default function ClientAccessPage() {
                 </SelectContent>
               </Select>
             </div>
-            <div>
-              <Label htmlFor="access_level">Access Level</Label>
-              <Select
-                value={grantAccessForm.access_level}
-                onValueChange={(value: 'full' | 'readonly') =>
-                  setGrantAccessForm(prev => ({ ...prev, access_level: value }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="full">
-                    <div className="flex items-center gap-2">
-                      <Edit2 className="h-4 w-4" />
-                      Full Access
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="readonly">
-                    <div className="flex items-center gap-2">
-                      <Eye className="h-4 w-4" />
-                      Read Only
-                    </div>
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
           </div>
           <DialogFooter>
             <Button
@@ -843,33 +762,6 @@ export default function ClientAccessPage() {
                       {user.email} {user.full_name && `(${user.full_name})`}
                     </SelectItem>
                   ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="bulk-access_level">Access Level</Label>
-              <Select
-                value={bulkAssignForm.access_level}
-                onValueChange={(value: 'full' | 'readonly') =>
-                  setBulkAssignForm(prev => ({ ...prev, access_level: value }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="full">
-                    <div className="flex items-center gap-2">
-                      <Edit2 className="h-4 w-4" />
-                      Full Access
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="readonly">
-                    <div className="flex items-center gap-2">
-                      <Eye className="h-4 w-4" />
-                      Read Only
-                    </div>
-                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/src/app/settings/components/profile-section.tsx
+++ b/src/app/settings/components/profile-section.tsx
@@ -27,7 +27,6 @@ import {
   UserCheck,
   Users,
   Eye,
-  LockKeyhole,
 } from 'lucide-react'
 import axios from '@/lib/axios-config'
 import { formatDate } from '@/lib/date-utils'
@@ -45,7 +44,6 @@ interface UserProfile {
   client_access: Array<{
     client_id: string
     client_name: string
-    access_level: string
   }>
 }
 
@@ -452,20 +450,6 @@ export function ProfileSection() {
                             </p>
                           </div>
                         </div>
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            'text-xs',
-                            access.access_level === 'full'
-                              ? 'bg-forest-bg text-forest border-forest'
-                              : 'bg-amber-token-bg text-amber-token border-amber-token',
-                          )}
-                        >
-                          <LockKeyhole className="h-3 w-3 mr-1" />
-                          {access.access_level === 'full'
-                            ? 'Full Access'
-                            : 'Read Only'}
-                        </Badge>
                       </div>
                     ))}
                   </div>

--- a/src/hooks/mutations/use-admin-access-mutations.ts
+++ b/src/hooks/mutations/use-admin-access-mutations.ts
@@ -12,8 +12,7 @@ import { toast } from 'sonner'
  *
  * grantAccess({
  *   client_id: 'client-123',
- *   user_id: 'user-456',
- *   access_level: 'full'
+ *   user_id: 'user-456'
  * })
  * ```
  */
@@ -21,11 +20,8 @@ export function useGrantClientAccess() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (data: {
-      client_id: string
-      user_id: string
-      access_level?: 'full' | 'readonly'
-    }) => adminService.grantClientAccess(data),
+    mutationFn: (data: { client_id: string; user_id: string }) =>
+      adminService.grantClientAccess(data),
 
     onSuccess: () => {
       toast.success('Access granted successfully')
@@ -47,8 +43,7 @@ export function useGrantClientAccess() {
  *
  * bulkAssign({
  *   user_id: 'user-123',
- *   client_ids: ['client-1', 'client-2', 'client-3'],
- *   access_level: 'full'
+ *   client_ids: ['client-1', 'client-2', 'client-3']
  * })
  * ```
  */
@@ -56,11 +51,8 @@ export function useBulkAssignClients() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (data: {
-      user_id: string
-      client_ids: string[]
-      access_level?: 'full' | 'readonly'
-    }) => adminService.bulkAssignClients(data),
+    mutationFn: (data: { user_id: string; client_ids: string[] }) =>
+      adminService.bulkAssignClients(data),
 
     onSuccess: result => {
       toast.success(`${result.assigned_count} clients assigned successfully`)

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -51,7 +51,6 @@ export interface RoleAssignment {
 export interface ClientAccess {
   client_id: string
   user_id: string
-  access_level: 'full' | 'readonly'
 }
 
 export interface ClientAccessMatrix {
@@ -62,7 +61,6 @@ export interface ClientAccessMatrix {
     email: string
     full_name: string | null
     roles: string[]
-    access_level: string
     is_owner?: boolean
   }[]
 }
@@ -174,7 +172,6 @@ class AdminService {
     {
       client_id: string
       client_name: string
-      access_level: string
       is_admin_access?: boolean
     }[]
   > {
@@ -190,7 +187,6 @@ class AdminService {
       email: string
       full_name: string | null
       roles: string[]
-      access_level: string
       granted_at?: string
       is_admin_access?: boolean
     }[]
@@ -204,7 +200,6 @@ class AdminService {
   async grantClientAccess(data: {
     client_id: string
     user_id: string
-    access_level?: 'full' | 'readonly'
   }): Promise<void> {
     await axiosInstance.post('/admin/client-access/grant', data)
   }
@@ -212,7 +207,6 @@ class AdminService {
   async bulkAssignClients(data: {
     user_id: string
     client_ids: string[]
-    access_level?: 'full' | 'readonly'
   }): Promise<{
     message: string
     assigned_count: number
@@ -241,7 +235,6 @@ class AdminService {
   async assignClientAccess(data: {
     client_id: string
     user_id: string
-    access_level: string
   }): Promise<any> {
     const response = await axiosInstance.post('/access/client-access', data)
     return response.data


### PR DESCRIPTION
## Phase 6d — frontend cleanup

The backend dropped `client_access.access_level` (always `"full"`; `"readonly"` never used). This removes the now-meaningless access-level UI:

- Access-level **Select dropdowns** in the grant + bulk-assign dialogs (`client-access-view.tsx`, `client-access/page.tsx`) — plus their form state/handlers.
- **Full/Read-Only badges** (settings profile, hierarchy-view, list-view, client-access pages).
- `access_level` **type fields** + request-payload keys + service/mutation params.

Granting, bulk-assigning, and revoking access all still work — there's just no level to choose. The backend still returns/accepts an (ignored) `access_level`, so nothing breaks during rollout.

**7 files, −245/+6.** `tsc --noEmit` clean aside from a pre-existing unrelated vitest error.