### PR TITLE
Surface client note on profile card; rename Edit Client → Client settings

### DIFF
--- a/src/app/clients/[clientId]/components/client-profile-section.tsx
+++ b/src/app/clients/[clientId]/components/client-profile-section.tsx
@@ -32,6 +32,7 @@ import {
   MoreVertical,
   Trash2,
   XCircle,
+  StickyNote,
 } from 'lucide-react'
 import { formatDate } from '@/lib/date-utils'
 
@@ -117,7 +118,7 @@ export function ClientProfileSection({
               <DropdownMenuContent align="end" className="w-48">
                 <DropdownMenuItem onClick={onEdit}>
                   <Edit className="h-4 w-4 mr-2" />
-                  Edit Client
+                  Client settings
                 </DropdownMenuItem>
                 {client.invitation_status !== 'accepted' && !client.user_id && (
                   <DropdownMenuItem onClick={onInvite}>
@@ -237,6 +238,19 @@ export function ClientProfileSection({
             </div>
           </div>
 
+          {/* Coach Notes */}
+          {client.notes && (
+            <div className="rounded-lg bg-paper border border-line p-3">
+              <div className="flex items-center gap-1.5 mb-1">
+                <StickyNote className="h-3.5 w-3.5 text-ink-4" />
+                <h4 className="text-xs font-semibold text-ink-2">Notes</h4>
+              </div>
+              <p className="text-sm text-ink-3 leading-relaxed whitespace-pre-wrap">
+                {client.notes}
+              </p>
+            </div>
+          )}
+
           {/* AI Insights from Persona */}
           {persona && persona.patterns && (
             <div className="pt-4 border-t border-line ">
@@ -353,16 +367,6 @@ export function ClientProfileSection({
               </h4>
               <p className="text-sm text-ink-3 leading-relaxed">
                 {client.meta_performance_vision}
-              </p>
-            </div>
-          )}
-
-          {/* Notes */}
-          {client.notes && (
-            <div className="pt-4 border-t border-line ">
-              <h4 className="text-sm font-semibold text-ink-2 mb-2">Notes</h4>
-              <p className="text-sm text-ink-3 leading-relaxed whitespace-pre-wrap">
-                {client.notes}
               </p>
             </div>
           )}

--- a/src/app/clients/components/client-card.tsx
+++ b/src/app/clients/components/client-card.tsx
@@ -178,7 +178,7 @@ export default function ClientCard({
                       }}
                     >
                       <Edit className="h-4 w-4 mr-2" />
-                      Edit Client
+                      Client settings
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onClick={e => {

--- a/src/components/clients/client-modal.tsx
+++ b/src/components/clients/client-modal.tsx
@@ -257,7 +257,7 @@ export default function ClientModal({
       <DialogContent className="sm:max-w-[400px] p-0 gap-0 overflow-hidden">
         <DialogHeader className="px-6 pt-6 pb-4">
           <DialogTitle className="text-lg font-semibold text-ink ">
-            {mode === 'create' ? 'New Client' : 'Edit Client'}
+            {mode === 'create' ? 'New Client' : 'Client settings'}
           </DialogTitle>
         </DialogHeader>
 


### PR DESCRIPTION
## What

Two small client-UI polish items (follow-up to the per-client questionnaire settings):

- **Note on the profile card** — the coach's client note now shows in a prominent panel directly under the contact info on the "Client Profile" card (Overview tab), instead of buried at the bottom after persona/stats/vision. Added a `StickyNote` icon.
- **Rename "Edit Client" → "Client settings"** — in the profile-card dropdown, the client-list-card dropdown, and the modal title (create mode still reads "New Client").

## Notes

Frontend-only. The note already rendered conditionally but never appeared because notes wasn't editable until the prior change. `tsc --noEmit` clean; lint-staged (eslint + prettier) passed.