### PR TITLE
Add auto-send Thrill Form toggle to client settings

### DIFF
--- a/src/components/clients/client-modal.tsx
+++ b/src/components/clients/client-modal.tsx
@@ -55,6 +55,7 @@ export default function ClientModal({
     inviteToPortal: false,
     autoSendQuestionnaire: true,
     leadTimeHours: 24,
+    autoSendThrillForm: true,
     notes: '',
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
@@ -71,6 +72,7 @@ export default function ClientModal({
         inviteToPortal: false,
         autoSendQuestionnaire: client?.auto_send_questionnaire ?? true,
         leadTimeHours: client?.questionnaire_lead_time_hours ?? 24,
+        autoSendThrillForm: client?.auto_send_thrill_form ?? true,
         notes: client?.notes || '',
       })
       setErrors({})
@@ -161,6 +163,7 @@ export default function ClientModal({
         notes: formData.notes,
         auto_send_questionnaire: formData.autoSendQuestionnaire,
         questionnaire_lead_time_hours: formData.leadTimeHours,
+        auto_send_thrill_form: formData.autoSendThrillForm,
       }
 
       // If onSubmit is provided, use it; otherwise handle internally
@@ -463,6 +466,27 @@ export default function ClientModal({
                   )}
                 </div>
               )}
+
+              <div className="flex items-center justify-between gap-3 py-3 px-4 bg-paper rounded-lg">
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium text-ink-2">
+                    Auto-send post-session Thrill Form
+                  </span>
+                  <span className="text-xs text-ink-3">
+                    Email the Thrill Form automatically after each session
+                  </span>
+                </div>
+                <Switch
+                  checked={formData.autoSendThrillForm}
+                  onCheckedChange={checked =>
+                    setFormData(prev => ({
+                      ...prev,
+                      autoSendThrillForm: checked,
+                    }))
+                  }
+                  disabled={isLoading}
+                />
+              </div>
 
               <div>
                 <label

--- a/src/services/client-service.ts
+++ b/src/services/client-service.ts
@@ -11,6 +11,7 @@ export interface ClientCreateDto {
   meta_performance_vision?: string
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
+  auto_send_thrill_form?: boolean
 }
 
 // Real-time recognition for the New Client modal.
@@ -36,6 +37,7 @@ export interface ClientUpdateDto {
   meta_performance_vision?: string
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
+  auto_send_thrill_form?: boolean
 }
 
 // Backend response format - matches what the API actually returns
@@ -49,6 +51,7 @@ interface BackendClient {
   meta_performance_vision?: string
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
+  auto_send_thrill_form?: boolean
   created_at: string
   updated_at: string
   has_portal_access?: boolean
@@ -114,6 +117,7 @@ function transformClient(backendClient: BackendClient): Client {
     meta_performance_vision: backendClient.meta_performance_vision,
     auto_send_questionnaire: backendClient.auto_send_questionnaire,
     questionnaire_lead_time_hours: backendClient.questionnaire_lead_time_hours,
+    auto_send_thrill_form: backendClient.auto_send_thrill_form,
     created_at: backendClient.created_at,
     updated_at: backendClient.updated_at,
     is_my_client: backendClient.is_my_client,

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -25,6 +25,7 @@ export interface Client {
   email?: string
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
+  auto_send_thrill_form?: boolean
   created_at: string
   updated_at: string
   user_id?: string


### PR DESCRIPTION
Companion to the backend per-client Thrill Form toggle (`auto_send_thrill_form`).

- Adds `auto_send_thrill_form` to the `Client` type, `ClientCreateDto`/`ClientUpdateDto`/`BackendClient`, and `transformClient`.
- Adds a second Switch — **Auto-send post-session Thrill Form** — to the Client settings modal, next to the pre-session questionnaire toggle (on/off only, no delay field).

Default on, so existing clients are unaffected. `tsc --noEmit` clean.