### PR TITLE
Super-admin Agent Chats oversight page

### DIFF
--- a/src/app/admin/agent-chats/page.tsx
+++ b/src/app/admin/agent-chats/page.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { formatDistanceToNow } from 'date-fns'
+import { MessagesSquare, Search } from 'lucide-react'
+
+import { AgentChatViewerDialog } from '@/components/admin/agent/agent-chat-viewer-dialog'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useAdminAgentChatGroups } from '@/hooks/queries/use-admin-agent-chats'
+import type {
+  AdminAgentChatGroup,
+  AgentChatGroupBy,
+} from '@/services/admin-service'
+
+const TABS: { value: AgentChatGroupBy; label: string; plural: string }[] = [
+  { value: 'coach', label: 'Coaches', plural: 'coaches' },
+  { value: 'client', label: 'Clients', plural: 'clients' },
+  { value: 'admin', label: 'Admins', plural: 'admins' },
+]
+
+export default function AdminAgentChatsPage() {
+  const [activeThreadId, setActiveThreadId] = useState<string | null>(null)
+  const [viewerOpen, setViewerOpen] = useState(false)
+
+  const openThread = (threadId: string) => {
+    setActiveThreadId(threadId)
+    setViewerOpen(true)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold text-ink">
+          <MessagesSquare className="h-6 w-6" />
+          Agent Chats
+        </h1>
+        <p className="mt-1 text-sm text-ink-3">
+          Review every Sidekick agent conversation across coaches, clients, and
+          admins. Read-only — this does not change what each user sees in their
+          own agent.
+        </p>
+      </div>
+
+      <Tabs defaultValue="coach">
+        <TabsList>
+          {TABS.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {TABS.map(tab => (
+          <TabsContent key={tab.value} value={tab.value} className="mt-4">
+            <GroupList
+              groupBy={tab.value}
+              plural={tab.plural}
+              onOpenThread={openThread}
+            />
+          </TabsContent>
+        ))}
+      </Tabs>
+
+      <AgentChatViewerDialog
+        threadId={activeThreadId}
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+      />
+    </div>
+  )
+}
+
+function GroupList({
+  groupBy,
+  plural,
+  onOpenThread,
+}: {
+  groupBy: AgentChatGroupBy
+  plural: string
+  onOpenThread: (threadId: string) => void
+}) {
+  const { data, isLoading, error } = useAdminAgentChatGroups(groupBy)
+  const [search, setSearch] = useState('')
+
+  const groups = useMemo(() => {
+    const all = data?.groups ?? []
+    const query = search.trim().toLowerCase()
+    if (!query) return all
+    return all.filter(
+      group =>
+        group.name.toLowerCase().includes(query) ||
+        (group.email ?? '').toLowerCase().includes(query) ||
+        (group.coach_name ?? '').toLowerCase().includes(query),
+    )
+  }, [data, search])
+
+  if (isLoading) return <GroupListSkeleton />
+
+  if (error) {
+    return (
+      <p className="text-sm text-vermillion">Failed to load agent chats.</p>
+    )
+  }
+
+  if ((data?.groups.length ?? 0) === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-ink-3">
+          No {plural} have any agent chats yet.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-3" />
+        <Input
+          placeholder={`Search ${plural}…`}
+          value={search}
+          onChange={event => setSearch(event.target.value)}
+          className="pl-10"
+        />
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="px-1 text-sm text-ink-3">No matches.</p>
+      ) : (
+        <Accordion type="multiple" className="space-y-2">
+          {groups.map(group => (
+            <GroupRow
+              key={group.key}
+              group={group}
+              onOpenThread={onOpenThread}
+            />
+          ))}
+        </Accordion>
+      )}
+    </div>
+  )
+}
+
+function GroupRow({
+  group,
+  onOpenThread,
+}: {
+  group: AdminAgentChatGroup
+  onOpenThread: (threadId: string) => void
+}) {
+  return (
+    <AccordionItem
+      value={group.key}
+      className="rounded-lg border border-line bg-surface-1 px-4"
+    >
+      <AccordionTrigger className="hover:no-underline">
+        <div className="flex w-full items-center justify-between gap-3 pr-2">
+          <div className="min-w-0 text-left">
+            <div className="truncate font-medium text-ink">{group.name}</div>
+            <div className="truncate text-xs text-ink-3">
+              {group.email}
+              {group.coach_name ? `  ·  Coach: ${group.coach_name}` : ''}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-3">
+            {group.last_activity ? (
+              <span className="hidden text-xs text-ink-3 sm:inline">
+                {formatDistanceToNow(new Date(group.last_activity), {
+                  addSuffix: true,
+                })}
+              </span>
+            ) : null}
+            <Badge variant="secondary">{group.thread_count}</Badge>
+          </div>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent>
+        <ul className="divide-y divide-line border-t border-line">
+          {group.threads.map(thread => (
+            <li key={thread.id}>
+              <button
+                type="button"
+                onClick={() => onOpenThread(thread.id)}
+                className="-mx-2 flex w-full items-center justify-between gap-3 rounded px-2 py-2.5 text-left transition-colors hover:bg-surface-2"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm text-ink">
+                    {thread.title}
+                  </div>
+                  <div className="text-xs text-ink-3">
+                    {thread.message_count} message
+                    {thread.message_count === 1 ? '' : 's'} · {thread.model}
+                  </div>
+                </div>
+                <span className="shrink-0 text-xs text-ink-3">
+                  {formatDistanceToNow(new Date(thread.last_message_at), {
+                    addSuffix: true,
+                  })}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </AccordionContent>
+    </AccordionItem>
+  )
+}
+
+function GroupListSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-10 w-full max-w-md" />
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Skeleton key={index} className="h-16 w-full" />
+      ))}
+    </div>
+  )
+}

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   BookOpen,
   Sparkles,
   GitMerge,
+  MessagesSquare,
 } from 'lucide-react'
 import { useAuth } from '@/contexts/auth-context'
 
@@ -31,6 +32,12 @@ const menuItems = [
     title: 'Sidekick Agent',
     href: '/admin/agent',
     icon: Sparkles,
+    requiredRole: ['super_admin'],
+  },
+  {
+    title: 'Agent Chats',
+    href: '/admin/agent-chats',
+    icon: MessagesSquare,
     requiredRole: ['super_admin'],
   },
   {

--- a/src/components/admin/agent/agent-chat-viewer-dialog.tsx
+++ b/src/components/admin/agent/agent-chat-viewer-dialog.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+/**
+ * Read-only viewer for a single agent chat, used by the super-admin Agent Chats
+ * oversight page. Reuses the exact same <AgentMessage> renderer the live chat
+ * uses (apiScope="admin" → full tool-call cards + charts), so nothing about how a
+ * conversation looks has to be re-implemented here.
+ */
+
+import { format } from 'date-fns'
+
+import { AgentMessage } from '@/components/admin/agent/agent-message'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useAdminAgentChatThread } from '@/hooks/queries/use-admin-agent-chats'
+import type { AdminAgentChatThreadDetail } from '@/services/admin-service'
+
+const SCOPE_LABEL: Record<string, string> = {
+  coach: 'Coach',
+  client: 'Client',
+  admin: 'Admin',
+}
+
+interface Props {
+  threadId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function AgentChatViewerDialog({ threadId, open, onOpenChange }: Props) {
+  // Only fetch while the dialog is open with a selected thread.
+  const {
+    data: thread,
+    isLoading,
+    error,
+  } = useAdminAgentChatThread(open ? threadId : null)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-3xl">
+        <DialogHeader className="border-b border-line px-6 pb-4 pt-6 text-left">
+          <div className="flex items-center gap-2">
+            <DialogTitle className="truncate">
+              {thread?.title ?? 'Conversation'}
+            </DialogTitle>
+            {thread ? (
+              <Badge variant="secondary">
+                {SCOPE_LABEL[thread.scope] ?? thread.scope}
+              </Badge>
+            ) : null}
+          </div>
+          <DialogDescription className="text-xs">
+            {thread ? subtitle(thread) : 'Loading conversation…'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="space-y-4 px-6 py-4">
+            {isLoading ? (
+              <ViewerSkeleton />
+            ) : error ? (
+              <p className="text-sm text-vermillion">
+                Failed to load conversation.
+              </p>
+            ) : thread && thread.messages.length > 0 ? (
+              thread.messages.map(message => (
+                <AgentMessage
+                  key={message.id}
+                  message={message}
+                  apiScope="admin"
+                />
+              ))
+            ) : (
+              <p className="text-sm text-ink-3">
+                No messages in this conversation.
+              </p>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function subtitle(thread: AdminAgentChatThreadDetail): string {
+  const parts: string[] = []
+  if (thread.owner_name) parts.push(thread.owner_name)
+  if (thread.scope === 'client' && thread.coach_name) {
+    parts.push(`Coach: ${thread.coach_name}`)
+  }
+  parts.push(thread.model)
+  parts.push(format(new Date(thread.created_at), 'MMM d, yyyy'))
+  return parts.join('  ·  ')
+}
+
+function ViewerSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-16 w-3/4" />
+      <Skeleton className="ml-auto h-10 w-1/2" />
+      <Skeleton className="h-24 w-4/5" />
+    </div>
+  )
+}

--- a/src/hooks/queries/use-admin-agent-chats.ts
+++ b/src/hooks/queries/use-admin-agent-chats.ts
@@ -1,0 +1,52 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import {
+  adminService,
+  type AgentChatGroupBy,
+  type AdminAgentChatGroupsResponse,
+  type AdminAgentChatThreadDetail,
+} from '@/services/admin-service'
+import { queryKeys } from '@/lib/query-client'
+
+/**
+ * Super-admin oversight: all agent chats grouped by coach / client / admin.
+ * Read-only. Cached for 5 minutes.
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading } = useAdminAgentChatGroups('coach')
+ * ```
+ */
+export function useAdminAgentChatGroups(
+  groupBy: AgentChatGroupBy,
+  options?: Omit<
+    UseQueryOptions<AdminAgentChatGroupsResponse, Error>,
+    'queryKey' | 'queryFn'
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.admin.agentChats.groups(groupBy),
+    queryFn: () => adminService.getAgentChatGroups(groupBy),
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}
+
+/**
+ * Full message history for one thread, for the read-only viewer. Disabled until
+ * a threadId is provided (e.g. when the viewer dialog opens).
+ */
+export function useAdminAgentChatThread(
+  threadId: string | null,
+  options?: Omit<
+    UseQueryOptions<AdminAgentChatThreadDetail, Error>,
+    'queryKey' | 'queryFn'
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.admin.agentChats.thread(threadId ?? ''),
+    queryFn: () => adminService.getAgentChatThread(threadId as string),
+    enabled: !!threadId,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -325,6 +325,15 @@ export const queryKeys = {
       detail: (id: string) =>
         [...queryKeys.admin.agentThreads.all, 'detail', id] as const,
     },
+
+    // Cross-owner agent-chats oversight (grouped by coach/client/admin)
+    agentChats: {
+      all: ['admin', 'agent-chats'] as const,
+      groups: (groupBy: string) =>
+        [...queryKeys.admin.agentChats.all, 'groups', groupBy] as const,
+      thread: (id: string) =>
+        [...queryKeys.admin.agentChats.all, 'thread', id] as const,
+    },
   },
 } as const
 

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/lib/axios-config'
+import type { AgentMessage } from '@/types/agent'
 import type {
   AdminClient,
   AdminClientListResponse,
@@ -63,6 +64,47 @@ export interface ClientAccessMatrix {
     roles: string[]
     is_owner?: boolean
   }[]
+}
+
+// Agent Chats (super-admin oversight) — see backend app/api/v1/admin/agent_chats.py
+export type AgentChatGroupBy = 'coach' | 'client' | 'admin'
+
+export interface AdminAgentChatThreadSummary {
+  id: string
+  title: string
+  model: string
+  message_count: number
+  last_message_at: string
+  created_at: string
+}
+
+export interface AdminAgentChatGroup {
+  key: string
+  name: string
+  email: string | null
+  coach_name: string | null // populated for client groups only (context)
+  thread_count: number
+  last_activity: string | null
+  threads: AdminAgentChatThreadSummary[]
+}
+
+export interface AdminAgentChatGroupsResponse {
+  group_by: AgentChatGroupBy
+  groups: AdminAgentChatGroup[]
+}
+
+export interface AdminAgentChatThreadDetail {
+  id: string
+  title: string
+  model: string
+  last_message_at: string
+  created_at: string
+  // Same {id, role, blocks, metrics?} shape the chat already renders.
+  messages: AgentMessage[]
+  owner_name: string | null
+  scope: AgentChatGroupBy
+  client_name: string | null
+  coach_name: string | null
 }
 
 class AdminService {
@@ -420,6 +462,25 @@ class AdminService {
       target_user_id: targetUserId,
       confirm: true,
     })
+    return response.data
+  }
+
+  // Agent Chats (super-admin oversight, read-only)
+  async getAgentChatGroups(
+    groupBy: AgentChatGroupBy,
+  ): Promise<AdminAgentChatGroupsResponse> {
+    const response = await axiosInstance.get('/admin/agent-chats', {
+      params: { group_by: groupBy },
+    })
+    return response.data
+  }
+
+  async getAgentChatThread(
+    threadId: string,
+  ): Promise<AdminAgentChatThreadDetail> {
+    const response = await axiosInstance.get(
+      `/admin/agent-chats/threads/${threadId}`,
+    )
     return response.data
   }
 }


### PR DESCRIPTION
## What
New **/admin/agent-chats** page (super_admin only) to browse every Sidekick agent conversation, grouped into **Coaches / Clients / Admins** tabs, with a **read-only** conversation viewer.

- Tabs → Accordion of groups → clickable thread rows.
- Viewer dialog reuses the existing `AgentMessage` renderer at `apiScope="admin"` (full tool-call cards + charts) in a Dialog + ScrollArea.
- Adds `admin-service` methods + types (`messages: AgentMessage[]`), `use-admin-agent-chats` query hooks, `queryKeys.admin.agentChats`, and an "Agent Chats" sidebar nav item.

Pairs with backend PR ainovusdev/coach-sidekick-backend#82. Isolation for coaches/clients is unchanged.

## Verification
`tsc --noEmit` clean (only 1 pre-existing unrelated vitest error); backend-backed smoke tests confirmed groups + detail render correctly against prod data.