### PR TITLE
Entity detail drawers + commitments + due dates; questionnaire skip/list mode

### DIFF
--- a/src/app/clients/[clientId]/components/goals-tree-view.tsx
+++ b/src/app/clients/[clientId]/components/goals-tree-view.tsx
@@ -55,6 +55,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { VisionDetailPanel } from '@/components/goals/vision-detail-panel'
+import { OutcomeDetailPanel } from '@/components/sprints/outcome-detail-panel'
+import { SprintDetailPanel } from '@/components/sprints/sprint-detail-panel'
 
 interface GoalsTreeViewProps {
   clientId: string
@@ -306,6 +309,10 @@ export function GoalsTreeView({
   const [selectedNodeType, setSelectedNodeType] = useState<
     'goal' | 'outcome' | 'sprint' | null
   >(null)
+  const [detailNode, setDetailNode] = useState<{
+    type: 'goal' | 'outcome' | 'sprint'
+    data: any
+  } | null>(null)
   const [assigneeFilter, setAssigneeFilter] = useState<
     'all' | 'client' | 'coach'
   >('all')
@@ -449,8 +456,39 @@ export function GoalsTreeView({
   }
 
   const handleNodeClick = (id: string, type: 'goal' | 'outcome' | 'sprint') => {
+    // Filter the commitments kanban (existing behavior)...
     setSelectedNodeId(id)
     setSelectedNodeType(type)
+    // ...and open the detail drawer for the clicked entity.
+    const data =
+      type === 'goal'
+        ? goals.find((g: any) => g.id === id)
+        : type === 'outcome'
+          ? clientTargets.find((t: any) => t.id === id)
+          : allSprints.find((s: any) => s.id === id)
+    if (data) setDetailNode({ type, data })
+  }
+
+  // Commitments associated with a node — reuses the same association rules as
+  // `filteredCommitments` (node scope only; no assignee/status/priority filters).
+  const getCommitmentsForNode = (
+    id: string,
+    type: 'goal' | 'outcome' | 'sprint',
+  ): any[] => {
+    if (type === 'outcome') {
+      return allCommitments.filter((c: any) =>
+        c.target_links?.some((link: any) => link.target_id === id),
+      )
+    }
+    // goal / sprint: via their linked outcomes (exclude unlinked/orphan commitments)
+    const outcomeIds = clientTargets
+      .filter((t: any) =>
+        type === 'goal' ? t.goal_ids?.includes(id) : t.sprint_ids?.includes(id),
+      )
+      .map((t: any) => t.id)
+    return allCommitments.filter((c: any) =>
+      c.target_links?.some((link: any) => outcomeIds.includes(link.target_id)),
+    )
   }
 
   const handleCommitmentUpdate = () => {
@@ -1221,6 +1259,123 @@ export function GoalsTreeView({
           </Card>
         </div>
       </div>
+
+      {/* Read-only detail drawers opened on row click (Vision / Outcome / Sprint) */}
+      {detailNode?.type === 'goal' && (
+        <VisionDetailPanel
+          goal={detailNode.data}
+          linkedOutcomes={clientTargets.filter((t: any) =>
+            (t.goal_ids || []).includes(detailNode.data.id),
+          )}
+          commitments={getCommitmentsForNode(detailNode.data.id, 'goal')}
+          onCommitmentClick={
+            onCommitmentClick
+              ? (c: any) => {
+                  setDetailNode(null)
+                  onCommitmentClick(c)
+                }
+              : undefined
+          }
+          onClose={() => setDetailNode(null)}
+          onEdit={
+            onEditGoal
+              ? () => {
+                  onEditGoal(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+          onDelete={
+            onDeleteGoal
+              ? () => {
+                  onDeleteGoal(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+        />
+      )}
+      {detailNode?.type === 'outcome' && (
+        <OutcomeDetailPanel
+          outcome={detailNode.data}
+          linkedSprints={allSprints.filter((s: any) =>
+            (detailNode.data.sprint_ids || []).includes(s.id),
+          )}
+          commitments={getCommitmentsForNode(detailNode.data.id, 'outcome')}
+          onCommitmentClick={
+            onCommitmentClick
+              ? (c: any) => {
+                  setDetailNode(null)
+                  onCommitmentClick(c)
+                }
+              : undefined
+          }
+          onClose={() => setDetailNode(null)}
+          onEdit={
+            onEditOutcome
+              ? () => {
+                  onEditOutcome(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+          onComplete={
+            onCompleteOutcome
+              ? () => {
+                  onCompleteOutcome(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+          onDelete={
+            onDeleteOutcome
+              ? () => {
+                  onDeleteOutcome(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+        />
+      )}
+      {detailNode?.type === 'sprint' && (
+        <SprintDetailPanel
+          sprint={detailNode.data}
+          commitments={getCommitmentsForNode(detailNode.data.id, 'sprint')}
+          onCommitmentClick={
+            onCommitmentClick
+              ? (c: any) => {
+                  setDetailNode(null)
+                  onCommitmentClick(c)
+                }
+              : undefined
+          }
+          onClose={() => setDetailNode(null)}
+          onEdit={
+            onEditSprint
+              ? () => {
+                  onEditSprint(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+          onComplete={
+            onCompleteSprint
+              ? () => {
+                  onCompleteSprint(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+          onDelete={
+            onDeleteSprint
+              ? () => {
+                  onDeleteSprint(detailNode.data)
+                  setDetailNode(null)
+                }
+              : undefined
+          }
+        />
+      )}
     </div>
   )
 }

--- a/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { useState, useRef, useEffect, useMemo } from 'react'
-import { ArrowLeft, ArrowRight, Check, Loader2 } from 'lucide-react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Loader2,
+  List,
+  Square,
+} from 'lucide-react'
 import Image from 'next/image'
 import { toast } from 'sonner'
 import { QuestionnaireService } from '@/services/questionnaire-service'
@@ -10,6 +17,8 @@ import type {
   QuestionnaireAnswerItem,
   QuestionnaireKind,
 } from '@/types/questionnaire'
+
+type ViewMode = 'step' | 'list'
 
 interface QuestionnaireFlowProps {
   token: string
@@ -93,6 +102,11 @@ export function QuestionnaireFlow({
     return initial
   })
 
+  // Step (Typeform-style, one at a time) is the default; the toggle lets the
+  // user switch to the all-questions list view. Not persisted — always opens
+  // in step mode.
+  const [viewMode, setViewMode] = useState<ViewMode>('step')
+
   // Visible questions update as answers change (conditional skipping).
   const visibleQuestions = useMemo(
     () => questions.filter(q => isQuestionVisible(q, answers)),
@@ -122,7 +136,6 @@ export function QuestionnaireFlow({
   const [direction, setDirection] = useState<'forward' | 'backward'>('forward')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   // Clamp position when conditional skipping changes the visible list length.
   useEffect(() => {
@@ -135,72 +148,67 @@ export function QuestionnaireFlow({
   const currentAnswer = currentQuestion
     ? answers[currentQuestion.index] || ''
     : ''
+  const hasAnswer = currentAnswer.trim().length > 0
   const isFirst = position === 0
   const isLast = position === visibleQuestions.length - 1
+
+  const answeredCount = visibleQuestions.filter(
+    q => (answers[q.index] || '').trim().length > 0,
+  ).length
+
   const progress =
     visibleQuestions.length > 0
-      ? ((position + 1) / visibleQuestions.length) * 100
+      ? viewMode === 'list'
+        ? (answeredCount / visibleQuestions.length) * 100
+        : ((position + 1) / visibleQuestions.length) * 100
       : 0
 
-  // Auto-focus textarea (only relevant for text questions).
-  useEffect(() => {
-    if (
-      currentQuestion?.type !== 'scale' &&
-      currentQuestion?.type !== 'yes_no'
-    ) {
-      const timer = setTimeout(() => {
-        textareaRef.current?.focus()
-      }, 400)
-      return () => clearTimeout(timer)
-    }
-  }, [position, currentQuestion?.type])
-
-  // Auto-resize textarea.
-  useEffect(() => {
-    const textarea = textareaRef.current
-    if (textarea) {
-      textarea.style.height = 'auto'
-      textarea.style.height = `${Math.max(120, textarea.scrollHeight)}px`
-    }
-  }, [currentAnswer])
-
-  const updateAnswer = (value: string) => {
-    if (!currentQuestion) return
-    const updated = { ...answers, [currentQuestion.index]: value }
+  const setAnswerFor = (index: number, value: string) => {
+    const updated = { ...answers, [index]: value }
     setAnswers(updated)
     saveToStorage(token, updated)
   }
 
-  const canAdvance = (() => {
-    if (!currentQuestion) return false
-    if (currentQuestion.optional) return true
-    return currentAnswer.trim().length > 0
-  })()
+  const updateAnswer = (value: string) => {
+    if (!currentQuestion) return
+    setAnswerFor(currentQuestion.index, value)
+  }
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return
+    setIsSubmitting(true)
+    try {
+      // Only submit answers for currently-visible questions; conditional
+      // branches that the user routed around shouldn't carry stale text.
+      // Skipped (blank) questions are simply omitted.
+      const visibleIndexes = new Set(visibleQuestions.map(q => q.index))
+      const allAnswers = questions
+        .filter(q => visibleIndexes.has(q.index))
+        .map(q => ({
+          question_index: q.index,
+          answer: (answers[q.index] || '').trim(),
+        }))
+        .filter(a => a.answer.length > 0)
+
+      await QuestionnaireService.submitAll(token, allAnswers)
+      clearStorage(token)
+      onComplete()
+    } catch {
+      toast.error('Failed to submit. Please try again.')
+      setIsSubmitting(false)
+    }
+  }
+
+  // Keep a ref to the latest submit so the list-mode key listener (subscribed
+  // once per mode) always calls the current-closure version.
+  const submitRef = useRef(handleSubmit)
+  submitRef.current = handleSubmit
 
   const goNext = async () => {
     if (isAnimating || !currentQuestion) return
 
     if (isLast) {
-      setIsSubmitting(true)
-      try {
-        // Only submit answers for currently-visible questions; conditional
-        // branches that the user routed around shouldn't carry stale text.
-        const visibleIndexes = new Set(visibleQuestions.map(q => q.index))
-        const allAnswers = questions
-          .filter(q => visibleIndexes.has(q.index))
-          .map(q => ({
-            question_index: q.index,
-            answer: (answers[q.index] || '').trim(),
-          }))
-          .filter(a => a.answer.length > 0)
-
-        await QuestionnaireService.submitAll(token, allAnswers)
-        clearStorage(token)
-        onComplete()
-      } catch {
-        toast.error('Failed to submit. Please try again.')
-        setIsSubmitting(false)
-      }
+      await handleSubmit()
       return
     }
 
@@ -230,6 +238,19 @@ export function QuestionnaireFlow({
     }
   }
 
+  // In list mode, Cmd/Ctrl+Enter submits the whole form.
+  useEffect(() => {
+    if (viewMode !== 'list') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        submitRef.current()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [viewMode])
+
   const headerCaption =
     kind === 'post_session' ? 'Thrill Form' : 'Pre-Session Questionnaire'
 
@@ -258,134 +279,192 @@ export function QuestionnaireFlow({
         <p className="text-xs uppercase tracking-widest text-ink-4 font-medium">
           {headerCaption}
         </p>
+        <ModeToggle mode={viewMode} onChange={setViewMode} />
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 flex items-center justify-center px-6 py-12">
-        <div className="w-full max-w-2xl">
-          <div
-            className={`transition-all duration-300 ease-out ${
-              isAnimating
-                ? direction === 'forward'
-                  ? '-translate-y-4 opacity-0'
-                  : 'translate-y-4 opacity-0'
-                : 'translate-y-0 opacity-100'
-            }`}
-          >
-            {/* Question Counter */}
+      {viewMode === 'list' ? (
+        <div className="flex-1 flex justify-center px-6 py-12">
+          <div className="w-full max-w-2xl">
+            {/* Answered counter */}
             <div className="mb-8">
               <span className="text-sm text-ink-4 font-medium">
-                {position + 1}{' '}
-                <span className="text-ink-2">/ {visibleQuestions.length}</span>
+                {answeredCount}{' '}
+                <span className="text-ink-2">
+                  of {visibleQuestions.length} answered
+                </span>
               </span>
             </div>
 
-            <h2 className="text-2xl sm:text-3xl font-light text-ink leading-relaxed mb-8">
-              {currentQuestion?.text}
-            </h2>
+            <div className="space-y-10">
+              {visibleQuestions.map((q, i) => (
+                <div key={q.index}>
+                  <div className="flex items-baseline gap-3 mb-4">
+                    <span className="text-sm text-ink-4 font-medium tabular-nums pt-1">
+                      {i + 1}
+                    </span>
+                    <h2 className="text-xl sm:text-2xl font-light text-ink leading-relaxed">
+                      {q.text}
+                    </h2>
+                  </div>
+                  <QuestionInput
+                    question={q}
+                    value={answers[q.index] || ''}
+                    onChange={value => setAnswerFor(q.index, value)}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              ))}
+            </div>
 
-            {/* Answer Input — switches by question type */}
-            {currentQuestion?.type === 'scale' ? (
-              <ScaleInput
-                question={currentQuestion}
-                value={currentAnswer}
-                onChange={updateAnswer}
+            {/* Submit */}
+            <div className="flex justify-end mt-12">
+              <button
+                onClick={handleSubmit}
                 disabled={isSubmitting}
-              />
-            ) : currentQuestion?.type === 'yes_no' ? (
-              <YesNoInput
-                value={currentAnswer}
-                onChange={updateAnswer}
-                disabled={isSubmitting}
-              />
-            ) : (
-              <textarea
-                ref={textareaRef}
-                value={currentAnswer}
-                onChange={e => updateAnswer(e.target.value)}
-                onKeyDown={handleKeyDown}
-                disabled={isSubmitting}
-                placeholder={
-                  currentQuestion?.optional
-                    ? 'Optional — leave blank if you have nothing to add'
-                    : 'Type your answer here...'
-                }
-                className="w-full bg-transparent border-0 border-b-2 border-line focus:border-line text-lg text-ink-2 placeholder-ink-2 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
-                rows={3}
-              />
-            )}
+                className="flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded-lg transition-all bg-ink text-ink-on-dark hover:bg-ink-2 shadow-sm disabled:opacity-70 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Submitting...
+                  </>
+                ) : (
+                  <>
+                    Complete
+                    <Check className="h-4 w-4" />
+                  </>
+                )}
+              </button>
+            </div>
+
+            {/* Keyboard hint */}
+            <p className="text-center text-xs text-ink-2 mt-8">
+              Answer as many as you like — blank questions are skipped. Press{' '}
+              <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
+                ⌘
+              </kbd>{' '}
+              +{' '}
+              <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
+                Enter
+              </kbd>{' '}
+              to submit
+            </p>
           </div>
-
-          {/* Navigation */}
-          <div className="flex items-center justify-between mt-12">
-            <button
-              onClick={goBack}
-              disabled={isFirst || isAnimating}
-              className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-all ${
-                isFirst
-                  ? 'text-ink-2 cursor-not-allowed'
-                  : 'text-ink-3 hover:text-ink hover:bg-surface-3'
-              }`}
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back
-            </button>
-
-            <button
-              onClick={goNext}
-              disabled={!canAdvance || isAnimating || isSubmitting}
-              className={`flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded-lg transition-all ${
-                canAdvance
-                  ? 'bg-ink text-ink-on-dark hover:bg-ink-2 shadow-sm'
-                  : 'bg-surface-3 text-ink-4 cursor-not-allowed'
-              }`}
-            >
-              <span
-                className={isSubmitting ? 'flex items-center gap-2' : 'hidden'}
-              >
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Submitting...
-              </span>
-              <span
-                className={
-                  !isSubmitting && isLast ? 'flex items-center gap-2' : 'hidden'
-                }
-              >
-                Complete
-                <Check className="h-4 w-4" />
-              </span>
-              <span
-                className={
-                  !isSubmitting && !isLast
-                    ? 'flex items-center gap-2'
-                    : 'hidden'
-                }
-              >
-                {currentQuestion?.optional && !currentAnswer.trim()
-                  ? 'Skip'
-                  : 'Next'}
-                <ArrowRight className="h-4 w-4" />
-              </span>
-            </button>
-          </div>
-
-          {/* Keyboard hint — only useful for text inputs */}
-          {currentQuestion?.type !== 'scale' &&
-            currentQuestion?.type !== 'yes_no' && (
-              <p className="text-center text-xs text-ink-2 mt-8">
-                Press{' '}
-                <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
-                  ⌘
-                </kbd>{' '}
-                +{' '}
-                <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
-                  Enter
-                </kbd>{' '}
-                to continue
-              </p>
-            )}
         </div>
-      </div>
+      ) : (
+        <div className="flex-1 flex items-center justify-center px-6 py-12">
+          <div className="w-full max-w-2xl">
+            <div
+              className={`transition-all duration-300 ease-out ${
+                isAnimating
+                  ? direction === 'forward'
+                    ? '-translate-y-4 opacity-0'
+                    : 'translate-y-4 opacity-0'
+                  : 'translate-y-0 opacity-100'
+              }`}
+            >
+              {/* Question Counter */}
+              <div className="mb-8">
+                <span className="text-sm text-ink-4 font-medium">
+                  {position + 1}{' '}
+                  <span className="text-ink-2">
+                    / {visibleQuestions.length}
+                  </span>
+                </span>
+              </div>
+
+              <h2 className="text-2xl sm:text-3xl font-light text-ink leading-relaxed mb-8">
+                {currentQuestion?.text}
+              </h2>
+
+              {/* Answer Input — switches by question type */}
+              {currentQuestion && (
+                <QuestionInput
+                  key={currentQuestion.index}
+                  question={currentQuestion}
+                  value={currentAnswer}
+                  onChange={updateAnswer}
+                  onKeyDown={handleKeyDown}
+                  disabled={isSubmitting}
+                  autoFocus
+                />
+              )}
+            </div>
+
+            {/* Navigation */}
+            <div className="flex items-center justify-between mt-12">
+              <button
+                onClick={goBack}
+                disabled={isFirst || isAnimating}
+                className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-all ${
+                  isFirst
+                    ? 'text-ink-2 cursor-not-allowed'
+                    : 'text-ink-3 hover:text-ink hover:bg-surface-3'
+                }`}
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back
+              </button>
+
+              <button
+                onClick={goNext}
+                disabled={isAnimating || isSubmitting}
+                className={`flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded-lg transition-all ${
+                  hasAnswer
+                    ? 'bg-ink text-ink-on-dark hover:bg-ink-2 shadow-sm'
+                    : 'bg-surface-3 text-ink-3 hover:text-ink'
+                } ${isAnimating || isSubmitting ? 'cursor-not-allowed' : ''}`}
+              >
+                <span
+                  className={
+                    isSubmitting ? 'flex items-center gap-2' : 'hidden'
+                  }
+                >
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Submitting...
+                </span>
+                <span
+                  className={
+                    !isSubmitting && isLast
+                      ? 'flex items-center gap-2'
+                      : 'hidden'
+                  }
+                >
+                  Complete
+                  <Check className="h-4 w-4" />
+                </span>
+                <span
+                  className={
+                    !isSubmitting && !isLast
+                      ? 'flex items-center gap-2'
+                      : 'hidden'
+                  }
+                >
+                  {hasAnswer ? 'Next' : 'Skip'}
+                  <ArrowRight className="h-4 w-4" />
+                </span>
+              </button>
+            </div>
+
+            {/* Keyboard hint — only useful for text inputs */}
+            {currentQuestion?.type !== 'scale' &&
+              currentQuestion?.type !== 'yes_no' && (
+                <p className="text-center text-xs text-ink-2 mt-8">
+                  Press{' '}
+                  <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
+                    ⌘
+                  </kbd>{' '}
+                  +{' '}
+                  <kbd className="px-1.5 py-0.5 bg-surface-3 rounded text-ink-4 font-mono">
+                    Enter
+                  </kbd>{' '}
+                  to continue
+                </p>
+              )}
+          </div>
+        </div>
+      )}
 
       {/* Footer */}
       <div className="pb-6 text-center">
@@ -396,6 +475,139 @@ export function QuestionnaireFlow({
 }
 
 // ---------- Sub-components ----------
+
+interface QuestionInputProps {
+  question: QuestionItem
+  value: string
+  onChange: (value: string) => void
+  onKeyDown?: (e: React.KeyboardEvent) => void
+  disabled?: boolean
+  autoFocus?: boolean
+}
+
+// Renders the correct input for a question's type. Shared by both view modes so
+// the type-switch logic lives in exactly one place.
+function QuestionInput({
+  question,
+  value,
+  onChange,
+  onKeyDown,
+  disabled,
+  autoFocus,
+}: QuestionInputProps) {
+  if (question.type === 'scale') {
+    return (
+      <ScaleInput
+        question={question}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+      />
+    )
+  }
+  if (question.type === 'yes_no') {
+    return <YesNoInput value={value} onChange={onChange} disabled={disabled} />
+  }
+  return (
+    <AutoTextarea
+      value={value}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      placeholder="Type your answer here, or leave blank to skip..."
+    />
+  )
+}
+
+interface AutoTextareaProps {
+  value: string
+  onChange: (value: string) => void
+  onKeyDown?: (e: React.KeyboardEvent) => void
+  disabled?: boolean
+  placeholder?: string
+  autoFocus?: boolean
+}
+
+// Self-managing auto-resize + optional auto-focus textarea. Owns its own ref so
+// any number of instances (e.g. every row in list mode) size independently.
+function AutoTextarea({
+  value,
+  onChange,
+  onKeyDown,
+  disabled,
+  placeholder,
+  autoFocus,
+}: AutoTextareaProps) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-resize to fit content.
+  useEffect(() => {
+    const el = ref.current
+    if (el) {
+      el.style.height = 'auto'
+      el.style.height = `${Math.max(120, el.scrollHeight)}px`
+    }
+  }, [value])
+
+  // Auto-focus (step mode only — list rows pass autoFocus={false}).
+  useEffect(() => {
+    if (!autoFocus) return
+    const timer = setTimeout(() => {
+      ref.current?.focus()
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [autoFocus])
+
+  return (
+    <textarea
+      ref={ref}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
+      disabled={disabled}
+      placeholder={placeholder}
+      className="w-full bg-transparent border-0 border-b-2 border-line focus:border-line text-lg text-ink-2 placeholder-ink-2 resize-none outline-none pb-3 transition-colors duration-200 min-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
+      rows={3}
+    />
+  )
+}
+
+interface ModeToggleProps {
+  mode: ViewMode
+  onChange: (mode: ViewMode) => void
+}
+
+// Segmented Step/List control shown in the header.
+function ModeToggle({ mode, onChange }: ModeToggleProps) {
+  const options = [
+    { value: 'step' as const, label: 'Step', Icon: Square },
+    { value: 'list' as const, label: 'List', Icon: List },
+  ]
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg bg-surface-3 p-1">
+      {options.map(({ value, label, Icon }) => {
+        const isActive = mode === value
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onChange(value)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
+              isActive
+                ? 'bg-ink text-ink-on-dark shadow-sm'
+                : 'text-ink-3 hover:text-ink'
+            }`}
+            aria-pressed={isActive}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
 interface ScaleInputProps {
   question: QuestionItem

--- a/src/components/goals/goal-form-modal.tsx
+++ b/src/components/goals/goal-form-modal.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { DueDateField } from '@/components/ui/due-date-field'
 import { GoalService, GoalCreate, Goal } from '@/services/goal-service'
 import { toast } from 'sonner'
 import { useEffect } from 'react'
@@ -44,6 +45,7 @@ export function GoalFormModal({
     title: '',
     description: '',
     category: 'career',
+    target_date: null as string | null,
     status: 'active',
   })
 
@@ -54,6 +56,7 @@ export function GoalFormModal({
         title: goal.title,
         description: goal.description || '',
         category: goal.category,
+        target_date: goal.target_date ?? null,
         status: goal.status,
       })
     } else if (open && mode === 'create') {
@@ -62,6 +65,7 @@ export function GoalFormModal({
         title: '',
         description: '',
         category: 'career',
+        target_date: null,
         status: 'active',
       })
     }
@@ -87,6 +91,7 @@ export function GoalFormModal({
           title: formData.title,
           description: formData.description || undefined,
           category: formData.category,
+          target_date: formData.target_date ?? null,
           status: formData.status,
         }
 
@@ -111,6 +116,7 @@ export function GoalFormModal({
           title: formData.title,
           description: formData.description || undefined,
           category: formData.category,
+          target_date: formData.target_date ?? null,
           status: formData.status,
         }
 
@@ -122,7 +128,6 @@ export function GoalFormModal({
           updated_at: new Date().toISOString(),
           created_by: '',
           progress: 0,
-          target_date: null,
         }
 
         queryClient.setQueryData(
@@ -215,6 +220,14 @@ export function GoalFormModal({
                 rows={3}
               />
             </div>
+
+            <DueDateField
+              id="vision-due-date"
+              value={formData.target_date}
+              onChange={value =>
+                setFormData({ ...formData, target_date: value })
+              }
+            />
 
             <div className="space-y-3">
               <Label>Category</Label>

--- a/src/components/goals/vision-detail-panel.tsx
+++ b/src/components/goals/vision-detail-panel.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+/**
+ * VisionDetailPanel — read-only detail drawer for a Vision (backend `goal`).
+ * Opened by clicking a Vision row on the goals tree board. Editing/deleting is
+ * delegated to the existing Vision form modal / confirm dialog via the passed
+ * handlers (see plan: no inline editing).
+ */
+
+import { Target, Zap } from 'lucide-react'
+import { Progress } from '@/components/ui/progress'
+import {
+  DetailSidePanel,
+  DetailSection,
+  DetailRow,
+  StatusBadge,
+  PanelActions,
+  EmptyHint,
+  LinkedItem,
+  CommitmentsSection,
+} from '@/components/ui/detail-side-panel'
+import { formatDateOnly } from '@/lib/date-utils'
+import type { Goal } from '@/services/goal-service'
+import type { Target as OutcomeTarget } from '@/types/sprint'
+
+interface VisionDetailPanelProps {
+  goal: Goal
+  linkedOutcomes: OutcomeTarget[]
+  commitments: any[]
+  onClose: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+  onCommitmentClick?: (commitment: any) => void
+}
+
+export function VisionDetailPanel({
+  goal,
+  linkedOutcomes,
+  commitments,
+  onClose,
+  onEdit,
+  onDelete,
+  onCommitmentClick,
+}: VisionDetailPanelProps) {
+  return (
+    <DetailSidePanel
+      onClose={onClose}
+      eyebrow="Vision"
+      icon={<Target className="h-5 w-5 text-ink-3" />}
+      title={goal.title}
+      statusBadge={<StatusBadge status={goal.status} />}
+      actions={
+        <PanelActions
+          onEdit={onEdit}
+          onDelete={onDelete}
+          deleteLabel="Delete Vision"
+        />
+      }
+    >
+      <DetailSection title="Details">
+        <DetailRow label="Category">
+          <span className="capitalize">{goal.category || '—'}</span>
+        </DetailRow>
+        <DetailRow label="Due date">
+          {goal.target_date ? formatDateOnly(goal.target_date) : '—'}
+        </DetailRow>
+        <DetailRow label="Progress">{goal.progress ?? 0}%</DetailRow>
+      </DetailSection>
+
+      <div className="space-y-1.5">
+        <Progress value={goal.progress ?? 0} className="h-2" />
+      </div>
+
+      {goal.description && (
+        <DetailSection title="Description">
+          <p className="text-sm text-ink-2 whitespace-pre-wrap break-words">
+            {goal.description}
+          </p>
+        </DetailSection>
+      )}
+
+      <DetailSection
+        title={`Meta Performance Outcomes (${linkedOutcomes.length})`}
+      >
+        {linkedOutcomes.length === 0 ? (
+          <EmptyHint>No outcomes linked to this vision yet.</EmptyHint>
+        ) : (
+          <div className="space-y-1.5">
+            {linkedOutcomes.map(outcome => (
+              <LinkedItem
+                key={outcome.id}
+                icon={<Zap className="h-4 w-4 text-ds-accent" />}
+                title={outcome.title}
+                status={outcome.status}
+              />
+            ))}
+          </div>
+        )}
+      </DetailSection>
+
+      <CommitmentsSection
+        commitments={commitments}
+        onCommitmentClick={onCommitmentClick}
+      />
+
+      <DetailSection title="Metadata">
+        <DetailRow label="Created">{formatDateOnly(goal.created_at)}</DetailRow>
+        <DetailRow label="Last updated">
+          {formatDateOnly(goal.updated_at)}
+        </DetailRow>
+      </DetailSection>
+    </DetailSidePanel>
+  )
+}

--- a/src/components/sprints/outcome-detail-panel.tsx
+++ b/src/components/sprints/outcome-detail-panel.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+/**
+ * OutcomeDetailPanel — read-only detail drawer for a Meta Performance Outcome
+ * (backend `target`). Opened by clicking an outcome row on the goals tree
+ * board. Edit / Complete / Delete are delegated to the existing outcome form
+ * modal + handlers (no inline editing).
+ */
+
+import { Zap, Target as TargetIcon, Calendar } from 'lucide-react'
+import { Progress } from '@/components/ui/progress'
+import {
+  DetailSidePanel,
+  DetailSection,
+  DetailRow,
+  StatusBadge,
+  PanelActions,
+  EmptyHint,
+  LinkedItem,
+  CommitmentsSection,
+} from '@/components/ui/detail-side-panel'
+import { formatDateOnly } from '@/lib/date-utils'
+import type { Target, Sprint } from '@/types/sprint'
+
+interface OutcomeDetailPanelProps {
+  outcome: Target
+  linkedSprints: Sprint[]
+  commitments: any[]
+  onClose: () => void
+  onEdit?: () => void
+  onComplete?: () => void
+  onDelete?: () => void
+  onCommitmentClick?: (commitment: any) => void
+}
+
+export function OutcomeDetailPanel({
+  outcome,
+  linkedSprints,
+  commitments,
+  onClose,
+  onEdit,
+  onComplete,
+  onDelete,
+  onCommitmentClick,
+}: OutcomeDetailPanelProps) {
+  const visionTitles = outcome.goal_titles || []
+  const total = outcome.commitment_count ?? 0
+  const done = outcome.completed_commitment_count ?? 0
+
+  return (
+    <DetailSidePanel
+      onClose={onClose}
+      eyebrow="Meta Performance Outcome"
+      icon={<Zap className="h-5 w-5 text-ds-accent" />}
+      title={outcome.title}
+      statusBadge={<StatusBadge status={outcome.status} />}
+      actions={
+        <PanelActions
+          onEdit={onEdit}
+          onComplete={onComplete}
+          canComplete={outcome.status !== 'completed'}
+          onDelete={onDelete}
+          deleteLabel="Delete Outcome"
+        />
+      }
+    >
+      <DetailSection title="Details">
+        <DetailRow label="Due date">
+          {outcome.target_date ? formatDateOnly(outcome.target_date) : '—'}
+        </DetailRow>
+        <DetailRow label="Progress">
+          {outcome.progress_percentage ?? 0}%
+        </DetailRow>
+        <DetailRow label="Commitments">
+          {done} of {total} complete
+        </DetailRow>
+      </DetailSection>
+
+      <div className="space-y-1.5">
+        <Progress value={outcome.progress_percentage ?? 0} className="h-2" />
+      </div>
+
+      {outcome.description && (
+        <DetailSection title="Description">
+          <p className="text-sm text-ink-2 whitespace-pre-wrap break-words">
+            {outcome.description}
+          </p>
+        </DetailSection>
+      )}
+
+      <DetailSection title={`Visions (${visionTitles.length})`}>
+        {visionTitles.length === 0 ? (
+          <EmptyHint>Not linked to a vision.</EmptyHint>
+        ) : (
+          <div className="space-y-1.5">
+            {visionTitles.map((title, i) => (
+              <LinkedItem
+                key={`${title}-${i}`}
+                icon={<TargetIcon className="h-4 w-4 text-ink-3" />}
+                title={title}
+              />
+            ))}
+          </div>
+        )}
+      </DetailSection>
+
+      <DetailSection title={`Sprints (${linkedSprints.length})`}>
+        {linkedSprints.length === 0 ? (
+          <EmptyHint>No sprints linked to this outcome yet.</EmptyHint>
+        ) : (
+          <div className="space-y-1.5">
+            {linkedSprints.map(sprint => (
+              <LinkedItem
+                key={sprint.id}
+                icon={<Calendar className="h-4 w-4 text-forest" />}
+                title={sprint.title}
+                status={sprint.status}
+              />
+            ))}
+          </div>
+        )}
+      </DetailSection>
+
+      <CommitmentsSection
+        commitments={commitments}
+        onCommitmentClick={onCommitmentClick}
+      />
+
+      <DetailSection title="Metadata">
+        <DetailRow label="Created">
+          {formatDateOnly(outcome.created_at)}
+        </DetailRow>
+        <DetailRow label="Last updated">
+          {formatDateOnly(outcome.updated_at)}
+        </DetailRow>
+      </DetailSection>
+    </DetailSidePanel>
+  )
+}

--- a/src/components/sprints/sprint-detail-panel.tsx
+++ b/src/components/sprints/sprint-detail-panel.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+/**
+ * SprintDetailPanel — read-only detail drawer for a Sprint. Opened by clicking
+ * a sprint row on the goals tree board. Base fields render immediately from the
+ * row's loaded object; linked outcomes are hydrated via the existing
+ * `useSprint` (SprintDetail.targets). Edit / Complete / Delete delegate to the
+ * existing sprint form modal + handlers (no inline editing).
+ */
+
+import { Calendar, Zap } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import {
+  DetailSidePanel,
+  DetailSection,
+  DetailRow,
+  StatusBadge,
+  PanelActions,
+  EmptyHint,
+  LinkedItem,
+  CommitmentsSection,
+} from '@/components/ui/detail-side-panel'
+import { useSprint } from '@/hooks/queries/use-sprints'
+import { formatDateOnly } from '@/lib/date-utils'
+import { cn } from '@/lib/utils'
+import type { Sprint } from '@/types/sprint'
+
+interface SprintDetailPanelProps {
+  sprint: Sprint
+  commitments: any[]
+  onClose: () => void
+  onEdit?: () => void
+  onComplete?: () => void
+  onDelete?: () => void
+  onCommitmentClick?: (commitment: any) => void
+}
+
+export function SprintDetailPanel({
+  sprint,
+  commitments,
+  onClose,
+  onEdit,
+  onComplete,
+  onDelete,
+  onCommitmentClick,
+}: SprintDetailPanelProps) {
+  // Hydrate linked outcomes; base fields come from the passed row object.
+  const { data: detail } = useSprint(sprint.id)
+  const outcomes = detail?.targets ?? []
+  const progress =
+    detail?.progress_percentage ?? sprint.progress_percentage ?? 0
+
+  return (
+    <DetailSidePanel
+      onClose={onClose}
+      eyebrow={`Sprint${sprint.sprint_number ? ` #${sprint.sprint_number}` : ''}`}
+      icon={<Calendar className="h-5 w-5 text-forest" />}
+      title={sprint.title}
+      statusBadge={
+        <div className="flex items-center gap-2">
+          <StatusBadge status={sprint.status} />
+          {sprint.is_current && (
+            <Badge
+              variant="outline"
+              className={cn(
+                'text-xs',
+                'bg-forest-bg text-forest border-forest',
+              )}
+            >
+              Current
+            </Badge>
+          )}
+        </div>
+      }
+      actions={
+        <PanelActions
+          onEdit={onEdit}
+          onComplete={onComplete}
+          canComplete={sprint.status !== 'completed'}
+          onDelete={onDelete}
+          deleteLabel="Delete Sprint"
+        />
+      }
+    >
+      <DetailSection title="Details">
+        <DetailRow label="Timeframe">
+          {formatDateOnly(sprint.start_date)} –{' '}
+          {formatDateOnly(sprint.end_date)}
+        </DetailRow>
+        {sprint.duration_weeks != null && (
+          <DetailRow label="Duration">
+            {sprint.duration_weeks} week{sprint.duration_weeks === 1 ? '' : 's'}
+          </DetailRow>
+        )}
+        <DetailRow label="Progress">{progress}%</DetailRow>
+      </DetailSection>
+
+      <div className="space-y-1.5">
+        <Progress value={progress} className="h-2" />
+      </div>
+
+      {sprint.description && (
+        <DetailSection title="Description">
+          <p className="text-sm text-ink-2 whitespace-pre-wrap break-words">
+            {sprint.description}
+          </p>
+        </DetailSection>
+      )}
+
+      <DetailSection title={`Meta Performance Outcomes (${outcomes.length})`}>
+        {outcomes.length === 0 ? (
+          <EmptyHint>No outcomes linked to this sprint yet.</EmptyHint>
+        ) : (
+          <div className="space-y-1.5">
+            {outcomes.map(outcome => (
+              <LinkedItem
+                key={outcome.id}
+                icon={<Zap className="h-4 w-4 text-ds-accent" />}
+                title={outcome.title}
+                status={outcome.status}
+              />
+            ))}
+          </div>
+        )}
+      </DetailSection>
+
+      <CommitmentsSection
+        commitments={commitments}
+        onCommitmentClick={onCommitmentClick}
+      />
+
+      <DetailSection title="Metadata">
+        <DetailRow label="Created">
+          {formatDateOnly(sprint.created_at)}
+        </DetailRow>
+        <DetailRow label="Last updated">
+          {formatDateOnly(sprint.updated_at)}
+        </DetailRow>
+      </DetailSection>
+    </DetailSidePanel>
+  )
+}

--- a/src/components/sprints/target-form-modal.tsx
+++ b/src/components/sprints/target-form-modal.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { DueDateField } from '@/components/ui/due-date-field'
 import { Check } from 'lucide-react'
 import { TargetService } from '@/services/target-service'
 import { TargetCreate, TargetUpdate } from '@/types/sprint'
@@ -48,6 +49,7 @@ export function TargetFormModal({
   const [formData, setFormData] = useState({
     title: '',
     description: '',
+    target_date: null as string | null,
     status: 'active' as const,
   })
 
@@ -60,6 +62,7 @@ export function TargetFormModal({
         setFormData({
           title: target.title || '',
           description: target.description || '',
+          target_date: target.target_date ?? null,
           status: target.status || 'active',
         })
         setSelectedGoalIds(target.goal_ids || [])
@@ -67,6 +70,7 @@ export function TargetFormModal({
         setFormData({
           title: '',
           description: '',
+          target_date: null,
           status: 'active',
         })
         setSelectedGoalIds([])
@@ -89,6 +93,7 @@ export function TargetFormModal({
         const updateData: TargetUpdate = {
           title: formData.title,
           description: formData.description || undefined,
+          target_date: formData.target_date ?? null,
           status: formData.status,
           goal_ids: selectedGoalIds,
         }
@@ -113,6 +118,7 @@ export function TargetFormModal({
           sprint_ids: sprintId ? [sprintId] : [],
           title: formData.title,
           description: formData.description || undefined,
+          target_date: formData.target_date ?? null,
           status: formData.status,
         }
 
@@ -273,6 +279,14 @@ export function TargetFormModal({
                 rows={3}
               />
             </div>
+
+            <DueDateField
+              id="outcome-due-date"
+              value={formData.target_date}
+              onChange={value =>
+                setFormData({ ...formData, target_date: value })
+              }
+            />
           </div>
 
           <DialogFooter>

--- a/src/components/ui/detail-side-panel.tsx
+++ b/src/components/ui/detail-side-panel.tsx
@@ -1,0 +1,326 @@
+'use client'
+
+/**
+ * DetailSidePanel — a lightweight, read-only right-slide drawer.
+ *
+ * Mirrors the shell of `commitment-detail-panel.tsx` (fixed backdrop + right
+ * panel + Escape-to-close + ScrollArea body) but is content-agnostic and
+ * read-only. Used by the Vision / Meta Performance Outcome / Sprint detail
+ * panels on the goals tree board. Editing is delegated to the existing form
+ * modals via the header actions, so this shell renders no inputs.
+ */
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { X, Edit2, MoreVertical, CheckCircle2, Trash2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatDateOnly } from '@/lib/date-utils'
+
+interface DetailSidePanelProps {
+  onClose: () => void
+  title: string
+  eyebrow?: string
+  icon?: React.ReactNode
+  statusBadge?: React.ReactNode
+  actions?: React.ReactNode
+  children: React.ReactNode
+}
+
+export function DetailSidePanel({
+  onClose,
+  title,
+  eyebrow,
+  icon,
+  statusBadge,
+  actions,
+  children,
+}: DetailSidePanelProps) {
+  // Mount off-screen then flip on the next frame so the drawer slides in.
+  const [entered, setEntered] = useState(false)
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setEntered(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return (
+    <>
+      {/* Backdrop overlay */}
+      <div
+        className="fixed inset-0 z-[60] bg-overlay animate-in fade-in duration-200"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        className={cn(
+          'fixed right-0 top-0 h-full w-full md:w-[600px] z-[70] bg-surface-1 border-l border-line shadow-2xl',
+          'transition-transform duration-300 ease-in-out',
+          entered ? 'translate-x-0' : 'translate-x-full',
+        )}
+      >
+        <div className="h-full flex flex-col">
+          {/* Header */}
+          <div className="flex items-start gap-3 p-6 pb-4 border-b border-line">
+            {icon && <div className="mt-1 shrink-0">{icon}</div>}
+            <div className="flex-1 min-w-0">
+              {eyebrow && (
+                <div className="text-xs font-semibold uppercase tracking-wide text-ink-4 mb-1">
+                  {eyebrow}
+                </div>
+              )}
+              <h2 className="text-xl font-bold text-ink break-words">
+                {title}
+              </h2>
+              {statusBadge && <div className="mt-2">{statusBadge}</div>}
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              {actions}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+                className="h-8 w-8 p-0"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Body */}
+          <ScrollArea className="flex-1">
+            <div className="p-6 space-y-6">{children}</div>
+          </ScrollArea>
+        </div>
+      </div>
+    </>
+  )
+}
+
+// === Presentational helpers (shared by all three detail panels) ===
+
+export function DetailSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-ink-4">
+        {title}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+export function DetailRow({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-1.5 border-b border-line/60 last:border-0">
+      <span className="text-sm text-ink-3 shrink-0">{label}</span>
+      <span className="text-sm text-ink text-right break-words min-w-0">
+        {children}
+      </span>
+    </div>
+  )
+}
+
+export function StatusBadge({ status }: { status?: string }) {
+  if (!status) return null
+  const cls =
+    status === 'active'
+      ? 'bg-forest-bg text-forest border-forest'
+      : status === 'completed'
+        ? 'bg-ds-accent-bg text-ds-accent border-ds-accent'
+        : status === 'paused' ||
+            status === 'planning' ||
+            status === 'in_progress'
+          ? 'bg-amber-token-bg text-amber-token border-amber-token'
+          : 'bg-surface-3 text-ink-2 border-line'
+  const label = status.replace(/_/g, ' ')
+  return (
+    <Badge variant="outline" className={cn('text-xs capitalize', cls)}>
+      {label}
+    </Badge>
+  )
+}
+
+export function PanelActions({
+  onEdit,
+  onComplete,
+  onDelete,
+  canComplete,
+  deleteLabel,
+}: {
+  onEdit?: () => void
+  onComplete?: () => void
+  onDelete?: () => void
+  canComplete?: boolean
+  deleteLabel?: string
+}) {
+  const showMenu = !!onDelete || (!!onComplete && canComplete)
+  return (
+    <>
+      {onEdit && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onEdit}
+          className="h-8 gap-1.5"
+        >
+          <Edit2 className="h-3.5 w-3.5" />
+          Edit
+        </Button>
+      )}
+      {showMenu && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="z-[80]">
+            {onComplete && canComplete && (
+              <DropdownMenuItem
+                onClick={onComplete}
+                className="text-forest focus:text-forest"
+              >
+                <CheckCircle2 className="h-4 w-4 mr-2" />
+                Mark Complete
+              </DropdownMenuItem>
+            )}
+            {onDelete && (
+              <DropdownMenuItem
+                onClick={onDelete}
+                className="text-vermillion focus:text-vermillion"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                {deleteLabel || 'Delete'}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </>
+  )
+}
+
+// A muted empty-state line for "no linked items" sections.
+export function EmptyHint({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-ink-4 italic">{children}</p>
+}
+
+// A compact linked-entity row (icon + title + optional status badge).
+export function LinkedItem({
+  icon,
+  title,
+  status,
+}: {
+  icon: React.ReactNode
+  title: string
+  status?: string
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1.5 px-3 rounded-lg bg-surface-3">
+      <div className="shrink-0">{icon}</div>
+      <span className="flex-1 text-sm text-ink break-words min-w-0">
+        {title}
+      </span>
+      {status && <StatusBadge status={status} />}
+    </div>
+  )
+}
+
+// A clickable commitment row — title + optional coach tag / due date / status.
+export function CommitmentRow({
+  title,
+  status,
+  dueDate,
+  isCoach,
+  onClick,
+}: {
+  title: string
+  status?: string
+  dueDate?: string
+  isCoach?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-2 py-2 px-3 rounded-lg border border-line hover:bg-surface-3 text-left transition-colors"
+    >
+      <span className="flex-1 text-sm text-ink break-words min-w-0">
+        {title}
+      </span>
+      {isCoach && (
+        <span className="text-[10px] font-medium uppercase tracking-wide text-ink-4 shrink-0">
+          Coach
+        </span>
+      )}
+      {dueDate && (
+        <span className="text-xs text-ink-4 shrink-0">{dueDate}</span>
+      )}
+      {status && <StatusBadge status={status} />}
+    </button>
+  )
+}
+
+// The "Commitments (N)" section shared by all three entity detail panels.
+export function CommitmentsSection({
+  commitments,
+  onCommitmentClick,
+}: {
+  commitments: any[]
+  onCommitmentClick?: (commitment: any) => void
+}) {
+  return (
+    <DetailSection title={`Commitments (${commitments.length})`}>
+      {commitments.length === 0 ? (
+        <EmptyHint>No commitments linked yet.</EmptyHint>
+      ) : (
+        <div className="space-y-1.5">
+          {commitments.map(c => (
+            <CommitmentRow
+              key={c.id}
+              title={c.title}
+              status={c.status}
+              dueDate={
+                c.target_date ? formatDateOnly(c.target_date) : undefined
+              }
+              isCoach={!!c.is_coach_commitment}
+              onClick={
+                onCommitmentClick ? () => onCommitmentClick(c) : undefined
+              }
+            />
+          ))}
+        </div>
+      )}
+    </DetailSection>
+  )
+}

--- a/src/components/ui/due-date-field.tsx
+++ b/src/components/ui/due-date-field.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+/**
+ * DueDateField — a small optional, clearable date picker used by the Vision and
+ * Outcome forms. Stores a date-only `yyyy-MM-dd` string (or null), matching the
+ * codebase convention for `target_date` (see `src/lib/date-utils.ts`). Mirrors
+ * the commitment detail panel's "Due Date" picker.
+ */
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Calendar as CalendarIcon, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { parseDateForPicker, formatDateOnly } from '@/lib/date-utils'
+
+interface DueDateFieldProps {
+  value?: string | null
+  onChange: (value: string | null) => void
+  label?: string
+  id?: string
+}
+
+export function DueDateField({
+  value,
+  onChange,
+  label = 'Due date',
+  id = 'due-date',
+}: DueDateFieldProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="flex items-center gap-2">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              id={id}
+              type="button"
+              variant="outline"
+              className={cn(
+                'flex-1 justify-start text-left font-normal',
+                !value && 'text-ink-3',
+              )}
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {value
+                ? formatDateOnly(value, 'MMM d, yyyy')
+                : 'Set a date (optional)'}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={parseDateForPicker(value ?? undefined)}
+              onSelect={date => {
+                onChange(date ? date.toISOString().split('T')[0] : null)
+                setOpen(false)
+              }}
+              initialFocus
+            />
+          </PopoverContent>
+        </Popover>
+        {value && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-9 w-9 p-0 text-ink-3"
+            onClick={() => onChange(null)}
+            aria-label="Clear due date"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/services/goal-service.ts
+++ b/src/services/goal-service.ts
@@ -26,6 +26,7 @@ export interface GoalCreate {
   title: string
   description?: string
   category?: string
+  target_date?: string | null
   status?: string
 }
 

--- a/src/types/sprint.ts
+++ b/src/types/sprint.ts
@@ -52,6 +52,7 @@ export interface SprintDetail extends Sprint {
 export interface TargetBase {
   title: string
   description?: string
+  target_date?: string | null // Optional due date
 }
 
 export interface TargetCreate extends TargetBase {
@@ -64,6 +65,7 @@ export interface TargetCreate extends TargetBase {
 export interface TargetUpdate {
   title?: string
   description?: string
+  target_date?: string | null // Update due date
   status?: TargetStatus
   progress_percentage?: number
   order_index?: number


### PR DESCRIPTION
## Summary
Two features on the frontend.

### Vision & Progress board
- Clicking a **Vision / Meta Performance Outcome / Sprint** row opens a read-only **detail drawer** (parity with commitments); the click also keeps the existing kanban filter.
- Edit / Complete / Delete in the drawer delegate to the existing form modals + handlers (no inline editing).
- Each drawer lists the **associated commitments**, clickable to drill into the commitment detail drawer.
- Optional **due date** on Visions and Outcomes (shared `DueDateField`, date-only), shown in the drawers.
- Works in both the coach portal and the client portal (shared `GoalsTreeView`).

### Questionnaire / Thrill Form
- **Skip any question** + a new **List view mode** alongside the step-by-step flow.

## Notes
- Pairs with backend PR ainovusdev/coach-sidekick-backend#83 (due-date columns; migration already applied to prod).

## Verification
- `tsc --noEmit` + `eslint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)