### PR TITLE
Add Download button to session recording player

### DIFF
--- a/src/app/client-portal/sessions/[id]/page.tsx
+++ b/src/app/client-portal/sessions/[id]/page.tsx
@@ -236,6 +236,7 @@ export default function ClientSessionDetailPage() {
               onRefresh={async () => {
                 await refetch()
               }}
+              getDownloadUrl={async () => session.video_download_url ?? null}
             />
           </TabsContent>
         )}

--- a/src/components/sessions/video-player.tsx
+++ b/src/components/sessions/video-player.tsx
@@ -11,7 +11,15 @@ import React, {
 } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Video, RefreshCw, AlertCircle, Loader2, VideoOff } from 'lucide-react'
+import {
+  Video,
+  RefreshCw,
+  AlertCircle,
+  Loader2,
+  VideoOff,
+  Download,
+} from 'lucide-react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 
 export type VideoPlayerHandle = {
@@ -45,6 +53,12 @@ interface VideoPlayerProps {
    * with no Refresh button — clicking it would just 404 again.
    */
   videoUnavailable?: boolean
+  /**
+   * When provided, renders a Download button that resolves a fresh, download-
+   * flavored URL (server sets Content-Disposition: attachment) and saves the
+   * file. Omit to hide the button (watch-only).
+   */
+  getDownloadUrl?: () => Promise<string | null>
 }
 
 const TIME_UPDATE_INTERVAL_MS = 250
@@ -72,12 +86,14 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       markers,
       onMarkerClick,
       videoUnavailable = false,
+      getDownloadUrl,
     },
     ref,
   ) {
     const [error, setError] = useState(false)
     const [loading, setLoading] = useState(true)
     const [refreshing, setRefreshing] = useState(false)
+    const [downloading, setDownloading] = useState(false)
     const [duration, setDuration] = useState(0)
     const videoRef = useRef<HTMLVideoElement>(null)
     const lastEmittedRef = useRef<number>(0)
@@ -156,6 +172,32 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         setRefreshing(false)
       }
     }, [onRefresh])
+
+    const handleDownload = useCallback(async () => {
+      if (!getDownloadUrl) return
+      setDownloading(true)
+      try {
+        const url = await getDownloadUrl()
+        if (!url) {
+          toast.error('Download link is not available for this recording.')
+          return
+        }
+        // The URL carries Content-Disposition: attachment, so a plain anchor
+        // click saves the file (streamed to disk) instead of navigating.
+        const a = document.createElement('a')
+        a.href = url
+        a.download = ''
+        a.rel = 'noopener'
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+      } catch (err) {
+        console.error('Failed to download video:', err)
+        toast.error('Could not download the recording. Please try again.')
+      } finally {
+        setDownloading(false)
+      }
+    }, [getDownloadUrl])
 
     // Reset emit timer when video URL changes
     useEffect(() => {
@@ -278,19 +320,37 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               <Video className="h-5 w-5" />
               Session Recording
             </CardTitle>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleRefresh}
-              disabled={refreshing}
-              className="border-line-strong hover:bg-paper"
-            >
-              {refreshing ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <RefreshCw className="h-4 w-4" />
+            <div className="flex items-center gap-2">
+              {getDownloadUrl && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDownload}
+                  disabled={downloading}
+                  className="border-line-strong hover:bg-paper"
+                >
+                  {downloading ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Download className="h-4 w-4 mr-2" />
+                  )}
+                  Download
+                </Button>
               )}
-            </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRefresh}
+                disabled={refreshing}
+                className="border-line-strong hover:bg-paper"
+              >
+                {refreshing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/components/sessions/video-review-panel.tsx
+++ b/src/components/sessions/video-review-panel.tsx
@@ -32,6 +32,7 @@ import {
   useUpdateVideoComment,
 } from '@/hooks/mutations/use-video-comment-mutations'
 import { useVideoReviewShortcuts } from '@/hooks/use-video-review-shortcuts'
+import { SessionService } from '@/services/session-service'
 import { cn } from '@/lib/utils'
 
 interface VideoReviewPanelProps {
@@ -187,6 +188,9 @@ export function VideoReviewPanel({
         videoUrl={videoUrl}
         videoUnavailable={videoUnavailable}
         onRefresh={onRefreshVideoUrl ?? (async () => undefined)}
+        getDownloadUrl={async () =>
+          (await SessionService.getVideoDownloadUrl(sessionId)).download_url
+        }
         onTimeUpdate={t => {
           setCurrentTime(t)
           isPlayingRef.current = !!playerRef.current?.isPlaying()

--- a/src/hooks/queries/use-client-sessions.ts
+++ b/src/hooks/queries/use-client-sessions.ts
@@ -66,6 +66,7 @@ export interface ClientSessionDetailData {
       email: string
     } | null
     video_url?: string | null
+    video_download_url?: string | null
     video_unavailable?: boolean
     recording_started_at?: string | null
   }

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -248,6 +248,14 @@ export class SessionService {
     return await ApiClient.get(`${BACKEND_URL}/sessions/${sessionId}/video-url`)
   }
 
+  static async getVideoDownloadUrl(sessionId: string): Promise<{
+    download_url: string
+  }> {
+    return await ApiClient.get(
+      `${BACKEND_URL}/sessions/${sessionId}/video-download`,
+    )
+  }
+
   static async generateClientAnalysis(
     sessionId: string,
     clientId?: string,


### PR DESCRIPTION
## Summary
Adds a **Download** button to the session recording player for both coaches and clients. Previously the video could only be streamed (`controlsList="nodownload"`, no download control anywhere).

## Changes
- `video-player.tsx` — optional `getDownloadUrl?: () => Promise<string | null>` prop; when provided, renders a Download button beside Refresh (spinner + `sonner` error toast). The URL carries `Content-Disposition: attachment`, so a plain anchor click saves the file instead of navigating.
- `session-service.ts` — `getVideoDownloadUrl()` hits the new backend endpoint.
- `video-review-panel.tsx` — coach wiring (covers the session-detail Recording tab and the review page).
- `client-portal/sessions/[id]/page.tsx` — client wiring via `session.video_download_url`.
- `use-client-sessions.ts` — added the `video_download_url` field to the type.

## Notes
Depends on backend PR #85 (the `/sessions/{id}/video-download` endpoint + `video_download_url` on the client session detail).