### PR TITLE
Admin-only Proficiency Ladder rubric in session analysis

### DIFF
--- a/src/app/sessions/[sessionId]/components/session-proficiency-analysis.tsx
+++ b/src/app/sessions/[sessionId]/components/session-proficiency-analysis.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import React from 'react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Quote } from 'lucide-react'
+import {
+  PROFICIENCY_CRITERIA,
+  RUNG_NAMES,
+  PROFICIENT_RUNG,
+  RUBRIC_LEGEND,
+} from '@/config/proficiency-rubric'
+import type {
+  ProficiencyResult,
+  ProficiencyScores,
+  ProficiencyCriterionScore,
+} from '@/services/analysis-service'
+
+interface Props {
+  proficiency: ProficiencyResult
+}
+
+function isScored(p: ProficiencyResult): p is ProficiencyScores {
+  return (p as ProficiencyScores)?.rubric_type !== undefined
+}
+
+// Tone by RUNG (the objective level), not the signed score — avoids confusion
+// when graduate scores go negative. Uses DS semantic tokens only.
+function rungTone(rung: number): { dot: string; text: string; badge: string } {
+  if (rung >= 5)
+    return {
+      dot: 'bg-forest',
+      text: 'text-forest',
+      badge: 'bg-forest-bg text-forest',
+    }
+  if (rung >= 4)
+    return {
+      dot: 'bg-indigo',
+      text: 'text-indigo',
+      badge: 'bg-indigo-bg text-indigo',
+    }
+  if (rung >= 2)
+    return {
+      dot: 'bg-amber-token',
+      text: 'text-amber-token',
+      badge: 'bg-amber-token-bg text-amber-token',
+    }
+  return {
+    dot: 'bg-vermillion',
+    text: 'text-vermillion',
+    badge: 'bg-vermillion-bg text-vermillion',
+  }
+}
+
+function fmtScore(score: number): string {
+  const rounded = Math.round(score * 10) / 10
+  return rounded > 0 ? `+${rounded}` : `${rounded}`
+}
+
+// A 7-segment ladder with the achieved rung filled and the Proficient bar marked.
+function RungLadder({ rung }: { rung: number }) {
+  const tone = rungTone(rung)
+  return (
+    <div className="flex items-center gap-1" aria-label={`Rung ${rung} of 7`}>
+      {Array.from({ length: 7 }, (_, i) => {
+        const r = i + 1
+        const filled = r <= rung
+        const isBar = r === PROFICIENT_RUNG
+        return (
+          <div
+            key={r}
+            title={`${r}. ${RUNG_NAMES[r]}`}
+            className={[
+              'h-2 w-5 rounded-sm transition-colors',
+              filled ? tone.dot : 'bg-line',
+              isBar ? 'ring-1 ring-offset-1 ring-indigo' : '',
+            ].join(' ')}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function CriterionRow({
+  label,
+  Icon,
+  data,
+  anchors,
+}: {
+  label: string
+  Icon: React.ComponentType<{ className?: string }>
+  data: ProficiencyCriterionScore
+  anchors: Record<number, string>
+}) {
+  const tone = rungTone(data.rung)
+  return (
+    <div className="rounded-lg border border-line p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <Icon className={`h-4 w-4 shrink-0 ${tone.text}`} />
+          <span className="font-medium text-sm text-ink">{label}</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Badge variant="secondary" className={tone.badge}>
+            {RUNG_NAMES[data.rung]}
+          </Badge>
+          <span className={`text-sm font-semibold tabular-nums ${tone.text}`}>
+            {fmtScore(data.score)}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-2">
+        <RungLadder rung={data.rung} />
+      </div>
+
+      <p className="mt-2 text-xs text-ink-3">{anchors[data.rung]}</p>
+
+      {data.evidence ? (
+        <p className="mt-2 flex gap-1.5 text-xs italic text-ink-3">
+          <Quote className="h-3 w-3 shrink-0 mt-0.5 text-ink-4" />
+          <span>{data.evidence}</span>
+        </p>
+      ) : null}
+
+      {data.justification ? (
+        <p className="mt-1.5 text-xs text-ink-2">{data.justification}</p>
+      ) : null}
+    </div>
+  )
+}
+
+export function SessionProficiencyAnalysis({ proficiency }: Props) {
+  if (!isScored(proficiency)) {
+    return (
+      <Card className="border-dashed">
+        <CardContent className="py-4">
+          <p className="text-sm text-ink-3">
+            Proficiency Ladder: not scored for this session
+            {proficiency?.reason ? ` (${proficiency.reason})` : ''}.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const isTrainee = proficiency.rubric_type === 'trainee'
+  const overallTone =
+    proficiency.overall >= PROFICIENT_RUNG ? 'text-forest' : 'text-amber-token'
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold text-ink">
+              Proficiency Ladder
+            </h3>
+            <Badge
+              variant="outline"
+              className="text-[10px] uppercase tracking-wide"
+            >
+              Admin preview
+            </Badge>
+            <Badge
+              variant="secondary"
+              className={
+                isTrainee
+                  ? 'bg-indigo-bg text-indigo'
+                  : 'bg-surface-3 text-ink-2'
+              }
+            >
+              {isTrainee ? 'Trainee scale' : 'Graduate scale'}
+            </Badge>
+          </div>
+          <div className="text-right">
+            <div className="text-[11px] text-ink-4">Overall</div>
+            <div className={`text-xl font-bold tabular-nums ${overallTone}`}>
+              {fmtScore(proficiency.overall)}
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-2">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+          {PROFICIENCY_CRITERIA.map(c => {
+            const data = proficiency[c.key]
+            if (!data) return null
+            return (
+              <CriterionRow
+                key={c.key}
+                label={c.label}
+                Icon={c.icon}
+                data={data}
+                anchors={c.anchors}
+              />
+            )
+          })}
+        </div>
+
+        <p className="pt-2 text-[11px] leading-relaxed text-ink-4">
+          {isTrainee ? RUBRIC_LEGEND.trainee : RUBRIC_LEGEND.graduate} The bar
+          is rung 4 (Proficient).
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default SessionProficiencyAnalysis

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -29,6 +29,7 @@ import SessionHeader from './components/session-header'
 import { SessionHeroCard } from './components/session-hero-card'
 import { SessionOverviewTab } from './components/session-overview-tab'
 import { SessionAnalysisMerged } from './components/session-analysis-merged'
+import { SessionProficiencyAnalysis } from './components/session-proficiency-analysis'
 import { VideoReviewPanel } from '@/components/sessions/video-review-panel'
 import { EvaluationsList } from '@/components/sessions/evaluations-list'
 import { useCoachEvaluations } from '@/hooks/queries/use-coach-evaluations'
@@ -974,6 +975,13 @@ export default function SessionDetailsPage({
                               : undefined
                           }
                         />
+
+                        {/* Proficiency Ladder rubric — admin-only preview while validating */}
+                        {isAdmin && analysisData.proficiency ? (
+                          <SessionProficiencyAnalysis
+                            proficiency={analysisData.proficiency}
+                          />
+                        ) : null}
                       </>
                     ) : (
                       <Card className="border-dashed border-2 border-app-border">

--- a/src/config/proficiency-rubric.ts
+++ b/src/config/proficiency-rubric.ts
@@ -1,0 +1,169 @@
+// Single source of truth for the Proficiency Ladder rubric UI (trainee vs graduate).
+// Keys MUST match the backend (app/schemas/analysis.py PROFICIENCY_CRITERIA and
+// app/services/proficiency_analysis_service.py CRITERIA_ANCHORS).
+
+import {
+  Target,
+  Eye,
+  Shield,
+  Users,
+  Brain,
+  Sparkles,
+  Zap,
+  MessageSquare,
+  type LucideIcon,
+} from 'lucide-react'
+
+export type ProficiencyCriterionKey =
+  | 'maximum_value'
+  | 'expansion'
+  | 'integrity'
+  | 'agency'
+  | 'listening'
+  | 'reinvention'
+  | 'energy'
+  | 'disruption'
+
+// Rung index (1..7) -> short display name. Rung 4 is the graduation "bar".
+export const RUNG_NAMES: Record<number, string> = {
+  1: 'Ineffective',
+  2: 'Emerging',
+  3: 'Foundational',
+  4: 'Proficient',
+  5: 'Intermediate',
+  6: 'Advanced',
+  7: 'Elite',
+}
+
+export const PROFICIENT_RUNG = 4 // the bar
+
+export interface ProficiencyCriterionConfig {
+  key: ProficiencyCriterionKey
+  label: string
+  icon: LucideIcon
+  // Short anchor text per rung (1..7), used for tooltips / expandable detail.
+  anchors: Record<number, string>
+}
+
+export const PROFICIENCY_CRITERIA: ProficiencyCriterionConfig[] = [
+  {
+    key: 'maximum_value',
+    label: 'Maximum Value',
+    icon: Target,
+    anchors: {
+      1: 'Conversation stays reactive, scattered, or problem-focused.',
+      2: 'Attempts to establish value; accepts the first answer at face value.',
+      3: 'Co-creates a workable outcome for the conversation.',
+      4: 'Establishes and maintains a specific Max Value aligned with the vision.',
+      5: 'Advocates for a higher-value opportunity and sets it before exploring gaps.',
+      6: 'Consistently advocates for the highest-leverage developmental opportunity.',
+      7: 'Reveals and advances value opportunities that were invisible to the client.',
+    },
+  },
+  {
+    key: 'expansion',
+    label: 'Expansion',
+    icon: Eye,
+    anchors: {
+      1: "Accepts the client's frame without testing its limits.",
+      2: 'Occasional, inconsistent invitations beyond a self-imposed limitation.',
+      3: 'Reliably surfaces limiting assumptions; client sees more choice.',
+      4: 'Inquiry consistently expands identity, capability, and possibility.',
+      5: "Invites the client to test their intuition about what's possible.",
+      6: 'Generates transformational shifts across multiple domains of life.',
+      7: 'Makes previously unbelievable possibilities available — client acts on them.',
+    },
+  },
+  {
+    key: 'integrity',
+    label: 'Integrity',
+    icon: Shield,
+    anchors: {
+      1: 'Leaves word/action misalignment unaddressed.',
+      2: 'Identifies explicit instances of being out of alignment with their word.',
+      3: 'Consistently surfaces gaps between commitments and behavior.',
+      4: 'Develops capacity to honor their word and restore workability.',
+      5: 'Reveals and dismantles the rackets behind out-of-integrity behavior.',
+      6: 'Transforms their relationship to their word as a source of power.',
+      7: 'Coaches the client’s relationship to themselves as their word.',
+    },
+  },
+  {
+    key: 'agency',
+    label: 'Agency',
+    icon: Users,
+    anchors: {
+      1: 'Reinforces a relationship of dependence.',
+      2: 'Empowerment attempts via rescuing and over-functioning.',
+      3: 'Frequently returns responsibility to the client.',
+      4: "Develops the client's capacity for self-leadership.",
+      5: 'Invites greater coachability and ownership of resourcefulness.',
+      6: 'Full participation is the central conversation in the call.',
+      7: 'Client shapes the coaching relationship itself toward their vision.',
+    },
+  },
+  {
+    key: 'listening',
+    label: 'Listening',
+    icon: Brain,
+    anchors: {
+      1: 'Listens to respond; misses cues, contradictions, emotional shifts.',
+      2: 'Intermittent attention; drifts into fixing/teaching. Level 1.',
+      3: 'Level 2 active listening; restates content, some silence.',
+      4: 'Sustains active listening + self-management; some global listening.',
+      5: 'Frequently reaches Level 3; notices subtle shifts (sometimes retreats).',
+      6: 'Level 3 as a reliable way of being; surfaces hidden dynamics.',
+      7: 'Listening itself is a transformational intervention.',
+    },
+  },
+  {
+    key: 'reinvention',
+    label: 'Reinvention',
+    icon: Sparkles,
+    anchors: {
+      1: 'Stays at circumstance/behavior; never explores who to become.',
+      2: 'Mostly things-to-do; rare, undeveloped identity questions.',
+      3: 'Invites alternative ways of being, but it stays theoretical.',
+      4: 'Helps articulate new possibilities for who they could become.',
+      5: 'Moves clients from insight into declaration & commitment.',
+      6: 'Client participates in reinvention live — shifts in real time.',
+      7: "Reinvents self in the call to advocate for the client's becoming.",
+    },
+  },
+  {
+    key: 'energy',
+    label: 'Energy',
+    icon: Zap,
+    anchors: {
+      1: "Energies are 'off'; discernible mistrust.",
+      2: 'Prepared but the call feels overly structured or rigid.',
+      3: 'Prepared with some flow; transitions can feel abrupt.',
+      4: 'Inviting, neutral, curious; natural flow with smooth transitions.',
+      5: 'Intentionally plays diverse energies; reliably lifts engagement.',
+      6: 'Discerns and evokes the energy transformation requires.',
+      7: 'Becomes whoever they must to unlock trajectory-shifting growth.',
+    },
+  },
+  {
+    key: 'disruption',
+    label: 'Disruption',
+    icon: MessageSquare,
+    anchors: {
+      1: 'Tolerates narratives/excuses; never leverages them.',
+      2: 'Alludes to disruption but does not hold the space in the moment.',
+      3: 'Interrupts patterns directly; some new awareness emerges.',
+      4: 'Disrupts interpretations/identity claims live; hidden things become seen.',
+      5: 'Disrupts strategically, tailored to the limiting constraint.',
+      6: 'Disrupts the deeper structure; steady through resistance.',
+      7: 'Disruption is seamless; client disrupts their own narratives.',
+    },
+  },
+]
+
+// How the trainee/graduate curve maps a rung to a score (for the legend).
+export const RUBRIC_LEGEND: Record<'trainee' | 'graduate', string> = {
+  trainee:
+    'Trainee scale: rungs 1–4 score as-is (1–4); above the bar earns a bonus (5→6.5, 6→7.8, 7→9.1).',
+  graduate:
+    'Graduate scale: at/above the bar scores as the rung (4–7); below the bar is penalized (3→−1, 2→−2, 1→−3).',
+}

--- a/src/services/analysis-service.ts
+++ b/src/services/analysis-service.ts
@@ -77,6 +77,39 @@ export interface GOLIVEScores {
   energy: number
 }
 
+// ---- Proficiency Ladder rubric (trainee vs graduate, 7-rung) ----
+// Runs alongside the Meta-Performance scores above. `score`/`overall` may be
+// negative (graduates below the bar) or exceed the rung (trainees above it).
+export interface ProficiencyCriterionScore {
+  rung: number // 1 (Ineffective) .. 7 (Elite)
+  score: number
+  justification?: string
+  evidence?: string | null
+}
+
+export interface ProficiencyScores {
+  maximum_value: ProficiencyCriterionScore
+  expansion: ProficiencyCriterionScore
+  integrity: ProficiencyCriterionScore
+  agency: ProficiencyCriterionScore
+  listening: ProficiencyCriterionScore
+  reinvention: ProficiencyCriterionScore
+  energy: ProficiencyCriterionScore
+  disruption: ProficiencyCriterionScore
+  overall: number
+  rubric_type: 'trainee' | 'graduate'
+  rubric_version: string
+}
+
+// When the rubric couldn't be scored (short transcript / error), the backend
+// stores a marker instead of scores.
+export interface ProficiencyUnavailable {
+  status: 'unavailable'
+  reason?: string
+}
+
+export type ProficiencyResult = ProficiencyScores | ProficiencyUnavailable
+
 export interface CoachingAnalysis {
   session_id: string
   timestamp: string
@@ -122,6 +155,8 @@ export interface FullAnalysisResponse {
     processing_time_ms: number
   } | null
   total_processing_time_ms?: number
+  // Proficiency Ladder rubric (admin-only display). Null when never scored.
+  proficiency?: ProficiencyResult | null
 }
 
 export class AnalysisService {


### PR DESCRIPTION
## Summary
Renders the new backend Proficiency Ladder scores (trainee vs graduate, 7-rung) in the session **Analysis** tab, **gated behind `isAdmin`** so coaches and clients don't see it while we validate the rubric. The backend also withholds the field from non-admins, so this is defense-in-depth. The existing Meta-Performance display is unchanged.

## Changes
- `ProficiencyScores`/`ProficiencyResult` types + `proficiency` field on `FullAnalysisResponse` (`analysis-service.ts`).
- `src/config/proficiency-rubric.ts` — single source of truth (criteria labels, rung names, per-rung anchor tooltips, scale legend).
- `SessionProficiencyAnalysis` component — a 7-segment rung ladder + signed scores, evidence/justification, Proficient-bar marker. Uses DS color tokens (forest/indigo/amber-token/vermillion) and handles **negative** graduate scores that the 0–10 `MetricCard` can't.
- Wired into `page.tsx` after `SessionAnalysisMerged`, behind `isAdmin`.

Pairs with backend PR ainovusdev/coach-sidekick-backend#87.