### PR TITLE
Fix client settings toggles not saving from clients list page

### DIFF
--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -91,10 +91,7 @@ export default function ClientsPage() {
     if (!selectedClient) return
     await updateMutation.mutateAsync({
       clientId: selectedClient.id,
-      data: {
-        name: clientData.name,
-        notes: clientData.notes,
-      },
+      data: clientData,
     })
   }
 


### PR DESCRIPTION
## Problem

Toggling **Auto-send post-session Thrill Form** in the Client settings modal did not persist when the modal was opened from the `/clients` list page.

## Root cause

The modal (`client-modal.tsx`) builds a complete update payload including `auto_send_thrill_form`, but the list-page parent handler `handleEditClient` (`src/app/clients/page.tsx`) rebuilt the mutation payload as `{ name, notes }` only — dropping `auto_send_thrill_form`, `auto_send_questionnaire`, and `questionnaire_lead_time_hours`. The backend `PATCH /clients/{id}` uses `exclude_unset=True`, so the omitted fields were silent no-ops.

## Fix

Forward the full `clientData` the modal already builds (type-safe: the mutation `data` and the modal `onSubmit` are both `Partial<Client>`). This also restores saving of the questionnaire toggle/lead-time/email from the list page, aligning it with the already-correct detail-page path. No backend change needed.