### PR TITLE
Gate proficiency rubric on PostHog feature flag (targetable per email)

### DIFF
--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -33,6 +33,7 @@ import { SessionProficiencyAnalysis } from './components/session-proficiency-ana
 import { VideoReviewPanel } from '@/components/sessions/video-review-panel'
 import { EvaluationsList } from '@/components/sessions/evaluations-list'
 import { useCoachEvaluations } from '@/hooks/queries/use-coach-evaluations'
+import { useFeatureFlagEnabled } from '@/hooks/use-feature-flag'
 import { useAuth } from '@/contexts/auth-context'
 import { isPresignedUrlExpired } from '@/lib/presigned-url'
 import { GroupParticipantBar } from './components/group-participant-bar'
@@ -88,6 +89,9 @@ export default function SessionDetailsPage({
   const permissions = usePermissions()
   const isViewer = permissions.isViewer()
   const isAdmin = permissions.isAdmin() || permissions.isSuperAdmin()
+  // Proficiency Ladder rubric visibility is gated by a PostHog feature flag
+  // rather than by role, so access can be rolled out without a deploy.
+  const showProficiency = useFeatureFlagEnabled('proficiency-rubric')
   const { userId: currentUserId } = useAuth()
   const resolvedParams = React.use(params)
   const queryClient = useQueryClient()
@@ -976,8 +980,9 @@ export default function SessionDetailsPage({
                           }
                         />
 
-                        {/* Proficiency Ladder rubric — admin-only preview while validating */}
-                        {isAdmin && analysisData.proficiency ? (
+                        {/* Proficiency Ladder rubric — gated by the
+                            `proficiency-rubric` PostHog feature flag */}
+                        {showProficiency && analysisData.proficiency ? (
                           <SessionProficiencyAnalysis
                             proficiency={analysisData.proficiency}
                           />

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -104,10 +104,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setOwnClientId(userClientId) // NEW
 
         // Identify the already-authenticated user so events on page refresh
-        // are linked to the correct person profile.
+        // are linked to the correct person profile. `email` is set so feature
+        // flags can be targeted per email address in PostHog.
         if (id) {
           posthog.identify(id, {
             name: fullName || undefined,
+            email: email || undefined,
             roles: userRoles,
           })
         }
@@ -166,10 +168,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setClientAccess(authService.getClientAccess())
       setOwnClientId(authService.getOwnClientId())
 
-      // Identify user in PostHog after successful login
+      // Identify user in PostHog after successful login. `email` is set so
+      // feature flags can be targeted per email address in PostHog.
       if (id) {
         posthog.identify(id, {
           name: fullName || undefined,
+          email: userEmail || email || undefined,
           roles: userRoles,
         })
       }

--- a/src/hooks/use-feature-flag.ts
+++ b/src/hooks/use-feature-flag.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+
+/**
+ * Subscribe to a PostHog boolean feature flag.
+ *
+ * Uses the global `posthog` singleton (initialized in
+ * `instrumentation-client.ts`) rather than `PostHogProvider`, matching how the
+ * rest of the app consumes PostHog. Returns `false` until flags have loaded,
+ * then re-renders whenever the flag resolves or changes — including after
+ * `posthog.identify()` on login, which reloads flags against the user's latest
+ * person properties (e.g. `roles`).
+ */
+export function useFeatureFlagEnabled(flagKey: string): boolean {
+  const [enabled, setEnabled] = useState<boolean>(false)
+
+  useEffect(() => {
+    // Reflect the current value immediately if flags are already loaded.
+    setEnabled(posthog.isFeatureEnabled(flagKey) ?? false)
+
+    // Re-evaluate whenever flags (re)load. onFeatureFlags returns an
+    // unsubscribe function for cleanup.
+    return posthog.onFeatureFlags(() => {
+      setEnabled(posthog.isFeatureEnabled(flagKey) ?? false)
+    })
+  }, [flagKey])
+
+  return enabled
+}


### PR DESCRIPTION
## What
- Replace the admin role gate on the Proficiency Ladder rubric section (session Analysis tab) with the `proficiency-rubric` PostHog feature flag.
- New `useFeatureFlagEnabled` hook (`src/hooks/use-feature-flag.ts`) reads the flag off the `posthog` singleton and re-renders on `onFeatureFlags` (matches how the app already consumes posthog-js — no `PostHogProvider`).
- Add `email` to `posthog.identify()` (both login + session-restore paths) so the flag can be **targeted per email address** in PostHog.

## Why
We want to control who sees the new rubric via PostHog — per email address — rather than a hard-coded admin role, so access rolls out without a deploy. Pairs with backend PR that stops role-gating `GET /analysis`.

## Note
Users must log in once after this ships for PostHog to have their `email` person property (existing sessions are re-identified on next page load / login).