### PR TITLE
PostHog frontend error tracking + session replay

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import posthog from 'posthog-js'
+import { isReplayExcludedPath } from './src/lib/posthog-replay'
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
   api_host: '/ingest',
@@ -6,4 +7,15 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
   defaults: '2026-01-30',
   capture_exceptions: true,
   debug: process.env.NODE_ENV === 'development',
+  session_recording: {
+    // Mask everything typed (notes, agent composer, forms, search). Page text
+    // stays visible; the most sensitive routes are excluded from recording
+    // entirely (see isReplayExcludedPath + SessionReplayController).
+    maskAllInputs: true,
+  },
+  // Fail-safe: if a user hard-loads directly onto a sensitive route, don't
+  // start recording. SessionReplayController handles subsequent SPA navigation.
+  disable_session_recording:
+    typeof window !== 'undefined' &&
+    isReplayExcludedPath(window.location.pathname),
 })

--- a/src/app/clients/[clientId]/components/chat-tab.tsx
+++ b/src/app/clients/[clientId]/components/chat-tab.tsx
@@ -39,5 +39,11 @@ export function ChatTab({ clientId, clientName, isViewer }: ChatTabProps) {
     )
   }
 
-  return <ClientChatUnified clientId={clientId} clientName={clientName} />
+  // ph-no-capture: the AI chat surfaces client data and coaching insights, so
+  // its content is excluded from session replay even on this recorded route.
+  return (
+    <div className="ph-no-capture h-full">
+      <ClientChatUnified clientId={clientId} clientName={clientName} />
+    </div>
+  )
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import { AlertCircle, RefreshCw, Home } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { captureException } from '@/lib/posthog-capture'
 
 export default function Error({
   error,
@@ -13,6 +14,7 @@ export default function Error({
 }) {
   useEffect(() => {
     console.error('Application error:', error)
+    captureException(error, { digest: error.digest, boundary: 'app' })
   }, [error])
 
   return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useEffect } from 'react'
 import './globals.css'
+import { captureException } from '@/lib/posthog-capture'
 
 export default function GlobalError({
   error,
@@ -9,6 +11,15 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    console.error('Global application error:', error)
+    captureException(error, {
+      digest: error.digest,
+      boundary: 'global',
+      fatal: true,
+    })
+  }, [error])
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased bg-background text-foreground flex items-center justify-center min-h-screen">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ProcessingProvider } from '@/contexts/processing-context'
 import { QueryProvider } from '@/components/providers/query-provider'
 import { ThemeProvider } from '@/components/providers/theme-provider'
 import { TimezoneInitializer } from '@/components/providers/timezone-initializer'
+import { SessionReplayController } from '@/components/providers/session-replay-controller'
 import { AgentModalProvider } from '@/components/agent/agent-modal'
 import { Toaster } from 'sonner'
 import './globals.css'
@@ -41,6 +42,7 @@ export default function RootLayout({
           <QueryProvider>
             <AuthProvider>
               <TimezoneInitializer />
+              <SessionReplayController />
               <PermissionProvider>
                 <WebSocketProvider>
                   <ProcessingProvider>

--- a/src/components/agent/agent-modal.tsx
+++ b/src/components/agent/agent-modal.tsx
@@ -119,7 +119,10 @@ export function AgentModalProvider({
       {children}
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
-          className="flex h-[95vh] w-[97vw] max-w-[1800px] flex-col gap-0 overflow-hidden rounded-2xl border border-line bg-paper p-0 shadow-2xl"
+          // ph-no-capture: the agent surfaces client data, transcripts, and
+          // scores, so its content is never recorded in session replay — even
+          // though this modal can open on otherwise-recorded routes.
+          className="ph-no-capture flex h-[95vh] w-[97vw] max-w-[1800px] flex-col gap-0 overflow-hidden rounded-2xl border border-line bg-paper p-0 shadow-2xl"
           // The agent owns its own composer focus; don't let the dialog steal the
           // first focus to a header icon button instead.
           onOpenAutoFocus={e => e.preventDefault()}

--- a/src/components/providers/session-replay-controller.tsx
+++ b/src/components/providers/session-replay-controller.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import posthog from 'posthog-js'
+import { isReplayExcludedPath } from '@/lib/posthog-replay'
+
+/**
+ * Starts/stops PostHog session recording per route so sensitive surfaces
+ * (transcripts, live meetings, AI chat) are never captured. Mounted once at the
+ * app root; runs on every client navigation. Recording is enabled in
+ * `instrumentation-client.ts`; this component only gates *where* it runs.
+ */
+export function SessionReplayController() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!pathname) return
+    if (isReplayExcludedPath(pathname)) {
+      posthog.stopSessionRecording()
+    } else if (!posthog.sessionRecordingStarted()) {
+      posthog.startSessionRecording()
+    }
+  }, [pathname])
+
+  return null
+}

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -6,6 +6,19 @@ import axios from '@/lib/axios-config'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner' // NEW: Add Sonner toasts
 import posthog from 'posthog-js'
+import { captureException } from '@/lib/posthog-capture'
+
+/**
+ * Report an auth failure to PostHog only when it's unexpected — a network
+ * error or a 5xx. Routine rejections (wrong password 401, "email exists" 400,
+ * pending-activation 403) are user error, not bugs, and would just be noise.
+ */
+function captureUnexpectedAuthError(error: unknown, flow: string) {
+  const status = (error as { response?: { status?: number } })?.response?.status
+  if (!status || status >= 500) {
+    captureException(error, { flow })
+  }
+}
 
 const TZ_SYNCED_FLAG = 'tz_synced'
 
@@ -137,6 +150,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return { error: null }
     } catch (error) {
       console.error('Sign up error:', error)
+      captureUnexpectedAuthError(error, 'sign_up')
       const errorMessage =
         error instanceof Error ? error.message : 'Failed to sign up'
       toast.error('Signup Failed', {
@@ -205,6 +219,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return { error: null }
     } catch (error) {
       console.error('Sign in error:', error)
+      captureUnexpectedAuthError(error, 'sign_in')
       // Prefer the backend's detail message (e.g. the pending "not activated yet"
       // 403) over axios's generic "Request failed with status code ..." text.
       const detail = (error as { response?: { data?: { detail?: string } } })

--- a/src/lib/posthog-capture.ts
+++ b/src/lib/posthog-capture.ts
@@ -1,0 +1,21 @@
+import posthog from 'posthog-js'
+
+/**
+ * Report an error to PostHog error tracking.
+ *
+ * PostHog's `capture_exceptions` only auto-captures errors that reach the
+ * browser's global `onerror`/`unhandledrejection` handlers. This app catches
+ * errors first (React error boundaries, TanStack Query `onError`), so those
+ * exceptions never reach PostHog. Call this at those choke points instead.
+ *
+ * Guarded for SSR/no-window. This is also the single place to scrub PII from
+ * error payloads in the future.
+ */
+export function captureException(
+  error: unknown,
+  properties?: Record<string, unknown>,
+): void {
+  if (typeof window === 'undefined') return
+  const err = error instanceof Error ? error : new Error(String(error))
+  posthog.captureException(err, properties)
+}

--- a/src/lib/posthog-replay.ts
+++ b/src/lib/posthog-replay.ts
@@ -1,0 +1,47 @@
+/**
+ * Routes whose rendered content is too sensitive to ever record in session
+ * replay — full transcripts, live meetings, and AI chat. Under our inputs-only
+ * masking, page *text* stays visible, so these surfaces must be excluded
+ * entirely rather than masked.
+ *
+ * Used in two places: `instrumentation-client.ts` (fail-safe when a user
+ * hard-loads directly onto one of these routes) and `SessionReplayController`
+ * (start/stop recording as the user navigates between routes).
+ */
+export function isReplayExcludedPath(pathname: string): boolean {
+  if (!pathname) return false
+
+  // Live meeting / real-time transcript views (coach + external client).
+  if (pathname.startsWith('/meeting/')) return true
+  if (pathname.startsWith('/client-meeting/')) return true
+
+  // AI agent / chat pages.
+  if (
+    pathname === '/agent' ||
+    pathname === '/client-portal/agent' ||
+    pathname === '/admin/agent' ||
+    pathname === '/admin/agent-chats'
+  ) {
+    return true
+  }
+
+  const seg = pathname.split('/').filter(Boolean)
+
+  // Session detail / review / group (transcripts + AI analysis) — but NOT the
+  // list (/sessions), /sessions/create, or /sessions/shared.
+  if (
+    seg[0] === 'sessions' &&
+    seg[1] &&
+    seg[1] !== 'create' &&
+    seg[1] !== 'shared'
+  ) {
+    return true
+  }
+
+  // Client-portal session detail — but NOT the list (/client-portal/sessions).
+  if (seg[0] === 'client-portal' && seg[1] === 'sessions' && seg[2]) {
+    return true
+  }
+
+  return false
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,4 +1,5 @@
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryCache, MutationCache } from '@tanstack/react-query'
+import { captureException } from '@/lib/posthog-capture'
 
 /**
  * Global QueryClient configuration for TanStack Query
@@ -8,6 +9,25 @@ import { QueryClient } from '@tanstack/react-query'
  * - Provides instant navigation with eventual consistency
  */
 export const queryClient = new QueryClient({
+  // Report every query/mutation failure to PostHog error tracking. Doing it at
+  // the cache level instruments all ~25 hook files at once; individual hooks
+  // still keep their own onError toasts.
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      captureException(error, {
+        source: 'react-query',
+        queryKey: query.queryKey,
+      })
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error, _variables, _context, mutation) => {
+      captureException(error, {
+        source: 'react-query-mutation',
+        mutationKey: mutation.options.mutationKey,
+      })
+    },
+  }),
   defaultOptions: {
     queries: {
       // Stale time: Data is considered fresh for 5 minutes


### PR DESCRIPTION
## What
**Error tracking** (was capturing nothing — 0 issues/30d):
- New `src/lib/posthog-capture.ts` (window-guarded `captureException`).
- Wired into `QueryCache`+`MutationCache` `onError` (instruments all query/mutation hooks at once), both error boundaries, and unexpected (5xx/network) auth failures.

**Session replay** (was off):
- `session_recording.maskAllInputs` — typed inputs masked, page text readable (per product decision).
- Sensitive routes fully **excluded** (live meeting, full transcripts/review, group + client-portal sessions, agent pages) via `isReplayExcludedPath` + a root-mounted `SessionReplayController`, plus a fail-safe `disable_session_recording` init gate.
- App-wide AI surfaces masked with `ph-no-capture` (agent modal + per-client chat).

## Ordering
Project-level `session_recording_opt_in` stays OFF until this is deployed; it will be re-enabled once live so the first recording is already protected.

## Notes
Backend untouched. LLM observability / dashboards deferred. Local dev can't verify (no posthog token in `.env.local`) — verified on prod.