### PR TITLE
Instrument key product flows with PostHog events

### DIFF
--- a/src/app/clients/[clientId]/components/client-chat-unified.tsx
+++ b/src/app/clients/[clientId]/components/client-chat-unified.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import posthog from 'posthog-js'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
@@ -131,6 +132,13 @@ export function ClientChatUnified({
     async (messageText?: string) => {
       const textToSend = messageText || input.trim()
       if (!textToSend || isLoading) return
+
+      posthog.capture('agent_message_sent', {
+        surface: 'client_chat',
+        client_id: clientId,
+        input_mode: inputMode,
+        provider: selectedProvider,
+      })
 
       // TODO: Add realtime voice support
       // if (useRealtimeVoice && realtimeConnected) {

--- a/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
+++ b/src/app/questionnaire/[token]/components/questionnaire-flow.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import Image from 'next/image'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 import { QuestionnaireService } from '@/services/questionnaire-service'
 import type {
   QuestionItem,
@@ -191,6 +192,12 @@ export function QuestionnaireFlow({
         .filter(a => a.answer.length > 0)
 
       await QuestionnaireService.submitAll(token, allAnswers)
+      posthog.capture('questionnaire_completed', {
+        kind,
+        question_count: visibleQuestions.length,
+        answered_count: allAnswers.length,
+        view_mode: viewMode,
+      })
       clearStorage(token)
       onComplete()
     } catch {

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -35,6 +35,7 @@ import { EvaluationsList } from '@/components/sessions/evaluations-list'
 import { useCoachEvaluations } from '@/hooks/queries/use-coach-evaluations'
 import { useFeatureFlagEnabled } from '@/hooks/use-feature-flag'
 import { useAuth } from '@/contexts/auth-context'
+import posthog from 'posthog-js'
 import { isPresignedUrlExpired } from '@/lib/presigned-url'
 import { GroupParticipantBar } from './components/group-participant-bar'
 import { QuickNote } from '@/components/session-notes/quick-note'
@@ -745,7 +746,17 @@ export default function SessionDetailsPage({
                 <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
                   <Tabs
                     value={activeTab}
-                    onValueChange={setActiveTab}
+                    onValueChange={v => {
+                      setActiveTab(v)
+                      if (v === 'analysis') {
+                        posthog.capture('session_analysis_viewed', {
+                          session_id: resolvedParams.sessionId,
+                          has_analysis: !!analysisData,
+                          show_proficiency: showProficiency,
+                          is_viewer: isViewer,
+                        })
+                      }
+                    }}
                     className="flex-1"
                   >
                     <TabsList className="bg-app-surface p-1 rounded-lg">

--- a/src/app/settings/components/integrations-section.tsx
+++ b/src/app/settings/components/integrations-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Calendar, CheckCircle2, AlertCircle } from 'lucide-react'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -38,6 +39,7 @@ export function IntegrationsSection() {
     const connected = searchParams.get('calendar_connected')
     const error = searchParams.get('calendar_error')
     if (connected) {
+      posthog.capture('calendar_connected', { provider: 'google_calendar' })
       toast.success('Google Calendar connected')
       router.replace('/settings?tab=profile#integrations')
     } else if (error) {

--- a/src/components/admin/agent/agent-chat.tsx
+++ b/src/components/admin/agent/agent-chat.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 import {
   Select,
   SelectContent,
@@ -233,6 +234,13 @@ export function AgentChat({
     async (questionOverride?: string) => {
       const question = (questionOverride ?? input).trim()
       if (!question || streaming) return
+
+      posthog.capture('agent_message_sent', {
+        surface: 'global_agent',
+        scope: apiScope,
+        is_new_thread: !threadId,
+        model,
+      })
 
       const userMsg: AgentMessageType = {
         id: crypto.randomUUID(),

--- a/src/components/agent/agent-modal.tsx
+++ b/src/components/agent/agent-modal.tsx
@@ -12,6 +12,7 @@ import {
 import { usePathname } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import { Loader2 } from 'lucide-react'
+import posthog from 'posthog-js'
 
 import {
   Dialog,
@@ -90,17 +91,25 @@ export function AgentModalProvider({
   // Bumped on every open so AgentChat remounts fresh.
   const [mountKey, setMountKey] = useState(0)
 
-  const openAgent = useCallback((opts: OpenAgentOptions = {}) => {
-    if (opts.scope) setScope(opts.scope)
-    // Always (re)seed + remount so every open is deterministic: a question, a
-    // saved thread, or — with neither — a fresh *empty* modal (clearing any seed
-    // left over from a prior open). Radix unmounts the content on close, so there's
-    // no in-memory conversation to preserve anyway.
-    setInitialQuery(opts.query)
-    setInitialThreadId(opts.threadId)
-    setMountKey(k => k + 1)
-    setOpen(true)
-  }, [])
+  const openAgent = useCallback(
+    (opts: OpenAgentOptions = {}) => {
+      posthog.capture('agent_opened', {
+        scope: opts.scope ?? defaultScope,
+        opened_with_query: !!opts.query,
+        opened_thread: !!opts.threadId,
+      })
+      if (opts.scope) setScope(opts.scope)
+      // Always (re)seed + remount so every open is deterministic: a question, a
+      // saved thread, or — with neither — a fresh *empty* modal (clearing any seed
+      // left over from a prior open). Radix unmounts the content on close, so there's
+      // no in-memory conversation to preserve anyway.
+      setInitialQuery(opts.query)
+      setInitialThreadId(opts.threadId)
+      setMountKey(k => k + 1)
+      setOpen(true)
+    },
+    [defaultScope],
+  )
 
   const closeAgent = useCallback(() => setOpen(false), [])
 

--- a/src/components/clients/client-modal.tsx
+++ b/src/components/clients/client-modal.tsx
@@ -19,6 +19,7 @@ import { Loader2, Send, UserCheck, Clock } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -177,6 +178,15 @@ export default function ClientModal({
           accessRequestSent,
           accessRequestName,
         } = await ClientService.createClient(clientData)
+
+        posthog.capture('client_created', {
+          client_id: createdClient?.id,
+          access_request_sent: !!accessRequestSent,
+          invited_to_portal: !!formData.inviteToPortal,
+          has_email: !!formData.email.trim(),
+          auto_send_questionnaire: formData.autoSendQuestionnaire,
+          auto_send_thrill_form: formData.autoSendThrillForm,
+        })
 
         if (accessRequestSent) {
           // Existing active user → an accept/decline request was emailed; they

--- a/src/components/goals/goal-form-modal.tsx
+++ b/src/components/goals/goal-form-modal.tsx
@@ -17,6 +17,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { DueDateField } from '@/components/ui/due-date-field'
 import { GoalService, GoalCreate, Goal } from '@/services/goal-service'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 import { useEffect } from 'react'
 import { cn } from '@/lib/utils'
 import { useQueryClient } from '@tanstack/react-query'
@@ -145,6 +146,12 @@ export function GoalFormModal({
 
         // Actual API call
         await GoalService.createGoal(goalData)
+
+        posthog.capture('goal_created', {
+          client_id: clientId,
+          has_target_date: !!goalData.target_date,
+          status: formData.status,
+        })
 
         // Invalidate to get the real data from server
         queryClient.invalidateQueries({

--- a/src/components/sprints/target-form-modal.tsx
+++ b/src/components/sprints/target-form-modal.tsx
@@ -18,6 +18,7 @@ import { Check } from 'lucide-react'
 import { TargetService } from '@/services/target-service'
 import { TargetCreate, TargetUpdate } from '@/types/sprint'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 import { cn } from '@/lib/utils'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-client'
@@ -152,6 +153,13 @@ export function TargetFormModal({
 
         // Actual API call
         await TargetService.createTarget(targetData)
+
+        posthog.capture('target_created', {
+          client_id: clientId,
+          goal_link_count: selectedGoalIds.length,
+          has_target_date: !!formData.target_date,
+          status: formData.status,
+        })
 
         // Invalidate to get the real data from server
         queryClient.invalidateQueries({

--- a/src/hooks/mutations/use-group-session-mutations.ts
+++ b/src/hooks/mutations/use-group-session-mutations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import posthog from 'posthog-js'
 import { invalidateQueries } from '@/lib/query-client'
 import { GroupSessionService } from '@/services/group-session-service'
 import { GroupSessionCreate, GroupSessionUpdate } from '@/types/group-session'
@@ -10,7 +11,13 @@ export function useCreateGroupSession() {
   return useMutation({
     mutationFn: (data: GroupSessionCreate) =>
       GroupSessionService.createGroupSession(data),
-    onSuccess: () => {
+    onSuccess: created => {
+      posthog.capture('group_session_created', {
+        group_session_id: created?.id,
+        participant_count: created?.participant_count ?? null,
+        session_type: created?.session_type ?? null,
+        has_program: !!created?.program_id,
+      })
       toast.success('Group session created')
       invalidateQueries.afterGroupSessionUpdate(queryClient)
     },


### PR DESCRIPTION
Adds `posthog.capture(...)` at the success path of nine previously-uninstrumented user flows so funnels, activation, and retention analysis work. Follows the existing posthog-singleton pattern (e.g. `commitment_created`). Non-PII props only — ids/counts/booleans, no names/emails/free text.

## New events
| Event | Fires when |
|---|---|
| `client_created` | Coach creates a coachee |
| `agent_opened` | AI agent modal opens (all entry paths) |
| `agent_message_sent` | Message sent in global agent + per-client chat (tagged with `surface`) |
| `questionnaire_completed` | Intake form submitted |
| `calendar_connected` | Google Calendar OAuth returns success |
| `goal_created` | Vision/goal created |
| `target_created` | Outcome/target created |
| `session_analysis_viewed` | Analysis tab opened on a session |
| `group_session_created` | Group session created |

Verified locally: `tsc --noEmit` clean on touched files, `eslint` clean. No new deps. Surveys work (separate) is PostHog-side only and needs no deploy.