### PR TITLE
fix: client Agent ignored selected coach profile (forward X-Active-Client)

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -82,7 +82,7 @@ export async function listAgentThreads(
   scope: AgentApiScope = 'admin',
 ): Promise<AgentThreadListResponse> {
   const res = await fetch(`${agentBase(scope)}/threads`, {
-    headers: authHeader(),
+    headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok) {
     throw new Error(
@@ -97,7 +97,7 @@ export async function getAgentThread(
   scope: AgentApiScope = 'admin',
 ): Promise<AgentThreadDetail> {
   const res = await fetch(`${agentBase(scope)}/threads/${threadId}`, {
-    headers: authHeader(),
+    headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok) {
     throw new Error(
@@ -113,7 +113,7 @@ export async function deleteAgentThread(
 ): Promise<void> {
   const res = await fetch(`${agentBase(scope)}/threads/${threadId}`, {
     method: 'DELETE',
-    headers: authHeader(),
+    headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok && res.status !== 204) {
     throw new Error(
@@ -126,7 +126,7 @@ export async function fetchModels(
   scope: AgentApiScope = 'admin',
 ): Promise<ModelsResponse> {
   const res = await fetch(`${agentBase(scope)}/models`, {
-    headers: authHeader(),
+    headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok) {
     throw new Error(`Failed to load models: ${res.status}`)
@@ -213,6 +213,7 @@ export async function* streamAgent({
     method: 'POST',
     headers: {
       ...authHeader(),
+      ...viewAsHeaders(),
       'Content-Type': 'application/json',
       Accept: 'text/event-stream',
     },


### PR DESCRIPTION
## Problem
For a coachee with **multiple coach profiles**, the client-portal Sidekick Agent always answered from the wrong coach — regardless of the profile switcher. It also 'didn't recognize' the selected coach's name.

## Root cause
The agent's raw-fetch calls in `src/services/agent-service.ts` sent only `authHeader()` and omitted `viewAsHeaders()`, so the `X-Active-Client` header never went out. The backend `get_client_context()` → `resolve_active_client_id()` then fell back to the JWT `client_id` (the user's **oldest** profile), so the Agent scoped to the wrong client. `fetchAgentInsight()` already forwarded these headers, which is why passive insight cards scoped correctly while the interactive Agent did not.

## Fix
Add `...viewAsHeaders()` to every agent-service fetch (`streamAgent` /stream, thread list/get/delete, models), matching `fetchAgentInsight`. Safe: the header is only added when the sessionStorage key exists, and the backend re-validates that the caller owns the requested profile before honoring it.

## Verification
- `tsc --noEmit`: no new errors (only a pre-existing unrelated vitest test-types error).
- Repro: Travis Patzkowsky (Foundations vs Faculty profiles) — Agent scoped to oldest (Foundations) instead of the selected Faculty profile.