### PR TITLE
feat: file attachments (images + documents) on session notes

### DIFF
--- a/src/app/sessions/[sessionId]/components/session-notes-compact.tsx
+++ b/src/app/sessions/[sessionId]/components/session-notes-compact.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -15,6 +15,7 @@ import {
   StickyNote,
   FileText,
   Loader2,
+  Paperclip,
   Plus,
   Lock,
   Users,
@@ -23,6 +24,12 @@ import {
 } from 'lucide-react'
 import { SessionNotesService } from '@/services/session-notes-service'
 import { SessionNote } from '@/types/session-note'
+import {
+  ATTACHMENT_ACCEPT,
+  NoteAttachmentsStrip,
+  PendingFilesList,
+  validateAttachment,
+} from '@/components/session-notes/note-attachments'
 import { formatRelativeTime } from '@/lib/date-utils'
 import { htmlToPlainText } from '@/components/ui/rich-text-editor'
 import { toast } from 'sonner'
@@ -48,6 +55,8 @@ export function SessionNotesCompact({
   )
   const [isCreating, setIsCreating] = useState(false)
   const [copiedNoteId, setCopiedNoteId] = useState<string | null>(null)
+  const [pendingFiles, setPendingFiles] = useState<File[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     fetchNotes()
@@ -69,20 +78,47 @@ export function SessionNotesCompact({
     }
   }
 
+  const handleFilesSelected = (fileList: FileList | null) => {
+    if (!fileList) return
+    const valid: File[] = []
+    for (const file of Array.from(fileList)) {
+      const error = validateAttachment(file)
+      if (error) {
+        toast.error(error)
+      } else {
+        valid.push(file)
+      }
+    }
+    if (valid.length) setPendingFiles(prev => [...prev, ...valid])
+  }
+
   const handleCreateNote = async () => {
     if (!newContent.trim()) return
     setIsCreating(true)
     try {
-      await SessionNotesService.createNote(sessionId, {
+      // Attachments need a note_id, so the note is created first and queued
+      // files are uploaded against it.
+      const created = await SessionNotesService.createNote(sessionId, {
         title: `Note - ${new Date().toLocaleTimeString()}`,
         content: newContent.trim(),
         note_type: newNoteType,
         ...(clientId ? { client_id: clientId } : {}),
       })
+      for (const file of pendingFiles) {
+        try {
+          await SessionNotesService.uploadAttachment(created.id, file)
+        } catch (uploadError) {
+          console.error('Failed to upload attachment:', uploadError)
+          toast.error(
+            `The note was saved, but ${file.name} could not be uploaded`,
+          )
+        }
+      }
       toast.success('Note added')
       setShowCreateDialog(false)
       setNewContent('')
       setNewNoteType('coach_private')
+      setPendingFiles([])
       fetchNotes()
     } catch (error) {
       console.error('Failed to create note:', error)
@@ -188,6 +224,10 @@ export function SessionNotesCompact({
                   />
                 )}
 
+                {note.attachments && note.attachments.length > 0 && (
+                  <NoteAttachmentsStrip attachments={note.attachments} />
+                )}
+
                 <div className="flex items-center justify-between">
                   <p className="text-xs text-app-secondary">
                     {formatRelativeTime(note.created_at)}
@@ -225,6 +265,7 @@ export function SessionNotesCompact({
             setShowCreateDialog(false)
             setNewContent('')
             setNewNoteType('coach_private')
+            setPendingFiles([])
           }
         }}
       >
@@ -274,6 +315,33 @@ export function SessionNotesCompact({
                 placeholder="Write your note..."
                 rows={4}
               />
+              <PendingFilesList
+                files={pendingFiles}
+                onRemove={index =>
+                  setPendingFiles(prev => prev.filter((_, i) => i !== index))
+                }
+              />
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept={ATTACHMENT_ACCEPT}
+                className="hidden"
+                onChange={e => {
+                  handleFilesSelected(e.target.files)
+                  e.target.value = ''
+                }}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isCreating}
+                className="mt-2 text-ink-3 hover:text-ink"
+              >
+                <Paperclip className="h-4 w-4 mr-1" />
+                Attach files
+              </Button>
             </div>
           </div>
           <DialogFooter>
@@ -283,6 +351,7 @@ export function SessionNotesCompact({
                 setShowCreateDialog(false)
                 setNewContent('')
                 setNewNoteType('coach_private')
+                setPendingFiles([])
               }}
             >
               Cancel

--- a/src/components/session-notes/note-attachments.tsx
+++ b/src/components/session-notes/note-attachments.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+/**
+ * Shared UI for note file attachments: display strip, pending-upload queue,
+ * and client-side validation matching the backend allowlist.
+ */
+
+import { File, FileText, Image as ImageIcon, X } from 'lucide-react'
+import { NoteAttachment } from '@/types/session-note'
+
+export const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024 // 25MB, matches backend
+export const ALLOWED_ATTACHMENT_EXTENSIONS = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.pdf',
+  '.docx',
+  '.txt',
+]
+export const ATTACHMENT_ACCEPT = ALLOWED_ATTACHMENT_EXTENSIONS.join(',')
+
+export function validateAttachment(file: File): string | null {
+  const extension = `.${file.name.split('.').pop()?.toLowerCase() || ''}`
+  if (!ALLOWED_ATTACHMENT_EXTENSIONS.includes(extension)) {
+    return `${file.name}: unsupported file type. Allowed: png, jpg, gif, webp, pdf, docx, txt.`
+  }
+  if (file.size > MAX_ATTACHMENT_SIZE) {
+    return `${file.name}: file too large. Maximum size is 25MB.`
+  }
+  return null
+}
+
+export function getFileIcon(contentType: string) {
+  if (contentType.startsWith('image/')) return ImageIcon
+  if (contentType === 'application/pdf') return FileText
+  return File
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function NoteAttachmentsStrip({
+  attachments,
+  canDelete = false,
+  onDelete,
+}: {
+  attachments: NoteAttachment[]
+  canDelete?: boolean
+  onDelete?: (attachment: NoteAttachment) => void
+}) {
+  if (!attachments.length) return null
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {attachments.map(att => {
+        const isImage = att.content_type.startsWith('image/')
+        const Icon = getFileIcon(att.content_type)
+
+        return (
+          <div key={att.id} className="relative group">
+            {isImage ? (
+              // Presigned URLs are re-signed on every notes fetch, so no
+              // staleness check is needed before opening.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={att.file_url}
+                alt={att.filename}
+                title={att.filename}
+                className="h-16 w-16 object-cover rounded-lg border cursor-pointer"
+                onClick={() => window.open(att.file_url, '_blank')}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => window.open(att.file_url, '_blank')}
+                className="flex items-center gap-2 px-2 py-1.5 rounded-lg border bg-muted/50 hover:bg-muted text-left"
+                title={att.filename}
+              >
+                <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="text-xs max-w-[140px] truncate">
+                  {att.filename}
+                </span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {formatFileSize(att.file_size)}
+                </span>
+              </button>
+            )}
+            {canDelete && onDelete && (
+              <button
+                type="button"
+                onClick={() => onDelete(att)}
+                className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-destructive text-destructive-foreground items-center justify-center hidden group-hover:flex"
+                title="Remove attachment"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function PendingFilesList({
+  files,
+  onRemove,
+}: {
+  files: File[]
+  onRemove: (index: number) => void
+}) {
+  if (!files.length) return null
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {files.map((file, index) => {
+        const Icon = getFileIcon(file.type)
+        return (
+          <div
+            key={`${file.name}-${index}`}
+            className="flex items-center gap-2 px-2 py-1.5 rounded-lg border bg-muted/50"
+          >
+            <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="text-xs max-w-[140px] truncate">{file.name}</span>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {formatFileSize(file.size)}
+            </span>
+            <button
+              type="button"
+              onClick={() => onRemove(index)}
+              className="text-muted-foreground hover:text-foreground"
+              title="Remove"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/session-notes/notes-list.tsx
+++ b/src/components/session-notes/notes-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -14,9 +14,16 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { SessionNotesService } from '@/services/session-notes-service'
-import { SessionNote, NoteType } from '@/types/session-note'
+import { SessionNote, NoteAttachment, NoteType } from '@/types/session-note'
+import {
+  ATTACHMENT_ACCEPT,
+  NoteAttachmentsStrip,
+  PendingFilesList,
+  validateAttachment,
+} from '@/components/session-notes/note-attachments'
 import {
   Loader2,
+  Paperclip,
   Plus,
   Pencil,
   Trash2,
@@ -107,6 +114,10 @@ export function NotesList({
     isClientPortal ? 'client_reflection' : 'coach_private',
   )
   const [creating, setCreating] = useState(false)
+  const [pendingFiles, setPendingFiles] = useState<File[]>([])
+  const [uploadingAttachment, setUploadingAttachment] = useState(false)
+  const createFileInputRef = useRef<HTMLInputElement>(null)
+  const editFileInputRef = useRef<HTMLInputElement>(null)
 
   // Types visible to the viewer. client_private notes are created during the
   // live meeting via the guest endpoint — clients should see them after the
@@ -243,7 +254,23 @@ export function NotesList({
     }
   }
 
-  // Handle create note
+  // Queue files for the create form (validated client-side)
+  const handleFilesSelected = (fileList: FileList | null) => {
+    if (!fileList) return
+    const valid: File[] = []
+    for (const file of Array.from(fileList)) {
+      const error = validateAttachment(file)
+      if (error) {
+        toast({ title: 'Error', description: error, variant: 'destructive' })
+      } else {
+        valid.push(file)
+      }
+    }
+    if (valid.length) setPendingFiles(prev => [...prev, ...valid])
+  }
+
+  // Handle create note — the note is created first, then queued files are
+  // uploaded against its id (attachments need a note_id).
   const handleCreateNote = async () => {
     if (!newNoteContent.trim()) return
 
@@ -253,11 +280,23 @@ export function NotesList({
       const autoTitle =
         newNoteContent.trim().substring(0, 50) ||
         `Note - ${new Date().toLocaleTimeString()}`
-      await SessionNotesService.createNote(sessionId, {
+      const created = await SessionNotesService.createNote(sessionId, {
         title: autoTitle,
         content: newNoteContent.trim(),
         note_type: newNoteType,
       })
+      for (const file of pendingFiles) {
+        try {
+          await SessionNotesService.uploadAttachment(created.id, file)
+        } catch (uploadError) {
+          console.error('Failed to upload attachment:', uploadError)
+          toast({
+            title: 'Attachment Failed',
+            description: `The note was saved, but ${file.name} could not be uploaded`,
+            variant: 'destructive',
+          })
+        }
+      }
       toast({
         title: 'Note Created',
         description: 'Your note has been saved',
@@ -265,6 +304,7 @@ export function NotesList({
       await fetchNotes()
       setShowCreateForm(false)
       setNewNoteContent('')
+      setPendingFiles([])
     } catch (error) {
       console.error('Failed to create note:', error)
       toast({
@@ -277,6 +317,49 @@ export function NotesList({
     }
   }
 
+  // Edit mode: the note exists, so uploads happen immediately on pick
+  const handleEditFilesSelected = async (fileList: FileList | null) => {
+    if (!fileList || !editingNote) return
+    setUploadingAttachment(true)
+    try {
+      for (const file of Array.from(fileList)) {
+        const error = validateAttachment(file)
+        if (error) {
+          toast({ title: 'Error', description: error, variant: 'destructive' })
+          continue
+        }
+        try {
+          await SessionNotesService.uploadAttachment(editingNote.id, file)
+        } catch (uploadError) {
+          console.error('Failed to upload attachment:', uploadError)
+          toast({
+            title: 'Error',
+            description: `Failed to upload ${file.name}`,
+            variant: 'destructive',
+          })
+        }
+      }
+      await fetchNotes()
+    } finally {
+      setUploadingAttachment(false)
+    }
+  }
+
+  const handleDeleteAttachment = async (attachment: NoteAttachment) => {
+    if (!editingNote) return
+    try {
+      await SessionNotesService.deleteAttachment(editingNote.id, attachment.id)
+      await fetchNotes()
+    } catch (error) {
+      console.error('Failed to delete attachment:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to remove attachment',
+        variant: 'destructive',
+      })
+    }
+  }
+
   // Render note card
   const renderNoteCard = (note: SessionNote) => {
     const config = NOTE_TYPE_CONFIG[note.note_type]
@@ -284,6 +367,10 @@ export function NotesList({
     const isEditing = editingNote?.id === note.id
 
     if (isEditing) {
+      // Source attachments from the notes state so fetchNotes() refreshes them
+      const currentAttachments =
+        notes.find(n => n.id === note.id)?.attachments || []
+
       return (
         <div
           key={note.id}
@@ -296,29 +383,61 @@ export function NotesList({
             className="min-h-[120px] mb-3 border-line bg-surface-1 resize-none"
             autoFocus
           />
-          <div className="flex items-center justify-end gap-2">
+          <NoteAttachmentsStrip
+            attachments={currentAttachments}
+            canDelete
+            onDelete={handleDeleteAttachment}
+          />
+          <input
+            ref={editFileInputRef}
+            type="file"
+            multiple
+            accept={ATTACHMENT_ACCEPT}
+            className="hidden"
+            onChange={e => {
+              handleEditFilesSelected(e.target.files)
+              e.target.value = ''
+            }}
+          />
+          <div className="flex items-center justify-between gap-2 mt-3">
             <Button
               variant="ghost"
               size="sm"
-              onClick={cancelEditing}
-              disabled={saving}
+              onClick={() => editFileInputRef.current?.click()}
+              disabled={saving || uploadingAttachment}
+              className="text-ink-3 hover:text-ink"
             >
-              <X className="h-4 w-4 mr-1" />
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              onClick={saveEdit}
-              disabled={saving || !editContent.trim()}
-              className="bg-ink hover:bg-ink-2 "
-            >
-              {saving ? (
+              {uploadingAttachment ? (
                 <Loader2 className="h-4 w-4 mr-1 animate-spin" />
               ) : (
-                <Check className="h-4 w-4 mr-1" />
+                <Paperclip className="h-4 w-4 mr-1" />
               )}
-              Save
+              Attach
             </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={cancelEditing}
+                disabled={saving}
+              >
+                <X className="h-4 w-4 mr-1" />
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={saveEdit}
+                disabled={saving || !editContent.trim()}
+                className="bg-ink hover:bg-ink-2 "
+              >
+                {saving ? (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                ) : (
+                  <Check className="h-4 w-4 mr-1" />
+                )}
+                Save
+              </Button>
+            </div>
           </div>
         </div>
       )
@@ -376,6 +495,11 @@ export function NotesList({
           className="text-sm text-ink-2 leading-relaxed prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-1"
           dangerouslySetInnerHTML={{ __html: note.content }}
         />
+
+        {/* Attachments */}
+        {note.attachments && note.attachments.length > 0 && (
+          <NoteAttachmentsStrip attachments={note.attachments} />
+        )}
       </div>
     )
   }
@@ -517,31 +641,61 @@ export function NotesList({
             className="min-h-[120px] mb-3 border-line bg-surface-1 resize-none"
             autoFocus
           />
-          <div className="flex items-center justify-end gap-2">
+          <PendingFilesList
+            files={pendingFiles}
+            onRemove={index =>
+              setPendingFiles(prev => prev.filter((_, i) => i !== index))
+            }
+          />
+          <input
+            ref={createFileInputRef}
+            type="file"
+            multiple
+            accept={ATTACHMENT_ACCEPT}
+            className="hidden"
+            onChange={e => {
+              handleFilesSelected(e.target.files)
+              e.target.value = ''
+            }}
+          />
+          <div className="flex items-center justify-between gap-2 mt-3">
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                setShowCreateForm(false)
-                setNewNoteContent('')
-              }}
+              onClick={() => createFileInputRef.current?.click()}
               disabled={creating}
+              className="text-ink-3 hover:text-ink"
             >
-              Cancel
+              <Paperclip className="h-4 w-4 mr-1" />
+              Attach
             </Button>
-            <Button
-              size="sm"
-              onClick={handleCreateNote}
-              disabled={creating || !newNoteContent.trim()}
-              className="bg-ink hover:bg-ink-2 "
-            >
-              {creating ? (
-                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-              ) : (
-                <Check className="h-4 w-4 mr-1" />
-              )}
-              Save Note
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setShowCreateForm(false)
+                  setNewNoteContent('')
+                  setPendingFiles([])
+                }}
+                disabled={creating}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleCreateNote}
+                disabled={creating || !newNoteContent.trim()}
+                className="bg-ink hover:bg-ink-2 "
+              >
+                {creating ? (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                ) : (
+                  <Check className="h-4 w-4 mr-1" />
+                )}
+                Save Note
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/src/services/session-notes-service.ts
+++ b/src/services/session-notes-service.ts
@@ -4,7 +4,9 @@
  */
 
 import { ApiClient } from '@/lib/api-client'
+import authService from '@/services/auth-service'
 import {
+  NoteAttachment,
   SessionNote,
   SessionNoteCreate,
   SessionNoteUpdate,
@@ -67,5 +69,79 @@ export class SessionNotesService {
    */
   static async deleteNote(noteId: string): Promise<void> {
     await ApiClient.delete(`${BACKEND_URL}/notes/${noteId}`)
+  }
+
+  /**
+   * Upload a file attachment to a note
+   * Raw fetch/XHR instead of ApiClient — multipart needs the browser to set
+   * the Content-Type boundary. XHR is used when progress tracking is wanted.
+   */
+  static async uploadAttachment(
+    noteId: string,
+    file: File,
+    onProgress?: (percent: number) => void,
+  ): Promise<NoteAttachment> {
+    const token = authService.getToken()
+    const formData = new FormData()
+    formData.append('file', file)
+
+    if (onProgress) {
+      return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest()
+        xhr.open('POST', `${BACKEND_URL}/notes/${noteId}/attachments`)
+        if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`)
+
+        xhr.upload.onprogress = e => {
+          if (e.lengthComputable) {
+            onProgress(Math.round((e.loaded / e.total) * 100))
+          }
+        }
+
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve(JSON.parse(xhr.responseText))
+          } else {
+            try {
+              const error = JSON.parse(xhr.responseText)
+              reject(new Error(error.detail || 'Failed to upload attachment'))
+            } catch {
+              reject(new Error('Upload failed'))
+            }
+          }
+        }
+
+        xhr.onerror = () => reject(new Error('Network error during upload'))
+        xhr.send(formData)
+      })
+    }
+
+    const response = await fetch(`${BACKEND_URL}/notes/${noteId}/attachments`, {
+      method: 'POST',
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: formData,
+    })
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ detail: 'Upload failed' }))
+      throw new Error(error.detail || 'Failed to upload attachment')
+    }
+
+    return response.json()
+  }
+
+  /**
+   * Delete a file attachment from a note
+   */
+  static async deleteAttachment(
+    noteId: string,
+    attachmentId: string,
+  ): Promise<void> {
+    await ApiClient.delete(
+      `${BACKEND_URL}/notes/${noteId}/attachments/${attachmentId}`,
+    )
   }
 }

--- a/src/types/session-note.ts
+++ b/src/types/session-note.ts
@@ -11,6 +11,18 @@ export type NoteType =
   | 'pre_session'
   | 'post_session'
 
+// File attachment stored on a note (same shape as commitment attachments)
+export interface NoteAttachment {
+  id: string
+  filename: string
+  file_key: string
+  file_url: string
+  file_size: number
+  content_type: string
+  uploaded_by_id?: string | null
+  uploaded_at: string
+}
+
 // Base session note interface
 export interface SessionNoteBase {
   title?: string | null // Optional for client notes
@@ -42,6 +54,7 @@ export interface SessionNote extends SessionNoteBase {
   template_id?: string
   is_visible_to_client: boolean
   note_metadata: Record<string, any>
+  attachments?: NoteAttachment[]
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## Summary
- New shared `note-attachments.tsx`: attachments strip (image thumbnails + document chips), pending-upload queue, and client-side validation (25MB, png/jpg/jpeg/gif/webp/pdf/docx/txt — mirrors the backend allowlist)
- Paperclip attach button in the coach session-notes card (`session-notes-compact.tsx`, create dialog) and the client-portal notes list (`notes-list.tsx`, create form + edit-mode attach/delete)
- Create flow saves the note first, then uploads queued files against its id; per-file failures keep the note and toast the error
- `SessionNotesService.uploadAttachment` (raw fetch/XHR + FormData, same pattern as commitment attachments) and `deleteAttachment`
- Attachments render for anyone who can see the note; URLs are re-signed by the backend on every fetch, so no staleness handling client-side

Backend counterpart: ainovusdev/coach-sidekick-backend#91 (merge that first — done)

## Out of scope (follow-ups)
- Live-meeting quick-note and guest notes panel
- HEIC support (most browsers can't render it; iOS transcodes to JPEG on file-pick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)