### PR TITLE
Sync Proficiency Ladder condensed anchors with the backend rubric

### DIFF
--- a/src/config/proficiency-rubric.ts
+++ b/src/config/proficiency-rubric.ts
@@ -127,7 +127,7 @@ export const PROFICIENCY_CRITERIA: ProficiencyCriterionConfig[] = [
       4: 'Helps articulate new possibilities for who they could become.',
       5: 'Moves clients from insight into declaration & commitment.',
       6: 'Client participates in reinvention live — shifts in real time.',
-      7: "Reinvents self in the call to advocate for the client's becoming.",
+      7: 'Reinvention is self-generating; the coach reinvents self in service of it.',
     },
   },
   {
@@ -136,12 +136,12 @@ export const PROFICIENCY_CRITERIA: ProficiencyCriterionConfig[] = [
     icon: Zap,
     anchors: {
       1: "Energies are 'off'; discernible mistrust.",
-      2: 'Prepared but the call feels overly structured or rigid.',
-      3: 'Prepared with some flow; transitions can feel abrupt.',
+      2: "Inconsistent presence; the coach's own state leaks into the call.",
+      3: 'Prepared, but overly structured or rigid; transitions can be abrupt.',
       4: 'Inviting, neutral, curious; natural flow with smooth transitions.',
       5: 'Intentionally plays diverse energies; reliably lifts engagement.',
       6: 'Discerns and evokes the energy transformation requires.',
-      7: 'Becomes whoever they must to unlock trajectory-shifting growth.',
+      7: 'Generates whatever energy the moment requires; becomes whoever they must.',
     },
   },
   {
@@ -155,7 +155,7 @@ export const PROFICIENCY_CRITERIA: ProficiencyCriterionConfig[] = [
       4: 'Disrupts interpretations/identity claims live; hidden things become seen.',
       5: 'Disrupts strategically, tailored to the limiting constraint.',
       6: 'Disrupts the deeper structure; steady through resistance.',
-      7: 'Disruption is seamless; client disrupts their own narratives.',
+      7: 'Seamless and resistance-free; client disrupts their own narratives.',
     },
   },
 ]


### PR DESCRIPTION
Companion to backend [#93](https://github.com/ainovusdev/coach-sidekick-backend/pull/93).

`src/config/proficiency-rubric.ts` is the single source of truth for the rung tooltips shown under each criterion, so it has to track the backend's `CRITERIA_ANCHORS` — otherwise the UI describes a rung the model was never scoring against.

Mirrors the four authored cells (condensed to the one-line tooltip form):

| Cell | Before | After |
|---|---|---|
| Energy 2 | Prepared but the call feels overly structured or rigid. | Inconsistent presence; the coach's own state leaks into the call. |
| Energy 3 | Prepared with some flow; transitions can feel abrupt. | Prepared, but overly structured or rigid; transitions can be abrupt. |
| Energy 7 | Becomes whoever they must to unlock trajectory-shifting growth. | Generates whatever energy the moment requires; becomes whoever they must. |
| Reinvention 7 | Reinvents self in the call to advocate for the client's becoming. | Reinvention is self-generating; the coach reinvents self in service of it. |
| Disruption 7 | Disruption is seamless; client disrupts their own narratives. | Seamless and resistance-free; client disrupts their own narratives. |

Text-only — no type, component, or visibility change. The section is still gated by the `proficiency-rubric` PostHog flag (per-email).

Isolated onto a clean branch off `origin/main` to keep the in-progress design-sync work out, same approach as #138/#139/#140.