### PR TITLE
Add public check-in page, Commitments hub, weekly-email toggle

### DIFF
--- a/src/app/checkin/[token]/components/checkin-list.tsx
+++ b/src/app/checkin/[token]/components/checkin-list.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Image from 'next/image'
+import { toast } from 'sonner'
+import { Check, PartyPopper } from 'lucide-react'
+import { differenceInCalendarDays, format, parseISO } from 'date-fns'
+import {
+  CheckinCommitment,
+  CheckinPage,
+  CheckinService,
+} from '@/services/checkin-service'
+
+interface CheckinListProps {
+  token: string
+  data: CheckinPage
+}
+
+function dueLabel(item: CheckinCommitment): string {
+  if (!item.target_date) return ''
+  const due = parseISO(item.target_date)
+  const days = differenceInCalendarDays(new Date(), due)
+  if (item.completed) return `Was due ${format(due, 'MMM d')}`
+  if (days > 0) {
+    return `Due ${format(due, 'MMM d')} · ${days} day${days === 1 ? '' : 's'} overdue`
+  }
+  if (days === 0) return 'Due today'
+  return `Due ${format(due, 'EEE, MMM d')}`
+}
+
+export function CheckinList({ token, data }: CheckinListProps) {
+  const searchParams = useSearchParams()
+  const highlightId = searchParams.get('commitment')
+
+  const [items, setItems] = useState<CheckinCommitment[]>(data.commitments)
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set())
+  const rowRefs = useRef<Record<string, HTMLDivElement | null>>({})
+  const scrolledRef = useRef(false)
+
+  // Scroll the row the email's "Mark done" button pointed at into view once.
+  useEffect(() => {
+    if (!highlightId || scrolledRef.current) return
+    const el = rowRefs.current[highlightId]
+    if (el) {
+      scrolledRef.current = true
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [highlightId, items])
+
+  const openCount = useMemo(
+    () => items.filter(i => !i.completed).length,
+    [items],
+  )
+  const overdueCount = useMemo(
+    () =>
+      items.filter(
+        i =>
+          !i.completed &&
+          i.target_date &&
+          differenceInCalendarDays(new Date(), parseISO(i.target_date)) > 0,
+      ).length,
+    [items],
+  )
+
+  const toggle = async (item: CheckinCommitment) => {
+    if (pendingIds.has(item.id)) return
+    const next = !item.completed
+
+    // Optimistic flip; revert on failure.
+    setItems(prev =>
+      prev.map(i => (i.id === item.id ? { ...i, completed: next } : i)),
+    )
+    setPendingIds(prev => new Set(prev).add(item.id))
+    try {
+      const res = await CheckinService.toggleCommitment(token, item.id, next)
+      setItems(prev =>
+        prev.map(i =>
+          i.id === item.id
+            ? { ...i, status: res.status, completed: res.completed }
+            : i,
+        ),
+      )
+      if (next) toast.success('Marked as done')
+    } catch {
+      setItems(prev =>
+        prev.map(i =>
+          i.id === item.id ? { ...i, completed: item.completed } : i,
+        ),
+      )
+      toast.error('Could not update — please try again')
+    } finally {
+      setPendingIds(prev => {
+        const nextSet = new Set(prev)
+        nextSet.delete(item.id)
+        return nextSet
+      })
+    }
+  }
+
+  const allDone = items.length > 0 && openCount === 0
+
+  return (
+    <div className="min-h-screen bg-surface-1 py-8 px-4">
+      <div className="max-w-lg mx-auto">
+        {/* Header */}
+        <div className="text-center mb-8">
+          {/* The logo asset is white-on-transparent — give it a dark chip
+              (mirrors the email's black header band) */}
+          <div className="inline-flex items-center justify-center bg-ink rounded-lg px-5 py-3 mb-6">
+            <Image
+              src="/novus-global-logo.webp"
+              alt="Novus Global"
+              width={110}
+              height={36}
+              priority
+            />
+          </div>
+          <h1 className="text-2xl font-bold text-ink mb-2">
+            {data.client_first_name}, here&apos;s your week
+          </h1>
+          {data.coach_name && (
+            <p className="text-sm text-ink-3 mb-4">
+              Coaching with {data.coach_name}
+            </p>
+          )}
+          <div className="flex items-center justify-center gap-2">
+            <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-paper border border-line text-ink-2">
+              {openCount} open
+            </span>
+            {overdueCount > 0 && (
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-vermillion-bg border border-vermillion text-vermillion">
+                {overdueCount} overdue
+              </span>
+            )}
+            {allDone && (
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-forest-bg border border-forest text-forest">
+                <PartyPopper className="h-3.5 w-3.5" />
+                All caught up
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Commitment rows */}
+        <div className="space-y-2">
+          {items.map(item => {
+            const isOverdue =
+              !item.completed &&
+              !!item.target_date &&
+              differenceInCalendarDays(new Date(), parseISO(item.target_date)) >
+                0
+            const isHighlighted = highlightId === item.id
+            const label = dueLabel(item)
+            return (
+              <div
+                key={item.id}
+                ref={el => {
+                  rowRefs.current[item.id] = el
+                }}
+                className={`flex items-start gap-3 p-4 bg-paper rounded-lg border transition-colors ${
+                  isHighlighted
+                    ? 'border-ink ring-2 ring-ink/20'
+                    : isOverdue
+                      ? 'border-line border-l-2 border-l-vermillion'
+                      : 'border-line'
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() => toggle(item)}
+                  disabled={pendingIds.has(item.id)}
+                  aria-label={
+                    item.completed
+                      ? `Mark "${item.title}" as not done`
+                      : `Mark "${item.title}" as done`
+                  }
+                  className={`mt-0.5 flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors cursor-pointer disabled:opacity-50 ${
+                    item.completed
+                      ? 'bg-forest border-forest text-white'
+                      : 'border-line-strong hover:border-forest'
+                  }`}
+                >
+                  {item.completed && <Check className="h-4 w-4" />}
+                </button>
+                <div className="min-w-0 flex-1">
+                  <p
+                    className={`text-sm font-medium leading-snug ${
+                      item.completed ? 'text-ink-4 line-through' : 'text-ink'
+                    }`}
+                  >
+                    {item.title}
+                  </p>
+                  {label && (
+                    <p
+                      className={`text-xs mt-1 ${
+                        isOverdue ? 'text-vermillion' : 'text-ink-3'
+                      }`}
+                    >
+                      {label}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {items.length === 0 && (
+          <div className="text-center py-12 bg-paper rounded-lg border border-line">
+            <p className="text-sm text-ink-3">
+              Nothing open right now. Enjoy the week!
+            </p>
+          </div>
+        )}
+
+        {/* Footer */}
+        <p className="text-center text-xs text-ink-4 mt-10">
+          Tap the circle to mark a commitment done — changes save instantly.
+        </p>
+        <p className="text-center text-xs text-ink-4 mt-2">
+          Powered by Novus Global
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/checkin/[token]/layout.tsx
+++ b/src/app/checkin/[token]/layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * Check-in Layout
+ * Simple layout for the public weekly commitment check-in page (no auth).
+ */
+
+import { ThemeProvider } from '@/components/providers/theme-provider'
+
+export default function CheckinLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  // No local <Toaster> — the root layout already mounts a global one, and a
+  // second instance renders every toast twice.
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="light"
+      enableSystem={false}
+      storageKey="checkin-theme"
+    >
+      <div className="min-h-screen">{children}</div>
+    </ThemeProvider>
+  )
+}

--- a/src/app/checkin/[token]/page.tsx
+++ b/src/app/checkin/[token]/page.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { Loader2, AlertCircle } from 'lucide-react'
+import {
+  CheckinService,
+  CheckinPage as CheckinPageData,
+} from '@/services/checkin-service'
+import { CheckinList } from './components/checkin-list'
+
+type PageState = 'loading' | 'error' | 'active'
+
+function LoadingScreen() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="h-8 w-8 animate-spin text-ink-4 mx-auto mb-4" />
+        <p className="text-ink-3 text-sm">Loading your commitments...</p>
+      </div>
+    </div>
+  )
+}
+
+export default function CheckinPage() {
+  const params = useParams()
+  const token = params.token as string
+
+  const [state, setState] = useState<PageState>('loading')
+  const [data, setData] = useState<CheckinPageData | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const result = await CheckinService.getCheckin(token)
+        setData(result)
+        setState('active')
+      } catch {
+        setState('error')
+      }
+    }
+    load()
+  }, [token])
+
+  if (state === 'loading') {
+    return <LoadingScreen />
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="text-center max-w-md">
+          <div className="w-16 h-16 bg-surface-3 rounded-full flex items-center justify-center mx-auto mb-6">
+            <AlertCircle className="h-8 w-8 text-ink-4" />
+          </div>
+          <h1 className="text-xl font-semibold text-ink mb-3">
+            Check-in Unavailable
+          </h1>
+          <p className="text-ink-3 leading-relaxed">
+            This check-in link is invalid or has expired. Ask your coach for a
+            fresh one — a new link arrives with every weekly summary.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'active' && data) {
+    return (
+      <Suspense fallback={<LoadingScreen />}>
+        <CheckinList token={token} data={data} />
+      </Suspense>
+    )
+  }
+
+  return null
+}

--- a/src/app/commitments/components/commitment-row.tsx
+++ b/src/app/commitments/components/commitment-row.tsx
@@ -1,0 +1,356 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Calendar as CalendarWidget } from '@/components/ui/calendar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Commitment,
+  CommitmentPriority,
+  CommitmentStatus,
+} from '@/types/commitment'
+import { formatDateOnly } from '@/lib/date-utils'
+import { parseISO } from 'date-fns'
+import { cn } from '@/lib/utils'
+import {
+  Calendar,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  Edit,
+  Loader2,
+  Sparkles,
+  Target,
+  Trash2,
+  XCircle,
+} from 'lucide-react'
+import { daysUntilDue, isOverdue } from '../utils/commitment-view'
+
+export const statusConfig: Record<
+  CommitmentStatus,
+  { label: string; dot: string }
+> = {
+  draft: { label: 'Draft', dot: 'bg-ink-4' },
+  active: { label: 'Active', dot: 'bg-ds-accent' },
+  in_progress: { label: 'In Progress', dot: 'bg-amber-token' },
+  completed: { label: 'Completed', dot: 'bg-forest' },
+  abandoned: { label: 'Abandoned', dot: 'bg-vermillion' },
+}
+
+export const priorityConfig: Record<
+  CommitmentPriority,
+  { label: string; className: string }
+> = {
+  low: { label: 'Low', className: 'text-ink-3' },
+  medium: { label: 'Medium', className: 'text-ink-3' },
+  high: { label: 'High', className: 'text-amber-token' },
+  urgent: { label: 'Urgent', className: 'text-vermillion' },
+}
+
+export interface CommitmentRowHandlers {
+  onEdit: (c: Commitment) => void
+  onDelete: (c: Commitment) => void
+  onConfirm: (id: string) => void
+  onReject: (id: string) => void
+  onStatusChange: (id: string, status: CommitmentStatus) => void
+  onDateChange: (id: string, date: string | undefined) => void
+  onSelect?: (id: string) => void
+}
+
+interface CommitmentRowProps extends CommitmentRowHandlers {
+  commitment: Commitment
+  isSelected?: boolean
+  /** Show a client chip on the row (flat / session / status views) */
+  showClient?: boolean
+}
+
+export function CommitmentRow({
+  commitment,
+  onEdit,
+  onDelete,
+  onConfirm,
+  onReject,
+  onStatusChange,
+  onDateChange,
+  isSelected,
+  onSelect,
+  showClient = false,
+}: CommitmentRowProps) {
+  const [actionLoading, setActionLoading] = useState<
+    'approve' | 'reject' | null
+  >(null)
+  const [dateOpen, setDateOpen] = useState(false)
+
+  const handleConfirm = async () => {
+    setActionLoading('approve')
+    try {
+      await onConfirm(commitment.id)
+    } finally {
+      setActionLoading(null)
+    }
+  }
+  const handleReject = async () => {
+    setActionLoading('reject')
+    try {
+      await onReject(commitment.id)
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  const status = statusConfig[commitment.status]
+  const priority = priorityConfig[commitment.priority]
+  const showPriority =
+    commitment.priority === 'high' || commitment.priority === 'urgent'
+  const isDraft = commitment.status === 'draft'
+  const overdue = isOverdue(commitment)
+  const daysUntil = daysUntilDue(commitment)
+
+  // Hover-revealed controls stay keyboard-reachable via focus-visible
+  const revealOnHover =
+    'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity'
+
+  return (
+    <div
+      className={cn(
+        'group flex items-start gap-3 px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper transition-colors',
+        overdue && 'border-l-2 border-l-vermillion',
+        isSelected && 'bg-ds-accent-bg/50 ',
+      )}
+    >
+      {/* Checkbox for drafts */}
+      {isDraft && (
+        <Checkbox
+          checked={isSelected}
+          onCheckedChange={() => onSelect?.(commitment.id)}
+          className="flex-shrink-0 mt-1"
+        />
+      )}
+
+      {/* Left: content */}
+      <div className="flex-1 min-w-0">
+        {/* Title line */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className="text-sm font-medium text-ink cursor-pointer hover:underline"
+            onClick={() => onEdit(commitment)}
+          >
+            {commitment.title}
+          </span>
+          {showPriority && (
+            <span className={cn('text-xs font-medium', priority.className)}>
+              {priority.label}
+            </span>
+          )}
+          {isDraft && commitment.extracted_from_transcript && (
+            <span className="inline-flex items-center gap-1 text-xs text-indigo">
+              <Sparkles className="h-3 w-3" />
+              AI
+            </span>
+          )}
+          {showClient && commitment.client_name && (
+            <Link
+              href={`/clients/${commitment.client_id}`}
+              className="text-xs text-ink-4 hover:text-ink hover:underline"
+              onClick={e => e.stopPropagation()}
+            >
+              {commitment.client_name}
+            </Link>
+          )}
+        </div>
+
+        {/* Description */}
+        {commitment.description && (
+          <p className="text-xs text-ink-3 mt-0.5 truncate max-w-2xl">
+            {commitment.description}
+          </p>
+        )}
+
+        {/* Transcript context for drafts */}
+        {isDraft && commitment.transcript_context && (
+          <p className="text-xs text-ink-4 italic mt-0.5 truncate max-w-xl">
+            &ldquo;{commitment.transcript_context}&rdquo;
+          </p>
+        )}
+      </div>
+
+      {/* Right: inline controls; secondary actions reveal on hover */}
+      <div className="flex items-center gap-1 flex-shrink-0">
+        {/* Inline status dropdown — quiet dot + label */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-ink-2 cursor-pointer transition-colors hover:bg-surface-3"
+              aria-label={`Status: ${status.label}`}
+            >
+              <span className={cn('h-2 w-2 rounded-full', status.dot)} />
+              {status.label}
+              <ChevronDown
+                className={cn('h-3 w-3 text-ink-4', revealOnHover)}
+              />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {isDraft && (
+              <DropdownMenuItem onClick={() => onConfirm(commitment.id)}>
+                <Check className="h-3.5 w-3.5 mr-2 text-forest" />
+                Approve
+              </DropdownMenuItem>
+            )}
+            {commitment.status !== 'active' && !isDraft && (
+              <DropdownMenuItem
+                onClick={() => onStatusChange(commitment.id, 'active')}
+              >
+                <Target className="h-3.5 w-3.5 mr-2 text-ds-accent" />
+                Active
+              </DropdownMenuItem>
+            )}
+            {commitment.status !== 'in_progress' && !isDraft && (
+              <DropdownMenuItem
+                onClick={() => onStatusChange(commitment.id, 'in_progress')}
+              >
+                <Circle className="h-3.5 w-3.5 mr-2 text-amber-token" />
+                In Progress
+              </DropdownMenuItem>
+            )}
+            {commitment.status !== 'completed' && (
+              <DropdownMenuItem
+                onClick={() => onStatusChange(commitment.id, 'completed')}
+              >
+                <CheckCircle2 className="h-3.5 w-3.5 mr-2 text-forest" />
+                Completed
+              </DropdownMenuItem>
+            )}
+            {commitment.status !== 'abandoned' && (
+              <DropdownMenuItem
+                onClick={() => onStatusChange(commitment.id, 'abandoned')}
+              >
+                <XCircle className="h-3.5 w-3.5 mr-2 text-vermillion" />
+                Abandon
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Inline due date picker — colored only when it needs attention */}
+        <Popover open={dateOpen} onOpenChange={setDateOpen}>
+          <PopoverTrigger asChild>
+            <button
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs cursor-pointer transition-colors hover:bg-surface-3',
+                overdue
+                  ? 'text-vermillion font-medium'
+                  : daysUntil !== null && daysUntil <= 7
+                    ? 'text-amber-token'
+                    : 'text-ink-3',
+                !commitment.target_date && cn('text-ink-4', revealOnHover),
+              )}
+            >
+              <Calendar className="h-3 w-3" />
+              {commitment.target_date
+                ? overdue
+                  ? `${Math.abs(daysUntil!)}d overdue`
+                  : daysUntil === 0
+                    ? 'Due today'
+                    : formatDateOnly(commitment.target_date, 'MMM d')
+                : 'Set date'}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="end">
+            <CalendarWidget
+              mode="single"
+              selected={
+                commitment.target_date
+                  ? parseISO(commitment.target_date)
+                  : undefined
+              }
+              onSelect={date => {
+                onDateChange(
+                  commitment.id,
+                  date ? date.toISOString().split('T')[0] : undefined,
+                )
+                setDateOpen(false)
+              }}
+              initialFocus
+            />
+          </PopoverContent>
+        </Popover>
+
+        {/* Draft: Approve / Reject stay always visible — primary actions */}
+        {isDraft && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 px-2.5 text-xs text-forest border-forest hover:bg-forest-bg "
+              onClick={handleConfirm}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading === 'approve' ? (
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+              ) : (
+                <Check className="h-3 w-3 mr-1" />
+              )}
+              Approve
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 px-2.5 text-xs text-vermillion border-vermillion hover:bg-vermillion-bg "
+              onClick={handleReject}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading === 'reject' ? (
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+              ) : (
+                <XCircle className="h-3 w-3 mr-1" />
+              )}
+              Reject
+            </Button>
+          </>
+        )}
+
+        {/* Edit / Delete — icon-only, revealed on hover */}
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-7 w-7 p-0 text-ink-4 hover:text-ink-2',
+            revealOnHover,
+          )}
+          onClick={() => onEdit(commitment)}
+          aria-label="Edit commitment"
+          title="Edit"
+        >
+          <Edit className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-7 w-7 p-0 text-ink-4 hover:text-vermillion hover:bg-vermillion-bg',
+            revealOnHover,
+          )}
+          onClick={() => onDelete(commitment)}
+          aria-label="Delete commitment"
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/commitments/components/commitments-empty-state.tsx
+++ b/src/app/commitments/components/commitments-empty-state.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { AlertCircle, FilterX, Plus, Target } from 'lucide-react'
+import { CommitmentTab, DueFilter } from '../utils/commitment-view'
+
+interface CommitmentsEmptyStateProps {
+  tab: CommitmentTab
+  dueFilter: DueFilter
+  searchActive: boolean
+  hasActiveFilters: boolean
+  onClearFilters: () => void
+  onCreate: () => void
+}
+
+export function CommitmentsEmptyState({
+  tab,
+  dueFilter,
+  searchActive,
+  hasActiveFilters,
+  onClearFilters,
+  onCreate,
+}: CommitmentsEmptyStateProps) {
+  let title = 'No commitments found'
+  let message =
+    'Commitments are created during sessions or manually by coaches.'
+  let Icon = Target
+
+  if (dueFilter === 'overdue' && !searchActive) {
+    title = 'Nothing overdue'
+    message = 'No commitments are past their due date. Nice work.'
+    Icon = AlertCircle
+  } else if (tab === 'drafts') {
+    title = 'No drafts to review'
+    message =
+      'Drafts are created when AI extracts commitments from session transcripts.'
+  } else if (hasActiveFilters) {
+    title = 'No matching commitments'
+    message = 'Nothing matches the current search and filters.'
+    Icon = FilterX
+  }
+
+  return (
+    <Card className="border-line ">
+      <CardContent className="py-16 text-center">
+        <div className="inline-flex items-center justify-center w-14 h-14 bg-surface-3 rounded-full mb-4">
+          <Icon className="h-7 w-7 text-ink-4" />
+        </div>
+        <h3 className="text-base font-semibold text-ink mb-1">{title}</h3>
+        <p className="text-sm text-ink-3 mb-4">{message}</p>
+        <div className="flex items-center justify-center gap-2">
+          {hasActiveFilters && (
+            <Button
+              variant="outline"
+              onClick={onClearFilters}
+              className="border-line-strong "
+            >
+              <FilterX className="h-4 w-4 mr-2" />
+              Clear filters
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={onCreate}
+            className="border-line-strong "
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Create Commitment
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/commitments/components/commitments-flat-list.tsx
+++ b/src/app/commitments/components/commitments-flat-list.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+import { CommitmentSection } from '../hooks/use-commitments-view'
+import { CommitmentRow, CommitmentRowHandlers } from './commitment-row'
+
+interface CommitmentsFlatListProps {
+  sections: CommitmentSection[]
+  rowHandlers: CommitmentRowHandlers
+  selectedDraftIds: Set<string>
+}
+
+/**
+ * Default view: one flat, smart-sorted list split into
+ * "My commitments" (assigned to the coach) and "Client commitments".
+ */
+export function CommitmentsFlatList({
+  sections,
+  rowHandlers,
+  selectedDraftIds,
+}: CommitmentsFlatListProps) {
+  return (
+    <div className="space-y-6">
+      {sections.map(section => (
+        <div key={section.key}>
+          <div className="flex items-baseline gap-2 mb-2 px-1">
+            <h2 className="text-xs font-semibold text-ink-3 uppercase tracking-wider">
+              {section.label}
+            </h2>
+            <span className="text-xs text-ink-4 tabular-nums">
+              {section.commitments.length}
+            </span>
+          </div>
+          <Card className="border-line overflow-hidden py-0 gap-0">
+            {section.commitments.map(commitment => (
+              <CommitmentRow
+                key={commitment.id}
+                commitment={commitment}
+                showClient
+                isSelected={selectedDraftIds.has(commitment.id)}
+                {...rowHandlers}
+              />
+            ))}
+          </Card>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/commitments/components/commitments-grouped-list.tsx
+++ b/src/app/commitments/components/commitments-grouped-list.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+import { Card } from '@/components/ui/card'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { formatDateOnly } from '@/lib/date-utils'
+import { cn } from '@/lib/utils'
+import { ChevronRight } from 'lucide-react'
+import { CommitmentGroup, CommitmentGroupBy } from '../utils/commitment-view'
+import { CommitmentRow, CommitmentRowHandlers } from './commitment-row'
+
+interface CommitmentsGroupedListProps {
+  groups: CommitmentGroup[]
+  groupBy: Exclude<CommitmentGroupBy, 'none'>
+  rowHandlers: CommitmentRowHandlers
+  selectedDraftIds: Set<string>
+}
+
+function groupSummary(
+  group: CommitmentGroup,
+  groupBy: Exclude<CommitmentGroupBy, 'none'>,
+): string {
+  if (groupBy === 'status') {
+    return `${group.commitments.length}`
+  }
+  const parts: string[] = []
+  if (group.draftCount > 0)
+    parts.push(`${group.draftCount} draft${group.draftCount !== 1 ? 's' : ''}`)
+  if (group.activeCount > 0) parts.push(`${group.activeCount} active`)
+  if (group.completedCount > 0) parts.push(`${group.completedCount} done`)
+  return parts.join(' · ')
+}
+
+/**
+ * Collapsible group cards for the By client / By session / By status views.
+ * Collapse state lives here — remount with `key={groupBy}` to reset it.
+ */
+export function CommitmentsGroupedList({
+  groups,
+  groupBy,
+  rowHandlers,
+  selectedDraftIds,
+}: CommitmentsGroupedListProps) {
+  // Track collapsed (not expanded) so new groups default to open
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+
+  const toggle = (key: string) => {
+    setCollapsed(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map(group => {
+        const isOpen = !collapsed.has(group.key)
+        return (
+          <Collapsible
+            key={group.key}
+            open={isOpen}
+            onOpenChange={() => toggle(group.key)}
+          >
+            <Card className="border-line overflow-hidden py-0 gap-0">
+              <CollapsibleTrigger asChild>
+                <button className="w-full flex items-center gap-3 px-4 py-3 hover:bg-paper transition-colors text-left">
+                  <ChevronRight
+                    className={cn(
+                      'h-4 w-4 text-ink-4 transition-transform flex-shrink-0',
+                      isOpen && 'rotate-90',
+                    )}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-semibold text-ink truncate">
+                      {group.label}
+                      {groupBy === 'session' && group.dateISO && (
+                        <span className="text-ink-3 font-normal">
+                          {' '}
+                          — {formatDateOnly(group.dateISO, 'MMM d, yyyy')}
+                        </span>
+                      )}
+                    </h3>
+                  </div>
+                  <span className="text-xs text-ink-4 flex-shrink-0">
+                    {groupSummary(group, groupBy)}
+                  </span>
+                </button>
+              </CollapsibleTrigger>
+
+              <CollapsibleContent>
+                <div className="border-t border-line ">
+                  {group.commitments.map(commitment => (
+                    <CommitmentRow
+                      key={commitment.id}
+                      commitment={commitment}
+                      showClient={groupBy !== 'client'}
+                      isSelected={selectedDraftIds.has(commitment.id)}
+                      {...rowHandlers}
+                    />
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </Card>
+          </Collapsible>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/commitments/components/commitments-skeleton.tsx
+++ b/src/app/commitments/components/commitments-skeleton.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function CommitmentsSkeleton() {
+  return (
+    <div>
+      {/* Stats strip */}
+      <div className="flex items-center gap-8 mb-6 px-1">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-5 w-20" />
+        ))}
+      </div>
+
+      {/* Tabs + controls */}
+      <div className="flex items-center gap-3 mb-6 pb-2 border-b border-line">
+        <Skeleton className="h-5 w-64" />
+        <div className="flex-1" />
+        <Skeleton className="h-8 w-44 rounded-md" />
+        <Skeleton className="h-8 w-24 rounded-md" />
+        <Skeleton className="h-8 w-24 rounded-md" />
+      </div>
+
+      {/* Rows */}
+      <Card className="border-line overflow-hidden py-0 gap-0">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 px-4 py-4 border-b border-line last:border-b-0"
+          >
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-2/5" />
+              <Skeleton className="h-3 w-3/5" />
+            </div>
+            <Skeleton className="h-6 w-16 rounded-md" />
+            <Skeleton className="h-6 w-20 rounded-md" />
+          </div>
+        ))}
+      </Card>
+    </div>
+  )
+}

--- a/src/app/commitments/components/commitments-stats.tsx
+++ b/src/app/commitments/components/commitments-stats.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { CommitmentStats } from '@/types/commitment'
+import { cn } from '@/lib/utils'
+
+interface CommitmentsStatsProps {
+  stats?: CommitmentStats
+  fallbackActive: number
+  fallbackCompleted: number
+  overdueFilterActive: boolean
+  onToggleOverdue: () => void
+}
+
+/**
+ * One quiet inline strip instead of stat cards. "At risk" is the only
+ * colored + interactive figure — it doubles as the overdue quick-filter.
+ */
+export function CommitmentsStats({
+  stats,
+  fallbackActive,
+  fallbackCompleted,
+  overdueFilterActive,
+  onToggleOverdue,
+}: CommitmentsStatsProps) {
+  const atRisk = stats?.at_risk_count ?? 0
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-8 gap-y-2 mb-6 px-1">
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-lg font-semibold text-ink tabular-nums">
+          {stats?.total_active ?? fallbackActive}
+        </span>
+        <span className="text-xs text-ink-3">active</span>
+      </div>
+
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-lg font-semibold text-ink tabular-nums">
+          {stats?.total_completed ?? fallbackCompleted}
+        </span>
+        <span className="text-xs text-ink-3">completed</span>
+      </div>
+
+      <button
+        onClick={onToggleOverdue}
+        aria-pressed={overdueFilterActive}
+        title={
+          overdueFilterActive
+            ? 'Showing overdue only — click to clear'
+            : 'Show overdue commitments only'
+        }
+        className={cn(
+          'flex items-baseline gap-1.5 rounded-md -mx-2 px-2 py-0.5 transition-colors',
+          'hover:bg-vermillion-bg/60',
+          overdueFilterActive && 'bg-vermillion-bg ring-1 ring-vermillion/40',
+        )}
+      >
+        <span
+          className={cn(
+            'text-lg font-semibold tabular-nums',
+            atRisk > 0 ? 'text-vermillion' : 'text-ink',
+          )}
+        >
+          {atRisk}
+        </span>
+        <span
+          className={cn(
+            'text-xs',
+            overdueFilterActive ? 'text-vermillion' : 'text-ink-3',
+          )}
+        >
+          at risk
+        </span>
+      </button>
+
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-lg font-semibold text-ink tabular-nums">
+          {stats?.completion_rate ?? 0}%
+        </span>
+        <span className="text-xs text-ink-3">completion</span>
+      </div>
+    </div>
+  )
+}

--- a/src/app/commitments/components/commitments-toolbar.tsx
+++ b/src/app/commitments/components/commitments-toolbar.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { CommitmentType, commitmentTypeLabels } from '@/types/commitment'
+import { cn } from '@/lib/utils'
+import { AlertCircle, ArrowUpDown, Layers, Search, X } from 'lucide-react'
+import {
+  CommitmentGroupBy,
+  CommitmentSort,
+  CommitmentTab,
+  DueFilter,
+} from '../utils/commitment-view'
+
+interface ClientOption {
+  id: string
+  name: string
+}
+
+interface CommitmentsToolbarProps {
+  tab: CommitmentTab
+  onTabChange: (tab: CommitmentTab) => void
+  counts: { all: number; active: number; drafts: number; completed: number }
+  searchInput: string
+  onSearchChange: (value: string) => void
+  sort: CommitmentSort
+  onSortChange: (sort: CommitmentSort) => void
+  groupBy: CommitmentGroupBy
+  onGroupByChange: (groupBy: CommitmentGroupBy) => void
+  clientFilter: string
+  onClientChange: (clientId: string) => void
+  clients: ClientOption[]
+  typeFilter: CommitmentType | 'all'
+  onTypeChange: (type: CommitmentType | 'all') => void
+  dueFilter: DueFilter
+  onClearDue: () => void
+}
+
+const SORT_LABELS: Record<CommitmentSort, string> = {
+  smart: 'Smart',
+  due: 'Due date',
+  priority: 'Priority',
+  created: 'Newest',
+  client: 'Client',
+}
+
+const GROUP_LABELS: Record<CommitmentGroupBy, string> = {
+  none: 'No grouping',
+  client: 'By client',
+  session: 'By session',
+  status: 'By status',
+}
+
+const GHOST_TRIGGER =
+  'h-8 w-auto gap-1 border-0 bg-transparent px-2 shadow-none text-ink-3 hover:text-ink data-[state=open]:text-ink focus:ring-0 focus-visible:ring-1'
+
+export function CommitmentsToolbar({
+  tab,
+  onTabChange,
+  counts,
+  searchInput,
+  onSearchChange,
+  sort,
+  onSortChange,
+  groupBy,
+  onGroupByChange,
+  clientFilter,
+  onClientChange,
+  clients,
+  typeFilter,
+  onTypeChange,
+  dueFilter,
+  onClearDue,
+}: CommitmentsToolbarProps) {
+  const tabs: { key: CommitmentTab; label: string; count: number }[] = [
+    { key: 'all', label: 'All', count: counts.all },
+    { key: 'active', label: 'Active', count: counts.active },
+    { key: 'drafts', label: 'Drafts', count: counts.drafts },
+    { key: 'completed', label: 'Completed', count: counts.completed },
+  ]
+
+  return (
+    <div className="mb-6 space-y-3">
+      {/* Tabs + controls share one hairline */}
+      <div className="flex flex-wrap items-end gap-x-2 gap-y-2 border-b border-line">
+        <div className="flex items-center gap-5">
+          {tabs.map(t => (
+            <button
+              key={t.key}
+              onClick={() => onTabChange(t.key)}
+              className={cn(
+                'pb-2.5 -mb-px text-sm font-medium border-b-2 transition-colors',
+                tab === t.key
+                  ? 'text-ink border-ink'
+                  : 'text-ink-3 border-transparent hover:text-ink-2',
+              )}
+            >
+              {t.label}
+              {t.count > 0 && (
+                <span className="ml-1.5 text-xs text-ink-4 tabular-nums">
+                  {t.count}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1" />
+
+        <div className="flex flex-wrap items-center gap-1 pb-1.5">
+          {/* Search */}
+          <div className="relative mr-1">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-ink-4 pointer-events-none" />
+            <Input
+              value={searchInput}
+              onChange={e => onSearchChange(e.target.value)}
+              placeholder="Search..."
+              className="h-8 pl-8 w-[180px] border-0 shadow-none bg-surface-3/60 focus-visible:bg-surface-1 focus-visible:ring-1"
+            />
+            {searchInput && (
+              <button
+                onClick={() => onSearchChange('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-ink-4 hover:text-ink-2"
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+
+          {/* Sort */}
+          <Select
+            value={sort}
+            onValueChange={v => onSortChange(v as CommitmentSort)}
+          >
+            <SelectTrigger className={GHOST_TRIGGER} aria-label="Sort">
+              <span className="flex items-center gap-1.5 truncate">
+                <ArrowUpDown className="h-3.5 w-3.5 shrink-0" />
+                <SelectValue />
+              </span>
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(SORT_LABELS) as CommitmentSort[]).map(key => (
+                <SelectItem key={key} value={key}>
+                  {SORT_LABELS[key]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Group by */}
+          <Select
+            value={groupBy}
+            onValueChange={v => onGroupByChange(v as CommitmentGroupBy)}
+          >
+            <SelectTrigger className={GHOST_TRIGGER} aria-label="Group by">
+              <span className="flex items-center gap-1.5 truncate">
+                <Layers className="h-3.5 w-3.5 shrink-0" />
+                <SelectValue />
+              </span>
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(GROUP_LABELS) as CommitmentGroupBy[]).map(key => (
+                <SelectItem key={key} value={key}>
+                  {GROUP_LABELS[key]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Client filter */}
+          <Select value={clientFilter} onValueChange={onClientChange}>
+            <SelectTrigger className={GHOST_TRIGGER} aria-label="Client">
+              <SelectValue placeholder="All Clients" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Clients</SelectItem>
+              {clients.map(client => (
+                <SelectItem key={client.id} value={client.id}>
+                  {client.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Type filter */}
+          <Select
+            value={typeFilter}
+            onValueChange={v => onTypeChange(v as CommitmentType | 'all')}
+          >
+            <SelectTrigger className={GHOST_TRIGGER} aria-label="Type">
+              <SelectValue placeholder="All Types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              {Object.entries(commitmentTypeLabels).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Active due-filter chip */}
+      {dueFilter && (
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onClearDue}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-vermillion-bg text-vermillion border border-vermillion hover:opacity-80 transition-opacity"
+          >
+            <AlertCircle className="h-3 w-3" />
+            {dueFilter === 'overdue' ? 'Overdue only' : 'Due within 7 days'}
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/commitments/components/draft-review-bar.tsx
+++ b/src/app/commitments/components/draft-review-bar.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
+
+interface DraftReviewBarProps {
+  visibleDraftIds: string[]
+  selectedDraftIds: Set<string>
+  onToggleAll: () => void
+  onBulkApprove: () => void
+  onBulkReject: () => void
+  approving: boolean
+  rejecting: boolean
+}
+
+/**
+ * Bulk approve/reject bar for AI-extracted draft commitments.
+ * Shown whenever drafts are visible in the current view (any tab).
+ */
+export function DraftReviewBar({
+  visibleDraftIds,
+  selectedDraftIds,
+  onToggleAll,
+  onBulkApprove,
+  onBulkReject,
+  approving,
+  rejecting,
+}: DraftReviewBarProps) {
+  const allSelected =
+    visibleDraftIds.length > 0 &&
+    visibleDraftIds.every(id => selectedDraftIds.has(id))
+
+  return (
+    <Card className="border-amber-token bg-amber-token-bg/50 mb-4 py-0 gap-0">
+      <CardContent className="py-3 px-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Checkbox checked={allSelected} onCheckedChange={onToggleAll} />
+            <span className="text-sm text-ink-2 ">
+              {selectedDraftIds.size > 0
+                ? `${selectedDraftIds.size} of ${visibleDraftIds.length} selected`
+                : `${visibleDraftIds.length} draft${
+                    visibleDraftIds.length !== 1 ? 's' : ''
+                  } pending review`}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onBulkReject}
+              disabled={selectedDraftIds.size === 0 || rejecting}
+              className="border-vermillion text-vermillion hover:bg-vermillion-bg "
+            >
+              {rejecting ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <XCircle className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              Reject
+            </Button>
+            <Button
+              size="sm"
+              onClick={onBulkApprove}
+              disabled={selectedDraftIds.size === 0 || approving}
+              className="bg-forest hover:bg-forest text-ink-on-dark"
+            >
+              {approving ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              Approve ({selectedDraftIds.size})
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/commitments/hooks/use-commitments-view.ts
+++ b/src/app/commitments/hooks/use-commitments-view.ts
@@ -1,0 +1,197 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { useCommitments } from '@/hooks/queries/use-commitments'
+import { Commitment, CommitmentType } from '@/types/commitment'
+import {
+  COMMITMENT_TABS,
+  CommitmentGroup,
+  CommitmentGroupBy,
+  CommitmentSort,
+  CommitmentTab,
+  DueFilter,
+  SORT_COMPARATORS,
+  groupCommitments,
+  matchesDueFilter,
+  matchesSearch,
+  matchesTab,
+} from '../utils/commitment-view'
+
+export interface CommitmentSection {
+  key: 'mine' | 'clients'
+  label: string
+  commitments: Commitment[]
+}
+
+/**
+ * State + derived data for the commitments hub.
+ *
+ * `tab`, `client` and `due` live in the URL so the dashboard's overdue chip
+ * (and any future surface) can deep-link into a pre-filtered view. Search,
+ * sort and grouping are ephemeral local state.
+ */
+export function useCommitmentsView() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const { userId } = useAuth()
+
+  // --- URL-backed state ---
+  const tabParam = searchParams.get('tab') as CommitmentTab | null
+  const tab: CommitmentTab =
+    tabParam && COMMITMENT_TABS.includes(tabParam) ? tabParam : 'all'
+  const clientFilter = searchParams.get('client') || 'all'
+  const dueParam = searchParams.get('due')
+  const dueFilter: DueFilter =
+    dueParam === 'overdue' || dueParam === 'soon' ? dueParam : null
+
+  const setParam = useCallback(
+    (key: string, value: string | null) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value === null) params.delete(key)
+      else params.set(key, value)
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [searchParams, router, pathname],
+  )
+
+  const setTab = useCallback(
+    (t: CommitmentTab) => setParam('tab', t === 'all' ? null : t),
+    [setParam],
+  )
+  const setClientFilter = useCallback(
+    (id: string) => setParam('client', id === 'all' ? null : id),
+    [setParam],
+  )
+  const toggleOverdueFilter = useCallback(
+    () => setParam('due', dueFilter === 'overdue' ? null : 'overdue'),
+    [setParam, dueFilter],
+  )
+  const clearDueFilter = useCallback(() => setParam('due', null), [setParam])
+
+  // --- Local state ---
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setSearch(searchInput), 200)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const [sort, setSort] = useState<CommitmentSort>('smart')
+  const [groupBy, setGroupBy] = useState<CommitmentGroupBy>('none')
+  const [typeFilter, setTypeFilter] = useState<CommitmentType | 'all'>('all')
+
+  // --- Data (keep the filter object identical to other surfaces so the
+  // query key stays shared with the client profile / portal caches) ---
+  const { data: commitmentsData, isLoading } = useCommitments({
+    include_drafts: true,
+    my_clients_only: true,
+  })
+
+  const allCommitments = useMemo(
+    () => commitmentsData?.commitments ?? [],
+    [commitmentsData],
+  )
+
+  // --- Pipeline: filter → sort → section/group ---
+  const filteredCommitments = useMemo(() => {
+    return allCommitments.filter(
+      c =>
+        matchesTab(c, tab) &&
+        (clientFilter === 'all' || c.client_id === clientFilter) &&
+        (typeFilter === 'all' || c.type === typeFilter) &&
+        matchesDueFilter(c, dueFilter) &&
+        matchesSearch(c, search),
+    )
+  }, [allCommitments, tab, clientFilter, typeFilter, dueFilter, search])
+
+  const isMine = useCallback(
+    (c: Commitment) =>
+      userId ? c.assigned_to_id === userId : !!c.is_coach_commitment,
+    [userId],
+  )
+
+  const sections = useMemo<CommitmentSection[]>(() => {
+    if (groupBy !== 'none') return []
+    const comparator = SORT_COMPARATORS[sort]
+    const mine = filteredCommitments.filter(isMine).sort(comparator)
+    const clients = filteredCommitments.filter(c => !isMine(c)).sort(comparator)
+    const result: CommitmentSection[] = []
+    if (mine.length > 0)
+      result.push({ key: 'mine', label: 'My commitments', commitments: mine })
+    if (clients.length > 0)
+      result.push({
+        key: 'clients',
+        label: 'Client commitments',
+        commitments: clients,
+      })
+    return result
+  }, [filteredCommitments, groupBy, sort, isMine])
+
+  const groups = useMemo<CommitmentGroup[]>(() => {
+    if (groupBy === 'none') return []
+    return groupCommitments(filteredCommitments, groupBy, sort)
+  }, [filteredCommitments, groupBy, sort])
+
+  // --- Counts for tab badges (from the unfiltered set, like before) ---
+  const counts = useMemo(
+    () => ({
+      all: allCommitments.length,
+      active: allCommitments.filter(c => c.status === 'active').length,
+      drafts: allCommitments.filter(c => c.status === 'draft').length,
+      completed: allCommitments.filter(c => c.status === 'completed').length,
+    }),
+    [allCommitments],
+  )
+
+  const visibleDraftIds = useMemo(
+    () => filteredCommitments.filter(c => c.status === 'draft').map(c => c.id),
+    [filteredCommitments],
+  )
+
+  const hasActiveFilters =
+    tab !== 'all' ||
+    clientFilter !== 'all' ||
+    typeFilter !== 'all' ||
+    dueFilter !== null ||
+    search.trim() !== ''
+
+  const clearAllFilters = useCallback(() => {
+    setSearchInput('')
+    setTypeFilter('all')
+    router.replace(pathname, { scroll: false })
+  }, [router, pathname])
+
+  return {
+    // URL-backed state
+    tab,
+    setTab,
+    clientFilter,
+    setClientFilter,
+    dueFilter,
+    toggleOverdueFilter,
+    clearDueFilter,
+    // local state
+    searchInput,
+    setSearchInput,
+    sort,
+    setSort,
+    groupBy,
+    setGroupBy,
+    typeFilter,
+    setTypeFilter,
+    // data
+    isLoading,
+    allCommitments,
+    filteredCommitments,
+    sections,
+    groups,
+    counts,
+    visibleDraftIds,
+    hasActiveFilters,
+    clearAllFilters,
+  }
+}

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -1,405 +1,53 @@
 'use client'
 
-import React, { useState, useMemo, useEffect } from 'react'
-import { Card, CardContent } from '@/components/ui/card'
+import { Suspense, useState } from 'react'
+import PageLayout from '@/components/layout/page-layout'
+import { ProtectedRoute } from '@/components/auth/protected-route'
+import { PageHeader } from '@/components/ui/page-header'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { Checkbox } from '@/components/ui/checkbox'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
-import {
-  Commitment,
-  CommitmentType,
-  CommitmentStatus,
-  CommitmentPriority,
-} from '@/types/commitment'
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
 import { CommitmentCreatePanel } from '@/components/commitments/commitment-create-panel'
 import { CommitmentDetailPanel } from '@/components/commitments/commitment-detail-panel'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { Calendar as CalendarWidget } from '@/components/ui/calendar'
-import {
-  useCommitments,
-  useCommitmentStats,
-} from '@/hooks/queries/use-commitments'
+import { useCommitmentStats } from '@/hooks/queries/use-commitments'
 import { useClients } from '@/hooks/queries/use-clients'
 import {
+  useBulkConfirmCommitments,
+  useBulkDiscardCommitments,
   useConfirmCommitment,
   useDiscardCommitment,
   useUpdateCommitment,
-  useBulkConfirmCommitments,
-  useBulkDiscardCommitments,
 } from '@/hooks/mutations/use-commitment-mutations'
-import { formatDate, formatDateOnly } from '@/lib/date-utils'
-import { isPast, parseISO, differenceInDays } from 'date-fns'
-import PageLayout from '@/components/layout/page-layout'
-import {
-  Plus,
-  Target,
-  CheckCircle2,
-  TrendingUp,
-  AlertCircle,
-  Loader2,
-  ChevronRight,
-  UserCircle,
-  Calendar,
-  Sparkles,
-  XCircle,
-  Edit,
-  Trash2,
-  Check,
-  FileText,
-} from 'lucide-react'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { cn } from '@/lib/utils'
+import { Commitment, CommitmentStatus } from '@/types/commitment'
+import { Plus, Target } from 'lucide-react'
+import { useCommitmentsView } from './hooks/use-commitments-view'
+import { CommitmentRowHandlers } from './components/commitment-row'
+import { CommitmentsStats } from './components/commitments-stats'
+import { CommitmentsToolbar } from './components/commitments-toolbar'
+import { CommitmentsFlatList } from './components/commitments-flat-list'
+import { CommitmentsGroupedList } from './components/commitments-grouped-list'
+import { DraftReviewBar } from './components/draft-review-bar'
+import { CommitmentsEmptyState } from './components/commitments-empty-state'
+import { CommitmentsSkeleton } from './components/commitments-skeleton'
 
-// --- Helper types ---
+type ConfirmState =
+  | { kind: 'delete'; id: string; title: string }
+  | { kind: 'bulk-discard'; ids: string[] }
+  | null
 
-interface ClientGroup {
-  clientId: string
-  clientName: string
-  sessions: SessionGroup[]
-  draftCount: number
-  activeCount: number
-  completedCount: number
-}
-
-interface SessionGroup {
-  sessionId: string | null
-  sessionLabel: string
-  sessionDate: string | null
-  commitments: Commitment[]
-}
-
-// --- Status/Priority config ---
-
-const statusConfig: Record<
-  CommitmentStatus,
-  { label: string; className: string }
-> = {
-  draft: {
-    label: 'Draft',
-    className: 'bg-surface-3 text-ink-3 border-line ',
-  },
-  active: {
-    label: 'Active',
-    className: 'bg-ds-accent-bg text-ds-accent border-ds-accent ',
-  },
-  in_progress: {
-    label: 'In Progress',
-    className: 'bg-amber-token-bg text-amber-token border-amber-token ',
-  },
-  completed: {
-    label: 'Completed',
-    className: 'bg-forest-bg text-forest border-forest ',
-  },
-  abandoned: {
-    label: 'Abandoned',
-    className: 'bg-vermillion-bg text-vermillion border-vermillion ',
-  },
-}
-
-const priorityConfig: Record<
-  CommitmentPriority,
-  { label: string; className: string }
-> = {
-  low: { label: 'Low', className: 'text-ink-3' },
-  medium: { label: 'Medium', className: 'text-amber-token' },
-  high: { label: 'High', className: 'text-amber-token' },
-  urgent: { label: 'Urgent', className: 'text-vermillion' },
-}
-
-// --- Inline Commitment Row ---
-
-function CommitmentRow({
-  commitment,
-  onEdit,
-  onDelete,
-  onConfirm,
-  onReject,
-  onStatusChange,
-  onDateChange,
-  isSelected,
-  onSelect,
-}: {
-  commitment: Commitment
-  onEdit: (c: Commitment) => void
-  onDelete: (id: string) => void
-  onConfirm: (id: string) => void
-  onReject: (id: string) => void
-  onStatusChange: (id: string, status: CommitmentStatus) => void
-  onDateChange: (id: string, date: string | undefined) => void
-  isSelected?: boolean
-  onSelect?: (id: string) => void
-}) {
-  const [actionLoading, setActionLoading] = useState<
-    'approve' | 'reject' | null
-  >(null)
-  const [dateOpen, setDateOpen] = useState(false)
-
-  const handleConfirm = async () => {
-    setActionLoading('approve')
-    try {
-      await onConfirm(commitment.id)
-    } finally {
-      setActionLoading(null)
-    }
-  }
-  const handleReject = async () => {
-    setActionLoading('reject')
-    try {
-      await onReject(commitment.id)
-    } finally {
-      setActionLoading(null)
-    }
-  }
-
-  const status = statusConfig[commitment.status]
-  const priority = priorityConfig[commitment.priority]
-  const isDraft = commitment.status === 'draft'
-  const isOverdue =
-    commitment.status !== 'completed' &&
-    commitment.target_date &&
-    isPast(parseISO(commitment.target_date))
-  const daysUntil = commitment.target_date
-    ? differenceInDays(parseISO(commitment.target_date), new Date())
-    : null
-
-  return (
-    <div
-      className={cn(
-        'flex items-start gap-3 px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper transition-colors',
-        isSelected && 'bg-ds-accent-bg/50 ',
-      )}
-    >
-      {/* Checkbox for drafts */}
-      {isDraft && (
-        <Checkbox
-          checked={isSelected}
-          onCheckedChange={() => onSelect?.(commitment.id)}
-          className="flex-shrink-0 mt-1"
-        />
-      )}
-
-      {/* Left: content */}
-      <div className="flex-1 min-w-0">
-        {/* Title line */}
-        <div className="flex items-center gap-2 flex-wrap">
-          <span
-            className="text-sm font-medium text-ink cursor-pointer hover:underline"
-            onClick={() => onEdit(commitment)}
-          >
-            {commitment.title}
-          </span>
-          {commitment.extracted_from_transcript && (
-            <Badge
-              variant="outline"
-              className="text-xs bg-indigo-bg text-indigo border-indigo "
-            >
-              <Sparkles className="h-3 w-3 mr-1" />
-              AI
-            </Badge>
-          )}
-          <Badge
-            variant="outline"
-            className={cn('text-xs', priority.className, 'border-current/20')}
-          >
-            {priority.label}
-          </Badge>
-        </div>
-
-        {/* Description */}
-        {commitment.description && (
-          <p className="text-xs text-ink-3 mt-0.5 truncate max-w-2xl">
-            {commitment.description}
-          </p>
-        )}
-
-        {/* Transcript context for drafts */}
-        {isDraft && commitment.transcript_context && (
-          <p className="text-xs text-ink-4 italic mt-0.5 truncate max-w-xl">
-            &ldquo;{commitment.transcript_context}&rdquo;
-          </p>
-        )}
-      </div>
-
-      {/* Right: inline controls + actions — always visible */}
-      <div className="flex items-center gap-2 flex-shrink-0">
-        {/* Inline status dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className={cn(
-                'inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium border cursor-pointer transition-colors hover:opacity-80',
-                status.className,
-              )}
-            >
-              {status.label}
-              <ChevronRight className="h-3 w-3" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {isDraft && (
-              <DropdownMenuItem onClick={() => onConfirm(commitment.id)}>
-                <Check className="h-3.5 w-3.5 mr-2 text-forest" />
-                Approve
-              </DropdownMenuItem>
-            )}
-            {commitment.status !== 'active' && !isDraft && (
-              <DropdownMenuItem
-                onClick={() => onStatusChange(commitment.id, 'active')}
-              >
-                <Target className="h-3.5 w-3.5 mr-2 text-ds-accent" />
-                Active
-              </DropdownMenuItem>
-            )}
-            {commitment.status !== 'completed' && (
-              <DropdownMenuItem
-                onClick={() => onStatusChange(commitment.id, 'completed')}
-              >
-                <CheckCircle2 className="h-3.5 w-3.5 mr-2 text-forest" />
-                Completed
-              </DropdownMenuItem>
-            )}
-            {commitment.status !== 'abandoned' && (
-              <DropdownMenuItem
-                onClick={() => onStatusChange(commitment.id, 'abandoned')}
-              >
-                <XCircle className="h-3.5 w-3.5 mr-2 text-vermillion" />
-                Abandon
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {/* Inline due date picker */}
-        <Popover open={dateOpen} onOpenChange={setDateOpen}>
-          <PopoverTrigger asChild>
-            <button
-              className={cn(
-                'inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs border border-line cursor-pointer transition-colors hover:bg-surface-3 ',
-                isOverdue
-                  ? 'text-vermillion font-medium border-vermillion '
-                  : daysUntil !== null && daysUntil <= 7
-                    ? 'text-amber-token '
-                    : 'text-ink-3 ',
-              )}
-            >
-              <Calendar className="h-3 w-3" />
-              {commitment.target_date
-                ? isOverdue
-                  ? `${Math.abs(daysUntil!)}d overdue`
-                  : formatDateOnly(commitment.target_date, 'MMM d')
-                : 'Set date'}
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="end">
-            <CalendarWidget
-              mode="single"
-              selected={
-                commitment.target_date
-                  ? parseISO(commitment.target_date)
-                  : undefined
-              }
-              onSelect={date => {
-                onDateChange(
-                  commitment.id,
-                  date ? date.toISOString().split('T')[0] : undefined,
-                )
-                setDateOpen(false)
-              }}
-              initialFocus
-            />
-          </PopoverContent>
-        </Popover>
-
-        {/* Draft: Approve / Reject */}
-        {isDraft && (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 px-2.5 text-xs text-forest border-forest hover:bg-forest-bg "
-              onClick={handleConfirm}
-              disabled={actionLoading !== null}
-            >
-              {actionLoading === 'approve' ? (
-                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-              ) : (
-                <Check className="h-3 w-3 mr-1" />
-              )}
-              Approve
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 px-2.5 text-xs text-vermillion border-vermillion hover:bg-vermillion-bg "
-              onClick={handleReject}
-              disabled={actionLoading !== null}
-            >
-              {actionLoading === 'reject' ? (
-                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-              ) : (
-                <XCircle className="h-3 w-3 mr-1" />
-              )}
-              Reject
-            </Button>
-          </>
-        )}
-
-        {/* Edit */}
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs text-ink-3 hover:text-ink-2 "
-          onClick={() => onEdit(commitment)}
-        >
-          <Edit className="h-3 w-3 mr-1" />
-          Edit
-        </Button>
-
-        {/* Delete */}
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs text-vermillion hover:text-vermillion hover:bg-vermillion-bg "
-          onClick={() => onDelete(commitment.id)}
-        >
-          <Trash2 className="h-3 w-3" />
-        </Button>
-      </div>
-    </div>
+function CommitmentsPageContent() {
+  const view = useCommitmentsView()
+  const { data: stats } = useCommitmentStats(undefined, true)
+  const { data: clientsData } = useClients()
+  const clients = (clientsData?.clients ?? []).filter(
+    c => c.is_my_client !== false,
   )
-}
 
-// --- Main Page ---
+  const confirmMutation = useConfirmCommitment()
+  const discardMutation = useDiscardCommitment()
+  const updateMutation = useUpdateCommitment()
+  const bulkConfirm = useBulkConfirmCommitments()
+  const bulkDiscard = useBulkDiscardCommitments()
 
-export default function CommitmentsPage() {
-  const [selectedClient, setSelectedClient] = useState<string>('all')
-  const [selectedType, setSelectedType] = useState<CommitmentType | 'all'>(
-    'all',
-  )
-  const [activeTab, setActiveTab] = useState<
-    'all' | 'active' | 'drafts' | 'completed'
-  >('all')
   const [createPanelOpen, setCreatePanelOpen] = useState(false)
   const [selectedCommitmentId, setSelectedCommitmentId] = useState<
     string | null
@@ -407,188 +55,57 @@ export default function CommitmentsPage() {
   const [selectedDraftIds, setSelectedDraftIds] = useState<Set<string>>(
     new Set(),
   )
-  const [expandedClients, setExpandedClients] = useState<Set<string>>(
-    new Set(['__all__']),
-  )
+  const [confirmState, setConfirmState] = useState<ConfirmState>(null)
 
-  // Data
-  const { data: commitmentsData, isLoading } = useCommitments({
-    include_drafts: true,
-    my_clients_only: true,
-  })
-  const { data: clientsData } = useClients()
-  const { data: stats } = useCommitmentStats(undefined, true)
-  const confirmMutation = useConfirmCommitment()
-  const discardMutation = useDiscardCommitment()
-  const updateMutation = useUpdateCommitment()
-  const bulkConfirm = useBulkConfirmCommitments()
-  const bulkDiscard = useBulkDiscardCommitments()
-
-  const allCommitments = useMemo(
-    () => commitmentsData?.commitments ?? [],
-    [commitmentsData],
-  )
-  const clients = clientsData?.clients ?? []
-
-  // Filter commitments
-  const filteredCommitments = useMemo(() => {
-    return allCommitments.filter(c => {
-      if (selectedClient !== 'all' && c.client_id !== selectedClient)
-        return false
-      if (selectedType !== 'all' && c.type !== selectedType) return false
-      if (activeTab === 'active' && c.status !== 'active') return false
-      if (activeTab === 'drafts' && c.status !== 'draft') return false
-      if (activeTab === 'completed' && c.status !== 'completed') return false
-      return true
+  // --- Draft selection ---
+  const deselectDraft = (id: string) => {
+    setSelectedDraftIds(prev => {
+      const next = new Set(prev)
+      next.delete(id)
+      return next
     })
-  }, [allCommitments, selectedClient, selectedType, activeTab])
-
-  // Group by client → session
-  const clientGroups = useMemo(() => {
-    const clientMap = new Map<string, ClientGroup>()
-
-    for (const c of filteredCommitments) {
-      const clientId = c.client_id
-      if (!clientMap.has(clientId)) {
-        clientMap.set(clientId, {
-          clientId,
-          clientName: c.client_name || 'Unknown Client',
-          sessions: [],
-          draftCount: 0,
-          activeCount: 0,
-          completedCount: 0,
-        })
-      }
-      const group = clientMap.get(clientId)!
-
-      if (c.status === 'draft') group.draftCount++
-      else if (c.status === 'active') group.activeCount++
-      else if (c.status === 'completed') group.completedCount++
-    }
-
-    // Now group by session within each client
-    for (const c of filteredCommitments) {
-      const group = clientMap.get(c.client_id)!
-      const sessionKey = c.session_id || '__manual__'
-
-      let sessionGroup = group.sessions.find(s => {
-        if (sessionKey === '__manual__') return s.sessionId === null
-        return s.sessionId === sessionKey
-      })
-
-      if (!sessionGroup) {
-        sessionGroup = {
-          sessionId: c.session_id || null,
-          sessionLabel: c.session_id ? `Session` : 'Manually Created',
-          sessionDate: c.created_at,
-          commitments: [],
-        }
-        group.sessions.push(sessionGroup)
-      }
-
-      sessionGroup.commitments.push(c)
-    }
-
-    // Sort sessions by date (newest first), and sort commitments within each session
-    for (const group of clientMap.values()) {
-      group.sessions.sort((a, b) => {
-        if (!a.sessionDate) return 1
-        if (!b.sessionDate) return -1
-        return (
-          new Date(b.sessionDate).getTime() - new Date(a.sessionDate).getTime()
-        )
-      })
-      for (const session of group.sessions) {
-        session.commitments.sort((a, b) => {
-          // Drafts first, then by date
-          if (a.status === 'draft' && b.status !== 'draft') return -1
-          if (a.status !== 'draft' && b.status === 'draft') return 1
-          return (
-            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-          )
-        })
-      }
-    }
-
-    // Sort clients alphabetically
-    return Array.from(clientMap.values()).sort((a, b) =>
-      a.clientName.localeCompare(b.clientName),
-    )
-  }, [filteredCommitments])
-
-  // Auto-expand all clients on first load
-
-  useEffect(() => {
-    if (clientGroups.length > 0 && expandedClients.has('__all__')) {
-      setExpandedClients(new Set(clientGroups.map(g => g.clientId)))
-    }
-  }, [clientGroups.length])
-
-  // Counts
-  const draftCount = allCommitments.filter(c => c.status === 'draft').length
-  const activeCount = allCommitments.filter(c => c.status === 'active').length
-  const completedCount = allCommitments.filter(
-    c => c.status === 'completed',
-  ).length
-
-  // Draft selection
-  const allDraftIds = filteredCommitments
-    .filter(c => c.status === 'draft')
-    .map(c => c.id)
-  const allDraftsSelected =
-    allDraftIds.length > 0 && allDraftIds.every(id => selectedDraftIds.has(id))
+  }
 
   const toggleDraftSelection = (id: string) => {
-    const next = new Set(selectedDraftIds)
-    if (next.has(id)) next.delete(id)
-    else next.add(id)
-    setSelectedDraftIds(next)
+    setSelectedDraftIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
   }
+
+  const allDraftsSelected =
+    view.visibleDraftIds.length > 0 &&
+    view.visibleDraftIds.every(id => selectedDraftIds.has(id))
 
   const toggleAllDrafts = () => {
-    if (allDraftsSelected) {
-      setSelectedDraftIds(new Set())
-    } else {
-      setSelectedDraftIds(new Set(allDraftIds))
-    }
+    setSelectedDraftIds(
+      allDraftsSelected ? new Set() : new Set(view.visibleDraftIds),
+    )
   }
 
-  const toggleClient = (clientId: string) => {
-    const next = new Set(expandedClients)
-    next.delete('__all__')
-    if (next.has(clientId)) next.delete(clientId)
-    else next.add(clientId)
-    setExpandedClients(next)
-  }
-
-  // Handlers
+  // --- Mutation handlers ---
   const handleConfirm = async (id: string) => {
     await confirmMutation.mutateAsync(id)
-    selectedDraftIds.delete(id)
-    setSelectedDraftIds(new Set(selectedDraftIds))
+    deselectDraft(id)
   }
 
   const handleReject = async (id: string) => {
     await discardMutation.mutateAsync(id)
-    selectedDraftIds.delete(id)
-    setSelectedDraftIds(new Set(selectedDraftIds))
+    deselectDraft(id)
   }
 
-  const handleDelete = async (id: string) => {
-    if (!confirm('Delete this commitment?')) return
-    await discardMutation.mutateAsync(id)
-    selectedDraftIds.delete(id)
-    setSelectedDraftIds(new Set(selectedDraftIds))
-  }
-
-  const handleStatusChange = async (
-    id: string,
-    newStatus: CommitmentStatus,
-  ) => {
-    await updateMutation.mutateAsync({
-      commitmentId: id,
-      data: { status: newStatus },
+  const handleDelete = (commitment: Commitment) => {
+    setConfirmState({
+      kind: 'delete',
+      id: commitment.id,
+      title: commitment.title,
     })
+  }
+
+  const handleStatusChange = async (id: string, status: CommitmentStatus) => {
+    await updateMutation.mutateAsync({ commitmentId: id, data: { status } })
   }
 
   const handleDateChange = async (id: string, date: string | undefined) => {
@@ -604,34 +121,37 @@ export default function CommitmentsPage() {
     setSelectedDraftIds(new Set())
   }
 
-  const handleBulkDiscard = async () => {
-    if (selectedDraftIds.size === 0) return
-    if (!confirm(`Delete ${selectedDraftIds.size} draft commitment(s)?`)) return
-    await bulkDiscard.mutateAsync(Array.from(selectedDraftIds))
-    setSelectedDraftIds(new Set())
+  const handleConfirmedAction = async () => {
+    if (!confirmState) return
+    if (confirmState.kind === 'delete') {
+      await discardMutation.mutateAsync(confirmState.id)
+      deselectDraft(confirmState.id)
+    } else {
+      await bulkDiscard.mutateAsync(confirmState.ids)
+      setSelectedDraftIds(new Set())
+    }
+    setConfirmState(null)
   }
 
-  if (isLoading) {
-    return (
-      <PageLayout>
-        <div className="flex items-center justify-center min-h-[60vh]">
-          <Loader2 className="h-8 w-8 animate-spin text-ink-4" />
-        </div>
-      </PageLayout>
-    )
+  const rowHandlers: CommitmentRowHandlers = {
+    onEdit: c => setSelectedCommitmentId(c.id),
+    onDelete: handleDelete,
+    onConfirm: handleConfirm,
+    onReject: handleReject,
+    onStatusChange: handleStatusChange,
+    onDateChange: handleDateChange,
+    onSelect: toggleDraftSelection,
   }
+
+  const isEmpty = view.filteredCommitments.length === 0
 
   return (
-    <PageLayout>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h1 className="text-3xl font-bold text-ink ">Commitments</h1>
-            <p className="text-ink-3 mt-1">
-              Track and manage commitments across all your clients
-            </p>
-          </div>
+    <>
+      <PageHeader
+        title="Commitments"
+        description="Track and manage commitments across all your clients"
+        icon={Target}
+        actions={
           <Button
             onClick={() => setCreatePanelOpen(true)}
             className="bg-ink hover:bg-ink-2 text-ink-on-dark "
@@ -639,326 +159,92 @@ export default function CommitmentsPage() {
             <Plus className="h-4 w-4 mr-2" />
             New Commitment
           </Button>
-        </div>
+        }
+      />
 
-        {/* Stats Cards */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
-          <Card className="border-line ">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2 mb-1">
-                <Target className="h-4 w-4 text-ds-accent" />
-                <span className="text-xs text-ink-3 font-medium">Active</span>
-              </div>
-              <p className="text-xl font-bold text-ink ">
-                {stats?.total_active ?? activeCount}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="border-line ">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2 mb-1">
-                <CheckCircle2 className="h-4 w-4 text-forest" />
-                <span className="text-xs text-ink-3 font-medium">
-                  Completed
-                </span>
-              </div>
-              <p className="text-xl font-bold text-ink ">
-                {stats?.total_completed ?? completedCount}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="border-line ">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2 mb-1">
-                <AlertCircle className="h-4 w-4 text-vermillion" />
-                <span className="text-xs text-ink-3 font-medium">At Risk</span>
-              </div>
-              <p className="text-xl font-bold text-ink ">
-                {stats?.at_risk_count ?? 0}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="border-line ">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2 mb-1">
-                <TrendingUp className="h-4 w-4 text-forest" />
-                <span className="text-xs text-ink-3 font-medium">
-                  Completion Rate
-                </span>
-              </div>
-              <p className="text-xl font-bold text-ink ">
-                {stats?.completion_rate ?? 0}%
-              </p>
-            </CardContent>
-          </Card>
-        </div>
+      {view.isLoading ? (
+        <CommitmentsSkeleton />
+      ) : (
+        <>
+          <CommitmentsStats
+            stats={stats}
+            fallbackActive={view.counts.active}
+            fallbackCompleted={view.counts.completed}
+            overdueFilterActive={view.dueFilter === 'overdue'}
+            onToggleOverdue={view.toggleOverdueFilter}
+          />
 
-        {/* Filters & Tabs Bar */}
-        <div className="flex flex-wrap items-center gap-3 mb-6">
-          {/* Tabs */}
-          <div className="flex items-center bg-surface-3 rounded-lg p-1">
-            {[
-              {
-                key: 'all' as const,
-                label: 'All',
-                count: allCommitments.length,
-              },
-              { key: 'active' as const, label: 'Active', count: activeCount },
-              { key: 'drafts' as const, label: 'Drafts', count: draftCount },
-              {
-                key: 'completed' as const,
-                label: 'Completed',
-                count: completedCount,
-              },
-            ].map(tab => (
-              <button
-                key={tab.key}
-                onClick={() => setActiveTab(tab.key)}
-                className={cn(
-                  'px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1.5',
-                  activeTab === tab.key
-                    ? 'bg-surface-1 text-ink shadow-sm'
-                    : 'text-ink-3 hover:text-ink-2 ',
-                )}
-              >
-                {tab.label}
-                {tab.count > 0 && (
-                  <span
-                    className={cn(
-                      'text-xs px-1.5 py-0.5 rounded-full',
-                      activeTab === tab.key
-                        ? 'bg-ink text-ink-on-dark '
-                        : 'bg-surface-3 text-ink-3 ',
-                    )}
-                  >
-                    {tab.count}
-                  </span>
-                )}
-              </button>
-            ))}
-          </div>
+          <CommitmentsToolbar
+            tab={view.tab}
+            onTabChange={view.setTab}
+            counts={view.counts}
+            searchInput={view.searchInput}
+            onSearchChange={view.setSearchInput}
+            sort={view.sort}
+            onSortChange={view.setSort}
+            groupBy={view.groupBy}
+            onGroupByChange={view.setGroupBy}
+            clientFilter={view.clientFilter}
+            onClientChange={view.setClientFilter}
+            clients={clients}
+            typeFilter={view.typeFilter}
+            onTypeChange={view.setTypeFilter}
+            dueFilter={view.dueFilter}
+            onClearDue={view.clearDueFilter}
+          />
 
-          <div className="flex-1" />
+          {view.visibleDraftIds.length > 0 && (
+            <DraftReviewBar
+              visibleDraftIds={view.visibleDraftIds}
+              selectedDraftIds={selectedDraftIds}
+              onToggleAll={toggleAllDrafts}
+              onBulkApprove={handleBulkConfirm}
+              onBulkReject={() =>
+                setConfirmState({
+                  kind: 'bulk-discard',
+                  ids: Array.from(selectedDraftIds),
+                })
+              }
+              approving={bulkConfirm.isPending}
+              rejecting={bulkDiscard.isPending}
+            />
+          )}
 
-          {/* Client filter */}
-          <Select value={selectedClient} onValueChange={setSelectedClient}>
-            <SelectTrigger className="w-[180px] border-line ">
-              <SelectValue placeholder="All Clients" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Clients</SelectItem>
-              {clients
-                .filter(c => c.is_my_client !== false)
-                .map(client => (
-                  <SelectItem key={client.id} value={client.id}>
-                    {client.name}
-                  </SelectItem>
-                ))}
-            </SelectContent>
-          </Select>
-
-          {/* Type filter */}
-          <Select
-            value={selectedType}
-            onValueChange={v => setSelectedType(v as CommitmentType | 'all')}
-          >
-            <SelectTrigger className="w-[160px] border-line ">
-              <SelectValue placeholder="All Types" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Types</SelectItem>
-              <SelectItem value="commitment">Commitment</SelectItem>
-              <SelectItem value="habit">Habit</SelectItem>
-              <SelectItem value="mp_outcome">MP Outcome</SelectItem>
-              <SelectItem value="learning">Learning</SelectItem>
-              <SelectItem value="sprint">Sprint</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* Bulk Draft Actions */}
-        {activeTab === 'drafts' && draftCount > 0 && (
-          <Card className="border-amber-token bg-amber-token-bg/50 mb-4">
-            <CardContent className="py-3 px-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <Checkbox
-                    checked={allDraftsSelected}
-                    onCheckedChange={toggleAllDrafts}
-                  />
-                  <span className="text-sm text-ink-2 ">
-                    {selectedDraftIds.size > 0
-                      ? `${selectedDraftIds.size} of ${allDraftIds.length} selected`
-                      : `${allDraftIds.length} draft${allDraftIds.length !== 1 ? 's' : ''} pending review`}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={handleBulkDiscard}
-                    disabled={
-                      selectedDraftIds.size === 0 || bulkDiscard.isPending
-                    }
-                    className="border-vermillion text-vermillion hover:bg-vermillion-bg "
-                  >
-                    {bulkDiscard.isPending ? (
-                      <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                    ) : (
-                      <XCircle className="h-3.5 w-3.5 mr-1.5" />
-                    )}
-                    Reject
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={handleBulkConfirm}
-                    disabled={
-                      selectedDraftIds.size === 0 || bulkConfirm.isPending
-                    }
-                    className="bg-forest hover:bg-forest text-ink-on-dark"
-                  >
-                    {bulkConfirm.isPending ? (
-                      <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                    ) : (
-                      <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />
-                    )}
-                    Approve ({selectedDraftIds.size})
-                  </Button>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Empty State */}
-        {filteredCommitments.length === 0 && (
-          <Card className="border-line ">
-            <CardContent className="py-16 text-center">
-              <div className="inline-flex items-center justify-center w-14 h-14 bg-surface-3 rounded-full mb-4">
-                <Target className="h-7 w-7 text-ink-4" />
-              </div>
-              <h3 className="text-base font-semibold text-ink mb-1">
-                No commitments found
-              </h3>
-              <p className="text-sm text-ink-3 mb-4">
-                {activeTab === 'drafts'
-                  ? 'No draft commitments to review. Drafts are created when AI extracts commitments from session transcripts.'
-                  : 'Commitments are created during sessions or manually by coaches.'}
-              </p>
-              <Button
-                variant="outline"
-                onClick={() => setCreatePanelOpen(true)}
-                className="border-line-strong "
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Create Commitment
-              </Button>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Client → Session → Commitments Hierarchy */}
-        <div className="space-y-4">
-          {clientGroups.map(clientGroup => (
-            <Collapsible
-              key={clientGroup.clientId}
-              open={expandedClients.has(clientGroup.clientId)}
-              onOpenChange={() => toggleClient(clientGroup.clientId)}
-            >
-              <Card className="border-line overflow-hidden">
-                {/* Client Header */}
-                <CollapsibleTrigger asChild>
-                  <button className="w-full flex items-center gap-3 px-5 py-4 hover:bg-paper transition-colors text-left">
-                    <ChevronRight
-                      className={cn(
-                        'h-4 w-4 text-ink-4 transition-transform flex-shrink-0',
-                        expandedClients.has(clientGroup.clientId) &&
-                          'rotate-90',
-                      )}
-                    />
-                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-ink flex-shrink-0">
-                      <UserCircle className="h-4 w-4 text-ink-on-dark " />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-semibold text-ink ">
-                        {clientGroup.clientName}
-                      </h3>
-                    </div>
-                    <div className="flex items-center gap-2 flex-shrink-0">
-                      {clientGroup.draftCount > 0 && (
-                        <Badge className="bg-surface-3 text-ink-3 text-xs">
-                          {clientGroup.draftCount} draft
-                          {clientGroup.draftCount !== 1 && 's'}
-                        </Badge>
-                      )}
-                      {clientGroup.activeCount > 0 && (
-                        <Badge className="bg-ds-accent-bg text-ds-accent text-xs">
-                          {clientGroup.activeCount} active
-                        </Badge>
-                      )}
-                      {clientGroup.completedCount > 0 && (
-                        <Badge className="bg-forest-bg text-forest text-xs">
-                          {clientGroup.completedCount} done
-                        </Badge>
-                      )}
-                    </div>
-                  </button>
-                </CollapsibleTrigger>
-
-                <CollapsibleContent>
-                  <div className="border-t border-line ">
-                    {clientGroup.sessions.map((session, idx) => (
-                      <div key={session.sessionId || `manual-${idx}`}>
-                        {/* Session Header */}
-                        <div className="flex items-center gap-2 px-5 py-2.5 bg-paper border-b border-line ">
-                          {session.sessionId ? (
-                            <Calendar className="h-3.5 w-3.5 text-ink-4" />
-                          ) : (
-                            <FileText className="h-3.5 w-3.5 text-ink-4" />
-                          )}
-                          <span className="text-xs font-medium text-ink-3 ">
-                            {session.sessionId
-                              ? `Session - ${session.sessionDate ? formatDate(session.sessionDate, 'MMM d, yyyy') : 'Unknown date'}`
-                              : 'Manually Created'}
-                          </span>
-                          <Badge variant="outline" className="text-xs ml-auto">
-                            {session.commitments.length}
-                          </Badge>
-                        </div>
-
-                        {/* Commitments */}
-                        <div>
-                          {session.commitments.map(commitment => (
-                            <CommitmentRow
-                              key={commitment.id}
-                              commitment={commitment}
-                              onEdit={c => setSelectedCommitmentId(c.id)}
-                              onDelete={handleDelete}
-                              onConfirm={handleConfirm}
-                              onReject={handleReject}
-                              onStatusChange={handleStatusChange}
-                              onDateChange={handleDateChange}
-                              isSelected={selectedDraftIds.has(commitment.id)}
-                              onSelect={toggleDraftSelection}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </CollapsibleContent>
-              </Card>
-            </Collapsible>
-          ))}
-        </div>
-      </div>
+          {isEmpty ? (
+            <CommitmentsEmptyState
+              tab={view.tab}
+              dueFilter={view.dueFilter}
+              searchActive={view.searchInput.trim() !== ''}
+              hasActiveFilters={view.hasActiveFilters}
+              onClearFilters={view.clearAllFilters}
+              onCreate={() => setCreatePanelOpen(true)}
+            />
+          ) : view.groupBy === 'none' ? (
+            <CommitmentsFlatList
+              sections={view.sections}
+              rowHandlers={rowHandlers}
+              selectedDraftIds={selectedDraftIds}
+            />
+          ) : (
+            <CommitmentsGroupedList
+              key={view.groupBy}
+              groups={view.groups}
+              groupBy={view.groupBy}
+              rowHandlers={rowHandlers}
+              selectedDraftIds={selectedDraftIds}
+            />
+          )}
+        </>
+      )}
 
       {/* Create Panel */}
       {clients.length > 0 && (
         <CommitmentCreatePanel
           isOpen={createPanelOpen}
           onClose={() => setCreatePanelOpen(false)}
-          clientId={selectedClient !== 'all' ? selectedClient : clients[0].id}
+          clientId={
+            view.clientFilter !== 'all' ? view.clientFilter : clients[0].id
+          }
           onCreated={commitment => {
             setCreatePanelOpen(false)
             setSelectedCommitmentId(commitment.id)
@@ -971,6 +257,45 @@ export default function CommitmentsPage() {
         commitmentId={selectedCommitmentId}
         onClose={() => setSelectedCommitmentId(null)}
       />
-    </PageLayout>
+
+      {/* Destructive-action confirmation */}
+      <ConfirmationDialog
+        open={confirmState !== null}
+        onOpenChange={open => {
+          if (!open) setConfirmState(null)
+        }}
+        title={
+          confirmState?.kind === 'bulk-discard'
+            ? `Delete ${confirmState.ids.length} draft commitment${
+                confirmState.ids.length !== 1 ? 's' : ''
+              }?`
+            : 'Delete commitment?'
+        }
+        description={
+          confirmState?.kind === 'bulk-discard'
+            ? 'The selected draft commitments will be permanently removed.'
+            : confirmState?.kind === 'delete'
+              ? `"${confirmState.title}" will be permanently removed.`
+              : ''
+        }
+        confirmText="Delete"
+        variant="destructive"
+        onConfirm={handleConfirmedAction}
+      />
+    </>
+  )
+}
+
+export default function CommitmentsPage() {
+  return (
+    <ProtectedRoute loadingMessage="Loading commitments...">
+      <PageLayout>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <Suspense fallback={<CommitmentsSkeleton />}>
+            <CommitmentsPageContent />
+          </Suspense>
+        </div>
+      </PageLayout>
+    </ProtectedRoute>
   )
 }

--- a/src/app/commitments/utils/commitment-view.ts
+++ b/src/app/commitments/utils/commitment-view.ts
@@ -1,0 +1,233 @@
+import { differenceInCalendarDays, parseISO } from 'date-fns'
+import {
+  Commitment,
+  CommitmentPriority,
+  CommitmentStatus,
+} from '@/types/commitment'
+
+export type CommitmentTab = 'all' | 'active' | 'drafts' | 'completed'
+export type CommitmentSort = 'smart' | 'due' | 'priority' | 'created' | 'client'
+export type CommitmentGroupBy = 'none' | 'client' | 'session' | 'status'
+export type DueFilter = 'overdue' | 'soon' | null
+
+export const COMMITMENT_TABS: CommitmentTab[] = [
+  'all',
+  'active',
+  'drafts',
+  'completed',
+]
+
+export const CLOSED_STATUSES: CommitmentStatus[] = ['completed', 'abandoned']
+
+const PRIORITY_RANK: Record<CommitmentPriority, number> = {
+  urgent: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+}
+
+export function daysUntilDue(c: Commitment): number | null {
+  if (!c.target_date) return null
+  return differenceInCalendarDays(parseISO(c.target_date), new Date())
+}
+
+export function isOverdue(c: Commitment): boolean {
+  if (CLOSED_STATUSES.includes(c.status)) return false
+  const days = daysUntilDue(c)
+  return days !== null && days < 0
+}
+
+export function isDueSoon(c: Commitment): boolean {
+  if (CLOSED_STATUSES.includes(c.status)) return false
+  const days = daysUntilDue(c)
+  return days !== null && days >= 0 && days <= 7
+}
+
+export function matchesTab(c: Commitment, tab: CommitmentTab): boolean {
+  if (tab === 'active') return c.status === 'active'
+  if (tab === 'drafts') return c.status === 'draft'
+  if (tab === 'completed') return c.status === 'completed'
+  return true
+}
+
+export function matchesSearch(c: Commitment, query: string): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  return [c.title, c.description, c.client_name].some(
+    field => field && field.toLowerCase().includes(q),
+  )
+}
+
+export function matchesDueFilter(c: Commitment, due: DueFilter): boolean {
+  if (due === 'overdue') return isOverdue(c)
+  if (due === 'soon') return isDueSoon(c)
+  return true
+}
+
+/**
+ * Smart ordering buckets: drafts need review first, then overdue,
+ * then dated (soonest first), then undated, closed items last.
+ */
+function smartRank(c: Commitment): number {
+  if (c.status === 'draft') return 0
+  if (CLOSED_STATUSES.includes(c.status)) return 4
+  if (isOverdue(c)) return 1
+  return c.target_date ? 2 : 3
+}
+
+function byCreatedDesc(a: Commitment, b: Commitment): number {
+  return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+}
+
+function tieBreak(a: Commitment, b: Commitment): number {
+  const p = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority]
+  if (p !== 0) return p
+  return byCreatedDesc(a, b)
+}
+
+function byDueAsc(a: Commitment, b: Commitment): number {
+  if (!a.target_date && !b.target_date) return 0
+  if (!a.target_date) return 1
+  if (!b.target_date) return -1
+  return new Date(a.target_date).getTime() - new Date(b.target_date).getTime()
+}
+
+export function compareSmart(a: Commitment, b: Commitment): number {
+  const rankDiff = smartRank(a) - smartRank(b)
+  if (rankDiff !== 0) return rankDiff
+  const rank = smartRank(a)
+  if (rank === 1 || rank === 2) {
+    const d = byDueAsc(a, b)
+    if (d !== 0) return d
+  }
+  if (rank === 4) {
+    const d =
+      new Date(b.completed_date ?? b.updated_at).getTime() -
+      new Date(a.completed_date ?? a.updated_at).getTime()
+    if (d !== 0) return d
+  }
+  return tieBreak(a, b)
+}
+
+export const SORT_COMPARATORS: Record<
+  CommitmentSort,
+  (a: Commitment, b: Commitment) => number
+> = {
+  smart: compareSmart,
+  due: (a, b) => byDueAsc(a, b) || tieBreak(a, b),
+  priority: (a, b) =>
+    PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority] ||
+    byDueAsc(a, b) ||
+    byCreatedDesc(a, b),
+  created: (a, b) => byCreatedDesc(a, b) || tieBreak(a, b),
+  client: (a, b) =>
+    (a.client_name || '').localeCompare(b.client_name || '') ||
+    compareSmart(a, b),
+}
+
+export interface CommitmentGroup {
+  key: string
+  label: string
+  /** ISO date shown next to the label (session grouping) */
+  dateISO?: string | null
+  commitments: Commitment[]
+  draftCount: number
+  activeCount: number
+  completedCount: number
+}
+
+const STATUS_GROUP_ORDER: CommitmentStatus[] = [
+  'draft',
+  'active',
+  'in_progress',
+  'completed',
+  'abandoned',
+]
+
+const STATUS_GROUP_LABELS: Record<CommitmentStatus, string> = {
+  draft: 'Drafts — needs review',
+  active: 'Active',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+  abandoned: 'Abandoned',
+}
+
+function buildGroup(key: string, label: string): CommitmentGroup {
+  return {
+    key,
+    label,
+    commitments: [],
+    draftCount: 0,
+    activeCount: 0,
+    completedCount: 0,
+  }
+}
+
+function addToGroup(group: CommitmentGroup, c: Commitment) {
+  group.commitments.push(c)
+  if (c.status === 'draft') group.draftCount++
+  else if (c.status === 'active' || c.status === 'in_progress')
+    group.activeCount++
+  else if (c.status === 'completed') group.completedCount++
+}
+
+export function groupCommitments(
+  commitments: Commitment[],
+  groupBy: Exclude<CommitmentGroupBy, 'none'>,
+  sort: CommitmentSort,
+): CommitmentGroup[] {
+  const map = new Map<string, CommitmentGroup>()
+
+  for (const c of commitments) {
+    let key: string
+    let label: string
+
+    if (groupBy === 'client') {
+      key = c.client_id
+      label = c.client_name || 'Unknown Client'
+    } else if (groupBy === 'session') {
+      key = c.session_id || '__manual__'
+      label = c.session_id ? c.session_title || 'Session' : 'Manually Created'
+    } else {
+      key = c.status
+      label = STATUS_GROUP_LABELS[c.status]
+    }
+
+    let group = map.get(key)
+    if (!group) {
+      group = buildGroup(key, label)
+      if (groupBy === 'session' && c.session_id) {
+        group.dateISO = c.session_date || null
+      }
+      map.set(key, group)
+    }
+    addToGroup(group, c)
+  }
+
+  const groups = Array.from(map.values())
+  const comparator = SORT_COMPARATORS[sort]
+  for (const group of groups) {
+    group.commitments.sort(comparator)
+  }
+
+  if (groupBy === 'client') {
+    groups.sort((a, b) => a.label.localeCompare(b.label))
+  } else if (groupBy === 'session') {
+    // Newest session first; the manual bucket goes last
+    groups.sort((a, b) => {
+      if (a.key === '__manual__') return 1
+      if (b.key === '__manual__') return -1
+      if (!a.dateISO) return 1
+      if (!b.dateISO) return -1
+      return new Date(b.dateISO).getTime() - new Date(a.dateISO).getTime()
+    })
+  } else {
+    groups.sort(
+      (a, b) =>
+        STATUS_GROUP_ORDER.indexOf(a.key as CommitmentStatus) -
+        STATUS_GROUP_ORDER.indexOf(b.key as CommitmentStatus),
+    )
+  }
+
+  return groups
+}

--- a/src/app/components/attention-needed.tsx
+++ b/src/app/components/attention-needed.tsx
@@ -49,7 +49,7 @@ export function AttentionNeeded({ clients }: AttentionNeededProps) {
       ? {
           label: `${overdueCount} overdue`,
           icon: Clock,
-          href: '/commitments',
+          href: '/commitments?due=overdue',
           color:
             'bg-vermillion-bg text-vermillion border-vermillion hover:bg-vermillion-bg ',
           iconColor: 'text-vermillion',

--- a/src/components/clients/client-modal.tsx
+++ b/src/components/clients/client-modal.tsx
@@ -57,6 +57,7 @@ export default function ClientModal({
     autoSendQuestionnaire: true,
     leadTimeHours: 24,
     autoSendThrillForm: true,
+    weeklyCommitmentEmail: true,
     notes: '',
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
@@ -74,6 +75,7 @@ export default function ClientModal({
         autoSendQuestionnaire: client?.auto_send_questionnaire ?? true,
         leadTimeHours: client?.questionnaire_lead_time_hours ?? 24,
         autoSendThrillForm: client?.auto_send_thrill_form ?? true,
+        weeklyCommitmentEmail: client?.weekly_commitment_email_enabled ?? true,
         notes: client?.notes || '',
       })
       setErrors({})
@@ -165,6 +167,7 @@ export default function ClientModal({
         auto_send_questionnaire: formData.autoSendQuestionnaire,
         questionnaire_lead_time_hours: formData.leadTimeHours,
         auto_send_thrill_form: formData.autoSendThrillForm,
+        weekly_commitment_email_enabled: formData.weeklyCommitmentEmail,
       }
 
       // If onSubmit is provided, use it; otherwise handle internally
@@ -186,6 +189,7 @@ export default function ClientModal({
           has_email: !!formData.email.trim(),
           auto_send_questionnaire: formData.autoSendQuestionnaire,
           auto_send_thrill_form: formData.autoSendThrillForm,
+          weekly_commitment_email_enabled: formData.weeklyCommitmentEmail,
         })
 
         if (accessRequestSent) {
@@ -492,6 +496,28 @@ export default function ClientModal({
                     setFormData(prev => ({
                       ...prev,
                       autoSendThrillForm: checked,
+                    }))
+                  }
+                  disabled={isLoading}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-3 py-3 px-4 bg-paper rounded-lg">
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium text-ink-2">
+                    Weekly commitment email
+                  </span>
+                  <span className="text-xs text-ink-3">
+                    Email a Monday summary of open commitments with a link to
+                    check them off. Turn off when a contract ends.
+                  </span>
+                </div>
+                <Switch
+                  checked={formData.weeklyCommitmentEmail}
+                  onCheckedChange={checked =>
+                    setFormData(prev => ({
+                      ...prev,
+                      weeklyCommitmentEmail: checked,
                     }))
                   }
                   disabled={isLoading}

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -14,6 +14,7 @@ import {
   BookOpen,
   Shield,
   Eye,
+  Target,
 } from 'lucide-react'
 import Image from 'next/image'
 import { useState, useEffect } from 'react'
@@ -60,6 +61,12 @@ export default function Navigation() {
       label: 'Sessions',
       icon: History,
       permission: { resource: 'sessions', action: 'view' },
+    },
+    {
+      path: '/commitments',
+      label: 'Commitments',
+      icon: Target,
+      permission: { resource: 'clients', action: 'view' },
     },
     {
       path: '/resources',

--- a/src/services/checkin-service.ts
+++ b/src/services/checkin-service.ts
@@ -1,0 +1,66 @@
+/**
+ * Public weekly commitment check-in API (token-based, no auth).
+ * Raw fetch on purpose — these endpoints are public and must not carry
+ * auth/impersonation headers from ApiClient (same pattern as
+ * questionnaire-service's public section).
+ */
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+export interface CheckinCommitment {
+  id: string
+  title: string
+  description?: string | null
+  target_date?: string | null
+  priority: string
+  status: string
+  overdue: boolean
+  completed: boolean
+}
+
+export interface CheckinPage {
+  client_first_name: string
+  coach_name?: string | null
+  open_count: number
+  overdue_count: number
+  due_this_week_count: number
+  commitments: CheckinCommitment[]
+}
+
+export interface CheckinToggleResult {
+  commitment_id: string
+  status: string
+  completed: boolean
+}
+
+export class CheckinService {
+  static async getCheckin(token: string): Promise<CheckinPage> {
+    const res = await fetch(
+      `${BACKEND_URL}/commitments/public/checkin/${token}`,
+    )
+    if (!res.ok) {
+      throw new Error('Check-in link not found or expired')
+    }
+    return res.json()
+  }
+
+  static async toggleCommitment(
+    token: string,
+    commitmentId: string,
+    completed: boolean,
+  ): Promise<CheckinToggleResult> {
+    const res = await fetch(
+      `${BACKEND_URL}/commitments/public/checkin/${token}/toggle`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ commitment_id: commitmentId, completed }),
+      },
+    )
+    if (!res.ok) {
+      throw new Error('Failed to update commitment')
+    }
+    return res.json()
+  }
+}

--- a/src/services/client-service.ts
+++ b/src/services/client-service.ts
@@ -12,6 +12,7 @@ export interface ClientCreateDto {
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
   auto_send_thrill_form?: boolean
+  weekly_commitment_email_enabled?: boolean
 }
 
 // Real-time recognition for the New Client modal.
@@ -38,6 +39,7 @@ export interface ClientUpdateDto {
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
   auto_send_thrill_form?: boolean
+  weekly_commitment_email_enabled?: boolean
 }
 
 // Backend response format - matches what the API actually returns
@@ -52,6 +54,7 @@ interface BackendClient {
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
   auto_send_thrill_form?: boolean
+  weekly_commitment_email_enabled?: boolean
   created_at: string
   updated_at: string
   has_portal_access?: boolean
@@ -118,6 +121,8 @@ function transformClient(backendClient: BackendClient): Client {
     auto_send_questionnaire: backendClient.auto_send_questionnaire,
     questionnaire_lead_time_hours: backendClient.questionnaire_lead_time_hours,
     auto_send_thrill_form: backendClient.auto_send_thrill_form,
+    weekly_commitment_email_enabled:
+      backendClient.weekly_commitment_email_enabled,
     created_at: backendClient.created_at,
     updated_at: backendClient.updated_at,
     is_my_client: backendClient.is_my_client,

--- a/src/types/commitment.ts
+++ b/src/types/commitment.ts
@@ -103,6 +103,8 @@ export interface Commitment extends CommitmentBase {
 
   // Computed fields
   client_name?: string
+  session_title?: string
+  session_date?: string
   creator_name?: string
   update_count?: number
   milestone_count?: number

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -26,6 +26,7 @@ export interface Client {
   auto_send_questionnaire?: boolean
   questionnaire_lead_time_hours?: number
   auto_send_thrill_form?: boolean
+  weekly_commitment_email_enabled?: boolean
   created_at: string
   updated_at: string
   user_id?: string


### PR DESCRIPTION
## What

1. **Public check-in page `/checkin/[token]`** — no-auth page the weekly commitment digest emails link to. **Fixes the 404 on every Review & Update link in the ~255 digest emails sent today** (backend shipped in coach-sidekick-backend#94; this page never made it to main). Tokens are valid until ~Aug 9, so deploying retroactively fixes all sent emails.
2. **Commitments hub** — promotes the hidden `/commitments` page to a nav item: flat prioritized cross-client list (mine-first), search/sort/group-by, `?due=overdue` deep link (dashboard chip now points there), plus a calmer redesign (inline stat strip, underline tabs, ghost filters, hover-revealed row actions).
3. **Client settings toggle** — per-client on/off for the weekly commitment email (defaults on, matches backend `weekly_commitment_email_enabled`).

## Notes
- Frontend only; no migration. Backend counterpart already live on Railway.
- Excludes unrelated local WIP (design-sync chore, stale formatting files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)