### PR TITLE
Add full-page commitment detail at /commitments/[id]

### DIFF
--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+/**
+ * Full-page commitment detail at /commitments/[id].
+ *
+ * Companion to — not a replacement for — the slide-over panel: the panel stays
+ * the fast path from lists and boards, this is the shareable, readable surface.
+ * Both run the same `useCommitmentDetail` controller and the same section
+ * components, so there is no second implementation to keep in sync.
+ *
+ * Layout follows the principle Linear's issue view uses: a measured content
+ * column with properties beside it, rather than a 640px panel stretched wide.
+ */
+
+import { use, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, ChevronRight, Link as LinkIcon, Target } from 'lucide-react'
+
+import PageLayout from '@/components/layout/page-layout'
+import { ProtectedRoute } from '@/components/auth/protected-route'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
+import { useAuth } from '@/contexts/auth-context'
+
+import {
+  useCommitmentDetail,
+  UUID_RE,
+} from '@/components/commitments/detail/use-commitment-detail'
+import { copyCommitmentLink } from '@/components/commitments/detail/commitment-links'
+import { CommitmentContextHeader } from '@/components/commitments/detail/commitment-context-header'
+import { CommitmentActivityTimeline } from '@/components/commitments/detail/commitment-activity-timeline'
+import { CommitmentProgressControl } from '@/components/commitments/detail/commitment-progress-control'
+import { CommitmentSiblings } from '@/components/commitments/detail/commitment-siblings'
+import {
+  PanelHeader,
+  FieldsGrid,
+  LinkedOutcomesSection,
+  DescriptionSection,
+  AttachmentsSection,
+  MilestonesSection,
+  ActivitySection,
+  MetadataFooter,
+} from '@/components/commitments/commitment-detail-panel'
+
+function NotAvailable({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <div className="h-12 w-12 rounded-full bg-surface-3 flex items-center justify-center mb-4">
+        <Target className="h-6 w-6 text-ink-3" />
+      </div>
+      <h2 className="text-lg font-semibold text-ink">{title}</h2>
+      <p className="mt-1 text-sm text-ink-3 max-w-md">{description}</p>
+      <Button asChild variant="outline" className="mt-6">
+        <Link href="/commitments">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to commitments
+        </Link>
+      </Button>
+    </div>
+  )
+}
+
+function PageSkeleton() {
+  return (
+    <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-10 space-y-8 lg:space-y-0">
+      <div className="space-y-4">
+        <Skeleton className="h-9 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    </div>
+  )
+}
+
+function CommitmentPageContent({ commitmentId }: { commitmentId: string }) {
+  const router = useRouter()
+  const { user } = useAuth()
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const {
+    commitment,
+    isLoading,
+    error,
+    capabilities,
+    handleFieldUpdate,
+    handleDelete,
+  } = useCommitmentDetail({
+    commitmentId,
+    // The page has no surrounding list to refresh; the mutations already
+    // invalidate the ['commitments'] prefix.
+    onDeleted: () => router.replace('/commitments'),
+  })
+
+  if (isLoading) return <PageSkeleton />
+
+  if (error || !commitment) {
+    // The API returns a uniform 404 for both "gone" and "not yours", so it
+    // deliberately can't be used to probe which one it is.
+    return (
+      <NotAvailable
+        title="Commitment not available"
+        description="It may have been deleted, or it belongs to a client you don't have access to."
+      />
+    )
+  }
+
+  return (
+    <>
+      {/* Breadcrumb + page actions */}
+      <div className="flex items-center justify-between gap-4 mb-6">
+        <nav className="flex items-center gap-1.5 text-sm text-ink-3 min-w-0">
+          <Link href="/commitments" className="hover:text-ink shrink-0">
+            Commitments
+          </Link>
+          {commitment.client_name && commitment.client_id && (
+            <>
+              <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+              <Link
+                href={`/clients/${commitment.client_id}`}
+                className="hover:text-ink truncate"
+              >
+                {commitment.client_name}
+              </Link>
+            </>
+          )}
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+          <span className="text-ink-2 truncate">{commitment.title}</span>
+        </nav>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => copyCommitmentLink(commitment.id)}
+        >
+          <LinkIcon className="h-4 w-4 mr-2" />
+          Copy link
+        </Button>
+      </div>
+
+      {/* One tree, two layouts: below lg the properties rail stacks ABOVE the
+          content (on a phone you want status and due date first); at lg the
+          grid takes over and the order-* utilities are neutralised. */}
+      <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-10 lg:items-start">
+        <main className="order-2 lg:order-1 min-w-0 space-y-8">
+          <div className="space-y-2">
+            <PanelHeader
+              commitment={commitment}
+              onClose={() => router.push('/commitments')}
+              onFieldUpdate={handleFieldUpdate}
+              onDelete={() => setConfirmDelete(true)}
+            />
+            <CommitmentContextHeader commitment={commitment} />
+          </div>
+
+          <DescriptionSection
+            commitment={commitment}
+            onFieldUpdate={handleFieldUpdate}
+          />
+
+          {capabilities.canMilestones && (
+            <MilestonesSection
+              commitment={commitment}
+              commitmentId={commitment.id}
+            />
+          )}
+
+          {capabilities.canAttach && (
+            <AttachmentsSection
+              commitment={commitment}
+              commitmentId={commitment.id}
+            />
+          )}
+
+          {capabilities.canActivity && (
+            <section className="space-y-4">
+              <ActivitySection
+                commitment={commitment}
+                commitmentId={commitment.id}
+                hideHistory
+              />
+              <CommitmentActivityTimeline
+                commitment={commitment}
+                currentUserId={user?.id}
+              />
+            </section>
+          )}
+        </main>
+
+        <aside className="order-1 lg:order-2 space-y-6 lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:border-l lg:border-line lg:pl-6">
+          <FieldsGrid
+            commitment={commitment}
+            onFieldUpdate={handleFieldUpdate}
+          />
+
+          <CommitmentProgressControl
+            commitment={commitment}
+            commitmentId={commitment.id}
+          />
+
+          {capabilities.canLinkOutcomes && (
+            <LinkedOutcomesSection
+              commitment={commitment}
+              commitmentId={commitment.id}
+            />
+          )}
+
+          {capabilities.canSeeSiblings && (
+            <CommitmentSiblings commitment={commitment} />
+          )}
+
+          <MetadataFooter commitment={commitment} />
+        </aside>
+      </div>
+
+      <ConfirmationDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title="Delete commitment?"
+        description={`"${commitment.title}" will be permanently removed.`}
+        confirmText="Delete"
+        variant="destructive"
+        onConfirm={handleDelete}
+      />
+    </>
+  )
+}
+
+export default function CommitmentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+
+  // `[id]` matches any string, so guard before firing a request — /commitments/foo
+  // must render not-found without hitting the API.
+  const isValid = UUID_RE.test(id)
+
+  return (
+    <ProtectedRoute loadingMessage="Loading commitment...">
+      <PageLayout>
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {isValid ? (
+            <CommitmentPageContent commitmentId={id} />
+          ) : (
+            <NotAvailable
+              title="Commitment not found"
+              description="That link doesn't point to a valid commitment."
+            />
+          )}
+        </div>
+      </PageLayout>
+    </ProtectedRoute>
+  )
+}

--- a/src/app/commitments/components/commitment-row.tsx
+++ b/src/app/commitments/components/commitment-row.tsx
@@ -144,12 +144,20 @@ export function CommitmentRow({
       <div className="flex-1 min-w-0">
         {/* Title line */}
         <div className="flex items-center gap-2 flex-wrap">
-          <span
-            className="text-sm font-medium text-ink cursor-pointer hover:underline"
-            onClick={() => onEdit(commitment)}
+          {/* A real <Link>, so the row gets a hover URL and cmd/ctrl/middle
+              click opens the full page in a new tab. Plain click is
+              intercepted and still opens the fast slide-over panel. */}
+          <Link
+            href={`/commitments/${commitment.id}`}
+            className="text-sm font-medium text-ink hover:underline"
+            onClick={e => {
+              if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
+              e.preventDefault()
+              onEdit(commitment)
+            }}
           >
             {commitment.title}
-          </span>
+          </Link>
           {showPriority && (
             <span className={cn('text-xs font-medium', priority.className)}>
               {priority.label}

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Suspense, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import PageLayout from '@/components/layout/page-layout'
 import { ProtectedRoute } from '@/components/auth/protected-route'
 import { PageHeader } from '@/components/ui/page-header'
@@ -35,6 +36,7 @@ type ConfirmState =
   | null
 
 function CommitmentsPageContent() {
+  const router = useRouter()
   const view = useCommitmentsView()
   const { data: stats } = useCommitmentStats(undefined, true)
   const { data: clientsData } = useClients()
@@ -256,6 +258,11 @@ function CommitmentsPageContent() {
       <CommitmentDetailPanel
         commitmentId={selectedCommitmentId}
         onClose={() => setSelectedCommitmentId(null)}
+        onOpenInPage={
+          selectedCommitmentId
+            ? () => router.push(`/commitments/${selectedCommitmentId}`)
+            : undefined
+        }
       />
 
       {/* Destructive-action confirmation */}

--- a/src/components/commitments/commitment-detail-panel.tsx
+++ b/src/components/commitments/commitment-detail-panel.tsx
@@ -1,26 +1,22 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { CommitmentService } from '@/services/commitment-service'
 import { ClientCommitmentService } from '@/services/client-commitment-service'
 import {
-  useUpdateCommitment,
   useUpdateCommitmentProgress,
   useAddMilestone,
   useUpdateMilestone,
   useDeleteMilestone,
-  useDiscardCommitment,
   useUploadAttachment,
   useDeleteAttachment,
 } from '@/hooks/mutations/use-commitment-mutations'
 import {
-  useClientUpdateCommitment,
   useClientUpdateCommitmentProgress,
   useClientAddMilestone,
   useClientUpdateMilestone,
   useClientDeleteMilestone,
-  useClientDiscardCommitment,
   useClientUploadAttachment,
   useClientDeleteAttachment,
 } from '@/hooks/mutations/use-client-commitment-mutations'
@@ -87,6 +83,8 @@ import {
   File,
   Loader2,
   Zap,
+  Maximize2,
+  Link as LinkIcon,
 } from 'lucide-react'
 import type {
   Commitment,
@@ -101,10 +99,15 @@ import { toast } from 'sonner'
 import { Progress } from '@/components/ui/progress'
 import { useConfetti } from '@/hooks/use-confetti'
 
-export interface GuestContext {
-  meetingToken: string
-  guestToken: string
-}
+import {
+  useCommitmentDetail,
+  type GuestContext,
+} from './detail/use-commitment-detail'
+import { copyCommitmentLink } from './detail/commitment-links'
+
+// Re-exported so the six existing mount sites keep importing GuestContext from
+// here unchanged; the definition now lives with the shared controller.
+export type { GuestContext }
 
 interface CommitmentDetailPanelProps {
   commitmentId: string | null
@@ -113,36 +116,8 @@ interface CommitmentDetailPanelProps {
   onCommitmentUpdate?: () => void
   guestContext?: GuestContext
   clientMode?: boolean
-}
-
-// UUID v4 pattern check — prevents sending invalid IDs (e.g. "temp-*", "None") to the API
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-function useCommitment(
-  commitmentId: string | null,
-  guestContext?: GuestContext,
-  clientMode?: boolean,
-) {
-  const isValidId = !!commitmentId && UUID_RE.test(commitmentId)
-  return useQuery({
-    queryKey: queryKeys.commitments.detail(commitmentId || ''),
-    queryFn: () => {
-      if (guestContext) {
-        return LiveMeetingService.getCommitmentDetail(
-          guestContext.meetingToken,
-          guestContext.guestToken,
-          commitmentId!,
-        )
-      }
-      if (clientMode) {
-        return ClientCommitmentService.getCommitment(commitmentId!)
-      }
-      return CommitmentService.getCommitment(commitmentId!)
-    },
-    enabled: isValidId,
-    staleTime: 2 * 60 * 1000,
-  })
+  /** Show the "open full page" affordance. Coach surfaces only. */
+  onOpenInPage?: () => void
 }
 
 export function CommitmentDetailPanel({
@@ -152,44 +127,28 @@ export function CommitmentDetailPanel({
   onCommitmentUpdate,
   guestContext,
   clientMode,
+  onOpenInPage,
 }: CommitmentDetailPanelProps) {
-  const { data: commitment, isLoading } = useCommitment(
+  // All data + mutation logic is shared with the /commitments/[id] page.
+  const {
+    commitment,
+    isLoading,
+    capabilities,
+    handleFieldUpdate,
+    handleDelete,
+  } = useCommitmentDetail({
     commitmentId,
+    clientId: clientIdProp,
     guestContext,
     clientMode,
-  )
-  const resolvedClientId = clientIdProp || commitment?.client_id
-
-  // Prefetch targets & sprints immediately using the known clientId
-  // so they're cached before LinkedOutcomesSection mounts.
-  // In guest mode, disable fetching (cache is pre-seeded by ClientCommitmentPanel)
-  // to avoid 403 errors from authenticated API calls.
-  const targetFilters = resolvedClientId
-    ? { client_id: resolvedClientId }
-    : undefined
-  const guestQueryOpts = guestContext
-    ? { enabled: false, staleTime: Infinity }
-    : {}
-  useTargets(targetFilters, guestQueryOpts)
-  useSprints(
-    resolvedClientId ? { client_id: resolvedClientId } : undefined,
-    guestQueryOpts,
-  )
-  const coachUpdateCommitment = useUpdateCommitment({ silent: true })
-  const clientUpdateCommitment = useClientUpdateCommitment({ silent: true })
-  const updateCommitment = clientMode
-    ? clientUpdateCommitment
-    : coachUpdateCommitment
-  const coachDiscardCommitment = useDiscardCommitment()
-  const clientDiscardCommitment = useClientDiscardCommitment()
-  const discardCommitment = clientMode
-    ? clientDiscardCommitment
-    : coachDiscardCommitment
-  const queryClient = useQueryClient()
+    onCommitmentUpdate,
+    onDeleted: onClose,
+  })
 
   const panelRef = useRef<HTMLDivElement>(null)
 
-  // Close on Escape
+  // Close on Escape. Panel-only: on the page route this would navigate away,
+  // which is hostile.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -199,71 +158,6 @@ export function CommitmentDetailPanel({
       return () => document.removeEventListener('keydown', handleKeyDown)
     }
   }, [commitmentId, onClose])
-
-  const handleFieldUpdate = useCallback(
-    (field: string, value: any) => {
-      if (!commitmentId) return
-
-      // Optimistically update the detail cache immediately
-      queryClient.setQueryData(
-        queryKeys.commitments.detail(commitmentId),
-        (old: any) => {
-          if (!old) return old
-          return { ...old, [field]: value }
-        },
-      )
-
-      if (guestContext) {
-        LiveMeetingService.updateCommitment(
-          guestContext.meetingToken,
-          guestContext.guestToken,
-          commitmentId,
-          { [field]: value },
-        )
-          .then(() => onCommitmentUpdate?.())
-          .catch(() => toast.error('Failed to update commitment'))
-      } else {
-        updateCommitment.mutate(
-          { commitmentId, data: { [field]: value } },
-          {
-            onSuccess: () => {
-              onCommitmentUpdate?.()
-            },
-          },
-        )
-      }
-    },
-    [
-      commitmentId,
-      updateCommitment,
-      queryClient,
-      onCommitmentUpdate,
-      guestContext,
-    ],
-  )
-
-  const handleDelete = () => {
-    if (!commitmentId) return
-    if (guestContext) {
-      LiveMeetingService.deleteCommitment(
-        guestContext.meetingToken,
-        guestContext.guestToken,
-        commitmentId,
-      )
-        .then(() => {
-          onClose()
-          onCommitmentUpdate?.()
-        })
-        .catch(() => toast.error('Failed to delete commitment'))
-    } else {
-      discardCommitment.mutate(commitmentId, {
-        onSuccess: () => {
-          onClose()
-          onCommitmentUpdate?.()
-        },
-      })
-    }
-  }
 
   const isOpen = !!commitmentId
 
@@ -298,6 +192,14 @@ export function CommitmentDetailPanel({
                   onClose={onClose}
                   onFieldUpdate={handleFieldUpdate}
                   onDelete={handleDelete}
+                  onOpenInPage={
+                    capabilities.canOpenInPage ? onOpenInPage : undefined
+                  }
+                  onCopyLink={
+                    capabilities.canOpenInPage
+                      ? () => copyCommitmentLink(commitment.id)
+                      : undefined
+                  }
                 />
 
                 {/* Fields Grid */}
@@ -367,16 +269,20 @@ export function CommitmentDetailPanel({
 
 // === Header Section ===
 
-function PanelHeader({
+export function PanelHeader({
   commitment,
   onClose,
   onFieldUpdate,
   onDelete,
+  onOpenInPage,
+  onCopyLink,
 }: {
   commitment: Commitment
   onClose: () => void
   onFieldUpdate: (field: string, value: any) => void
   onDelete: () => void
+  onOpenInPage?: () => void
+  onCopyLink?: () => void
 }) {
   const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [titleValue, setTitleValue] = useState(commitment.title)
@@ -431,6 +337,20 @@ function PanelHeader({
 
       {/* Actions */}
       <div className="flex items-center gap-1 shrink-0">
+        {/* Coach surfaces only — guests and the client portal have no
+            /commitments/[id] route, so the affordance simply isn't rendered. */}
+        {onOpenInPage && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={onOpenInPage}
+            title="Open as full page"
+            aria-label="Open as full page"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </Button>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
@@ -438,6 +358,12 @@ function PanelHeader({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="z-[80]">
+            {onCopyLink && (
+              <DropdownMenuItem onClick={onCopyLink}>
+                <LinkIcon className="h-4 w-4 mr-2" />
+                Copy link
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={onDelete} className="text-vermillion">
               <Trash2 className="h-4 w-4 mr-2" />
               Delete
@@ -459,7 +385,7 @@ function PanelHeader({
 
 // === Fields Grid ===
 
-function FieldsGrid({
+export function FieldsGrid({
   commitment,
   onFieldUpdate,
 }: {
@@ -468,13 +394,9 @@ function FieldsGrid({
 }) {
   const [calendarOpen, setCalendarOpen] = useState(false)
 
-  const _priorityColors: Record<string, string> = {
-    urgent: 'bg-vermillion-bg text-vermillion ',
-    high: 'bg-amber-token-bg text-amber-token ',
-    medium: 'bg-amber-token-bg text-amber-token ',
-    low: 'bg-surface-3 text-ink-2 ',
-  }
-
+  // Settable statuses. `in_progress` MUST be here: the kanban board and three
+  // other surfaces write it, so without it an In Progress commitment opened
+  // here showed no selected chip and picking any option silently lost the state.
   const statusOptions: {
     value: string
     label: string
@@ -487,6 +409,13 @@ function FieldsGrid({
       selected: 'bg-ds-accent-bg text-ds-accent border-ds-accent ',
       unselected:
         'bg-transparent text-ink-3 border-line hover:bg-ds-accent-bg hover:text-ds-accent hover:border-ds-accent ',
+    },
+    {
+      value: 'in_progress',
+      label: 'In Progress',
+      selected: 'bg-amber-token-bg text-amber-token border-amber-token ',
+      unselected:
+        'bg-transparent text-ink-3 border-line hover:bg-amber-token-bg hover:text-amber-token hover:border-amber-token ',
     },
     {
       value: 'completed',
@@ -503,6 +432,22 @@ function FieldsGrid({
         'bg-transparent text-ink-3 border-line hover:bg-vermillion-bg hover:text-vermillion hover:border-vermillion ',
     },
   ]
+
+  // Guard the whole class of bug rather than the one instance: any status that
+  // isn't settable here (today `draft`) still renders, read-only, so the
+  // control can never show "nothing selected".
+  const isKnownStatus = statusOptions.some(o => o.value === commitment.status)
+
+  // Milestone-derived progress, used when reopening a completed commitment so
+  // we restore real progress instead of hard-zeroing it.
+  const milestones = commitment.milestones || []
+  const derivedProgress = milestones.length
+    ? Math.round(
+        (milestones.filter(m => m.status === 'completed').length /
+          milestones.length) *
+          100,
+      )
+    : 0
 
   return (
     <div className="p-4 bg-paper rounded-lg space-y-4">
@@ -591,6 +536,14 @@ function FieldsGrid({
       <div className="space-y-1">
         <label className="text-xs font-medium text-ink-3 ">Status</label>
         <div className="flex flex-wrap gap-1.5">
+          {!isKnownStatus && (
+            <span
+              className="px-2.5 py-1 rounded-full text-xs font-medium border bg-surface-3 text-ink-2 border-line capitalize"
+              title="Current status — set elsewhere and not directly settable here"
+            >
+              {commitment.status.replace('_', ' ')}
+            </span>
+          )}
           {statusOptions.map(opt => {
             const isSelected = commitment.status === opt.value
             return (
@@ -600,14 +553,17 @@ function FieldsGrid({
                 onClick={() => {
                   if (isSelected) return
                   onFieldUpdate('status', opt.value)
+                  // Progress rules live here, in one place, rather than being
+                  // implied by whichever button was pressed.
                   if (opt.value === 'completed') {
                     onFieldUpdate('progress_percentage', 100)
-                  } else if (
-                    commitment.status === 'completed' &&
-                    opt.value === 'active'
-                  ) {
-                    onFieldUpdate('progress_percentage', 0)
+                  } else if (commitment.status === 'completed') {
+                    // Reopening: restore milestone-derived progress rather than
+                    // hard-zeroing work that was actually done.
+                    onFieldUpdate('progress_percentage', derivedProgress)
                   }
+                  // Moving to in_progress with no milestones leaves progress
+                  // alone — we don't invent a number.
                 }}
                 aria-pressed={isSelected}
                 className={cn(
@@ -627,7 +583,7 @@ function FieldsGrid({
 
 // === Linked Outcomes & Sprints Section ===
 
-function LinkedOutcomesSection({
+export function LinkedOutcomesSection({
   commitment,
   commitmentId,
   onCommitmentUpdate,
@@ -860,7 +816,7 @@ function LinkedOutcomesSection({
 
 // === Description Section ===
 
-function DescriptionSection({
+export function DescriptionSection({
   commitment,
   onFieldUpdate,
 }: {
@@ -940,7 +896,7 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function AttachmentsSection({
+export function AttachmentsSection({
   commitment,
   commitmentId,
   clientMode,
@@ -1149,7 +1105,10 @@ function AttachmentsSection({
         open={!!deleteConfirmId}
         onOpenChange={open => !open && setDeleteConfirmId(null)}
       >
-        <AlertDialogContent>
+        {/* Both classes are required: the panel is z-70, and the dialog's own
+            backdrop defaults to z-50, so lifting only the content would leave
+            the scrim rendering behind the panel. */}
+        <AlertDialogContent className="z-[80]" overlayClassName="z-[80]">
           <AlertDialogHeader>
             <AlertDialogTitle>Remove Attachment</AlertDialogTitle>
             <AlertDialogDescription>
@@ -1179,7 +1138,7 @@ function AttachmentsSection({
 
 // === Milestones Section ===
 
-function MilestonesSection({
+export function MilestonesSection({
   commitment,
   commitmentId,
   clientMode,
@@ -1360,23 +1319,36 @@ function MilestoneItem({
 
 // === Comments Section ===
 
-function ActivitySection({
+export function ActivitySection({
   commitment,
   commitmentId,
   onCommitmentUpdate,
   clientMode,
+  hideHistory,
 }: {
   commitment: Commitment
   commitmentId: string
   onCommitmentUpdate?: () => void
   clientMode?: boolean
+  /**
+   * Render the composer only. The page route pairs this with
+   * CommitmentActivityTimeline, which shows the same updates plus the status
+   * and progress events this flat list drops.
+   */
+  hideHistory?: boolean
 }) {
   const [note, setNote] = useState('')
   const [showExtras, setShowExtras] = useState(false)
   const [wins, setWins] = useState('')
   const [blockers, setBlockers] = useState('')
   const inputRef = useRef<HTMLTextAreaElement>(null)
-  const _queryClient = useQueryClient()
+  // Resolved after mount: `navigator` is undefined during server rendering,
+  // and this component now also renders under a page route.
+  const [isMac, setIsMac] = useState(false)
+  useEffect(() => {
+    setIsMac(/Mac|iPhone|iPad/.test(navigator.platform || ''))
+  }, [])
+
   const coachUpdateProgress = useUpdateCommitmentProgress()
   const clientUpdateProgress = useClientUpdateCommitmentProgress()
   const updateProgress = clientMode ? clientUpdateProgress : coachUpdateProgress
@@ -1449,7 +1421,7 @@ function ActivitySection({
           </button>
           <div className="flex items-center gap-2">
             <span className="text-[10px] text-ink-4 ">
-              {navigator.platform?.includes('Mac') ? '⌘' : 'Ctrl'}+Enter
+              {isMac ? '⌘' : 'Ctrl'}+Enter
             </span>
             <Button
               size="sm"
@@ -1490,8 +1462,9 @@ function ActivitySection({
         )}
       </div>
 
-      {/* Comments feed */}
-      {updates.length > 0 ? (
+      {/* Comments feed — suppressed on the page route, which renders the
+          richer CommitmentActivityTimeline in its place. */}
+      {hideHistory ? null : updates.length > 0 ? (
         <div className="space-y-2">
           {updates.map(update => (
             <div
@@ -1535,7 +1508,7 @@ function ActivitySection({
 
 // === Metadata Footer ===
 
-function MetadataFooter({ commitment }: { commitment: Commitment }) {
+export function MetadataFooter({ commitment }: { commitment: Commitment }) {
   return (
     <div className="pt-4 border-t border-line space-y-1">
       <div className="flex items-center gap-2 text-xs text-ink-4 ">
@@ -1560,7 +1533,7 @@ function MetadataFooter({ commitment }: { commitment: Commitment }) {
 
 // === Loading Skeleton ===
 
-function PanelSkeleton() {
+export function PanelSkeleton() {
   return (
     <div className="p-6 space-y-6">
       <div className="space-y-3">

--- a/src/components/commitments/detail/build-activity-feed.ts
+++ b/src/components/commitments/detail/build-activity-feed.ts
@@ -1,0 +1,192 @@
+/**
+ * Turns a commitment's stored history into a chronological activity feed.
+ *
+ * The key structural point: a single `commitment_updates` row can be BOTH a
+ * system event and a comment — the same row can move progress to 60% *and*
+ * carry a note. So this is fan-out-then-sort, not merge-two-arrays.
+ *
+ * Pure function, no React, so the ordering/dedup rules are unit-testable.
+ */
+
+import type { Commitment, CommitmentUpdateEntry } from '@/types/commitment'
+
+export type ActivityKind =
+  | 'comment'
+  | 'status'
+  | 'progress'
+  | 'created'
+  | 'completed'
+
+export interface ActivityItem {
+  id: string
+  kind: ActivityKind
+  at: string
+  actorId?: string
+  actorName?: string
+  /** comment */
+  note?: string
+  wins?: string
+  blockers?: string
+  /** status */
+  toStatus?: string
+  /** progress */
+  fromProgress?: number
+  toProgress?: number
+}
+
+export interface ActivityGroup {
+  /** Source update id, or a synthetic key for created/completed. */
+  key: string
+  at: string
+  actorId?: string
+  actorName?: string
+  items: ActivityItem[]
+}
+
+function sameDay(a?: string | null, b?: string | null) {
+  if (!a || !b) return false
+  return new Date(a).toDateString() === new Date(b).toDateString()
+}
+
+export function buildActivityFeed(commitment: Commitment): ActivityGroup[] {
+  const updates: CommitmentUpdateEntry[] = [...(commitment.updates || [])]
+
+  // Ascending first, so progress deltas can be computed against the running
+  // previous value rather than guessed.
+  updates.sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  )
+
+  const groups: ActivityGroup[] = []
+  let runningProgress: number | undefined = undefined
+  let sawCompletedStatus = false
+
+  for (const u of updates) {
+    const items: ActivityItem[] = []
+    const base = {
+      at: u.created_at,
+      actorId: u.updated_by_id,
+      actorName: u.updated_by_name,
+    }
+
+    if (u.status_change) {
+      items.push({
+        ...base,
+        id: `${u.id}:status`,
+        kind: 'status',
+        toStatus: u.status_change,
+      })
+      if (u.status_change === 'completed') sawCompletedStatus = true
+    }
+
+    if (
+      u.progress_percentage !== null &&
+      u.progress_percentage !== undefined &&
+      u.progress_percentage !== runningProgress
+    ) {
+      items.push({
+        ...base,
+        id: `${u.id}:progress`,
+        kind: 'progress',
+        fromProgress: runningProgress,
+        toProgress: u.progress_percentage,
+      })
+      runningProgress = u.progress_percentage
+    }
+
+    if (u.note || u.wins || u.blockers) {
+      items.push({
+        ...base,
+        id: `${u.id}:comment`,
+        kind: 'comment',
+        note: u.note,
+        wins: u.wins,
+        blockers: u.blockers,
+      })
+    }
+
+    if (items.length) {
+      groups.push({
+        key: u.id,
+        at: u.created_at,
+        actorId: u.updated_by_id,
+        actorName: u.updated_by_name,
+        items,
+      })
+    }
+  }
+
+  // There is no DB row for creation — synthesize one so the feed has an origin.
+  groups.unshift({
+    key: 'created',
+    at: commitment.created_at,
+    actorId: commitment.created_by_id,
+    actorName: commitment.creator_name,
+    items: [
+      {
+        id: 'created',
+        kind: 'created',
+        at: commitment.created_at,
+        actorId: commitment.created_by_id,
+        actorName: commitment.creator_name,
+      },
+    ],
+  })
+
+  // Only synthesize completion when no status_change row already covers it,
+  // otherwise the same event appears twice.
+  if (
+    commitment.completed_date &&
+    !sawCompletedStatus &&
+    !groups.some(g => sameDay(g.at, commitment.completed_date))
+  ) {
+    groups.push({
+      key: 'completed',
+      at: commitment.completed_date,
+      items: [
+        {
+          id: 'completed',
+          kind: 'completed',
+          at: commitment.completed_date,
+        },
+      ],
+    })
+  }
+
+  // Newest first for rendering.
+  return groups.sort(
+    (a, b) => new Date(b.at).getTime() - new Date(a.at).getTime(),
+  )
+}
+
+/**
+ * Best-effort display name for an actor.
+ *
+ * Order matters: the backend-supplied name wins, then "You". The
+ * 'current-user' check exists because useUpdateCommitmentProgress writes that
+ * literal string as updated_by_id in its optimistic update, so without it a
+ * freshly posted comment reads "Someone" until the next refetch.
+ */
+export function resolveActorName(
+  item: { actorId?: string; actorName?: string },
+  ctx: {
+    currentUserId?: string
+    assignedToId?: string
+    assignedToName?: string
+    createdById?: string
+    creatorName?: string
+  },
+): string {
+  if (item.actorName) return item.actorName
+  if (!item.actorId) return 'Someone'
+  if (item.actorId === 'current-user') return 'You'
+  if (ctx.currentUserId && item.actorId === ctx.currentUserId) return 'You'
+  if (ctx.assignedToId && item.actorId === ctx.assignedToId) {
+    return ctx.assignedToName || 'Someone'
+  }
+  if (ctx.createdById && item.actorId === ctx.createdById) {
+    return ctx.creatorName || 'Someone'
+  }
+  return 'Someone'
+}

--- a/src/components/commitments/detail/commitment-activity-timeline.tsx
+++ b/src/components/commitments/detail/commitment-activity-timeline.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+/**
+ * Chronological activity feed: comments AND system events in one column.
+ *
+ * The underlying `commitment_updates` rows already stored status changes and
+ * progress deltas; the old panel rendered only the free-text fields, so the
+ * history of how a commitment actually moved was invisible.
+ */
+
+import {
+  Plus,
+  Sparkles,
+  TrendingUp,
+  CheckCircle2,
+  Trophy,
+  AlertTriangle,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatDate } from '@/lib/date-utils'
+import type { Commitment } from '@/types/commitment'
+import {
+  buildActivityFeed,
+  resolveActorName,
+  type ActivityItem,
+} from './build-activity-feed'
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: 'Draft',
+  active: 'Active',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+  abandoned: 'Abandoned',
+}
+
+function ItemIcon({ item }: { item: ActivityItem }) {
+  const base = 'h-3.5 w-3.5'
+  switch (item.kind) {
+    case 'created':
+      return <Plus className={cn(base, 'text-ink-3')} />
+    case 'status':
+      return item.toStatus === 'completed' ? (
+        <CheckCircle2 className={cn(base, 'text-forest')} />
+      ) : (
+        <div className="h-2 w-2 rounded-full bg-ds-accent" />
+      )
+    case 'progress':
+      return <TrendingUp className={cn(base, 'text-amber-token')} />
+    case 'completed':
+      return <CheckCircle2 className={cn(base, 'text-forest')} />
+    default:
+      return <div className="h-2 w-2 rounded-full bg-line" />
+  }
+}
+
+function ItemBody({
+  item,
+  actor,
+  extractedByAi,
+}: {
+  item: ActivityItem
+  actor: string
+  extractedByAi?: boolean
+}) {
+  switch (item.kind) {
+    case 'created':
+      return (
+        <span className="text-ink-3">
+          {extractedByAi ? (
+            <span className="inline-flex items-center gap-1">
+              <Sparkles className="h-3 w-3 text-ds-accent" />
+              Extracted from the session transcript
+            </span>
+          ) : (
+            <>
+              <span className="text-ink-2 font-medium">{actor}</span> created
+              this commitment
+            </>
+          )}
+        </span>
+      )
+    case 'status':
+      return (
+        <span className="text-ink-3">
+          <span className="text-ink-2 font-medium">{actor}</span> moved it to{' '}
+          <span className="text-ink-2 font-medium">
+            {STATUS_LABELS[item.toStatus || ''] || item.toStatus}
+          </span>
+        </span>
+      )
+    case 'progress':
+      return (
+        <span className="text-ink-3">
+          <span className="text-ink-2 font-medium">{actor}</span> set progress{' '}
+          {item.fromProgress !== undefined && (
+            <>
+              <span className="tabular-nums">{item.fromProgress}%</span>
+              {' → '}
+            </>
+          )}
+          <span className="text-ink-2 font-medium tabular-nums">
+            {item.toProgress}%
+          </span>
+        </span>
+      )
+    case 'completed':
+      return <span className="text-ink-3">Marked complete</span>
+    default:
+      return (
+        <div className="space-y-1.5">
+          {item.note && (
+            <p className="text-sm text-ink-2 whitespace-pre-wrap">
+              {item.note}
+            </p>
+          )}
+          {item.wins && (
+            <p className="text-xs text-forest flex items-start gap-1.5">
+              <Trophy className="h-3 w-3 mt-0.5 shrink-0" />
+              <span className="whitespace-pre-wrap">{item.wins}</span>
+            </p>
+          )}
+          {item.blockers && (
+            <p className="text-xs text-vermillion flex items-start gap-1.5">
+              <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+              <span className="whitespace-pre-wrap">{item.blockers}</span>
+            </p>
+          )}
+        </div>
+      )
+  }
+}
+
+export function CommitmentActivityTimeline({
+  commitment,
+  currentUserId,
+}: {
+  commitment: Commitment
+  currentUserId?: string
+}) {
+  const groups = buildActivityFeed(commitment)
+
+  const ctx = {
+    currentUserId,
+    assignedToId: commitment.assigned_to_id,
+    assignedToName: commitment.assigned_to_name,
+    createdById: commitment.created_by_id,
+    creatorName: commitment.creator_name,
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map(group => {
+        const actor = resolveActorName(group, ctx)
+        return (
+          <div key={group.key} className="flex gap-3">
+            {/* Rail */}
+            <div className="flex flex-col items-center pt-1">
+              <div className="flex h-5 w-5 items-center justify-center rounded-full bg-surface-3 shrink-0">
+                <ItemIcon item={group.items[0]} />
+              </div>
+              <div className="w-px flex-1 bg-line mt-1" />
+            </div>
+
+            <div className="flex-1 min-w-0 pb-1 space-y-1">
+              {group.items.map(item => (
+                <div key={item.id}>
+                  <ItemBody
+                    item={item}
+                    actor={actor}
+                    extractedByAi={commitment.extracted_from_transcript}
+                  />
+                </div>
+              ))}
+              <p className="text-[11px] text-ink-3">{formatDate(group.at)}</p>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/commitments/detail/commitment-context-header.tsx
+++ b/src/components/commitments/detail/commitment-context-header.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+/**
+ * Who / where a commitment belongs to: client, originating session, assignee.
+ *
+ * This is the enrichment the standalone page most needs. In the panel you
+ * always arrive from a list that already shows whose commitment it is; a page
+ * opened from a pasted link has no such context to borrow.
+ *
+ * Every field is optional-chained, so this renders correctly against an older
+ * backend that doesn't yet return the names — it just shows less.
+ */
+
+import Link from 'next/link'
+import { Calendar, User2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatDateOnly } from '@/lib/date-utils'
+import type { Commitment } from '@/types/commitment'
+
+export function CommitmentContextHeader({
+  commitment,
+  linkable = true,
+  className,
+}: {
+  commitment: Commitment
+  /** Client/session links only make sense on coach surfaces. */
+  linkable?: boolean
+  className?: string
+}) {
+  const assignee = commitment.assigned_to_name || commitment.client_name
+
+  const clientNode = commitment.client_name ? (
+    linkable && commitment.client_id ? (
+      <Link
+        href={`/clients/${commitment.client_id}`}
+        className="font-medium text-ink-2 hover:text-ink hover:underline"
+      >
+        {commitment.client_name}
+      </Link>
+    ) : (
+      <span className="font-medium text-ink-2">{commitment.client_name}</span>
+    )
+  ) : null
+
+  const sessionLabel = commitment.session_title || 'Session'
+  const sessionNode = commitment.session_id ? (
+    <span className="inline-flex items-center gap-1">
+      <Calendar className="h-3 w-3 shrink-0" />
+      {linkable ? (
+        <Link
+          href={`/sessions/${commitment.session_id}`}
+          className="hover:text-ink hover:underline truncate"
+        >
+          {sessionLabel}
+        </Link>
+      ) : (
+        <span className="truncate">{sessionLabel}</span>
+      )}
+      {commitment.session_date && (
+        <span className="text-ink-3">
+          ({formatDateOnly(commitment.session_date, 'MMM d')})
+        </span>
+      )}
+    </span>
+  ) : (
+    // Mirrors the 'Manually Created' label the hub's grouping already uses.
+    <span className="text-ink-3">Created manually</span>
+  )
+
+  const parts = [
+    clientNode,
+    sessionNode,
+    assignee ? (
+      <span className="inline-flex items-center gap-1 min-w-0">
+        <User2 className="h-3 w-3 shrink-0" />
+        <span className="truncate">{assignee}</span>
+        {commitment.is_coach_commitment && (
+          <span className="ml-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface-3 text-ink-2 uppercase tracking-wide">
+            Coach
+          </span>
+        )}
+      </span>
+    ) : null,
+  ].filter(Boolean)
+
+  if (parts.length === 0) return null
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-ink-3 min-w-0',
+        className,
+      )}
+    >
+      {parts.map((node, i) => (
+        <span key={i} className="inline-flex items-center gap-2 min-w-0">
+          {i > 0 && (
+            <span aria-hidden className="text-line">
+              ·
+            </span>
+          )}
+          {node}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/commitments/detail/commitment-links.ts
+++ b/src/components/commitments/detail/commitment-links.ts
@@ -1,0 +1,23 @@
+import { toast } from 'sonner'
+
+/** Canonical URL for a commitment's full page. */
+export function commitmentHref(commitmentId: string) {
+  return `/commitments/${commitmentId}`
+}
+
+/**
+ * Copy a shareable link to the clipboard.
+ *
+ * This is the thing the new route unlocks that nothing else could: pasting a
+ * specific commitment into Slack. Before, a commitment had no address at all.
+ */
+export async function copyCommitmentLink(commitmentId: string) {
+  const url = `${window.location.origin}${commitmentHref(commitmentId)}`
+  try {
+    await navigator.clipboard.writeText(url)
+    toast.success('Link copied')
+  } catch {
+    // Clipboard API is unavailable over plain http and in some embedded views.
+    toast.error('Could not copy link')
+  }
+}

--- a/src/components/commitments/detail/commitment-progress-control.tsx
+++ b/src/components/commitments/detail/commitment-progress-control.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+/**
+ * Progress control with a milestone-derived suggestion.
+ *
+ * Before this, progress was only ever 0 or 100 — set as a side effect of the
+ * status toggle — even though the commitment already had subtasks that imply a
+ * real percentage.
+ *
+ * Deliberately an affordance, not an automation: `progress_percentage` is
+ * written independently by several surfaces, and most commitments have no
+ * milestones at all (where a derived number would be meaningless). Silently
+ * overwriting a coach's manual figure on every subtask toggle would be a
+ * data-loss-shaped surprise, so the rollup is offered as one click instead.
+ */
+
+import { TrendingUp } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { useUpdateCommitmentProgress } from '@/hooks/mutations/use-commitment-mutations'
+import { useClientUpdateCommitmentProgress } from '@/hooks/mutations/use-client-commitment-mutations'
+import type { Commitment } from '@/types/commitment'
+
+const STEPS = [0, 25, 50, 75, 100]
+
+export function CommitmentProgressControl({
+  commitment,
+  commitmentId,
+  clientMode,
+}: {
+  commitment: Commitment
+  commitmentId: string
+  clientMode?: boolean
+}) {
+  // Both called unconditionally — never make these conditional.
+  const coachUpdate = useUpdateCommitmentProgress()
+  const clientUpdate = useClientUpdateCommitmentProgress()
+  const updateProgress = clientMode ? clientUpdate : coachUpdate
+
+  const current = commitment.progress_percentage ?? 0
+  const milestones = commitment.milestones || []
+  const done = milestones.filter(m => m.status === 'completed').length
+  const derived = milestones.length
+    ? Math.round((done / milestones.length) * 100)
+    : null
+
+  // Writes through POST /{id}/progress rather than PATCH: that path also
+  // creates the commitment_updates row the activity timeline is built from.
+  const setProgress = (value: number) => {
+    if (value === current) return
+    updateProgress.mutate({
+      commitmentId,
+      data: { progress_percentage: value },
+    })
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-ink-3">Progress</label>
+        <span className="text-xs font-medium text-ink-2 tabular-nums">
+          {current}%
+        </span>
+      </div>
+
+      <Progress value={current} className="h-1.5" />
+
+      <div className="flex flex-wrap gap-1">
+        {STEPS.map(step => (
+          <button
+            key={step}
+            type="button"
+            onClick={() => setProgress(step)}
+            aria-pressed={current === step}
+            className={
+              'px-2 py-0.5 rounded text-[11px] font-medium border transition-colors tabular-nums ' +
+              (current === step
+                ? 'bg-ds-accent-bg text-ds-accent border-ds-accent'
+                : 'bg-transparent text-ink-3 border-line hover:text-ink-2 hover:border-ink-4')
+            }
+          >
+            {step}%
+          </button>
+        ))}
+      </div>
+
+      {derived !== null && (
+        <div className="flex items-center justify-between gap-2 pt-1">
+          <span className="text-[11px] text-ink-3">
+            {done} of {milestones.length} subtask
+            {milestones.length === 1 ? '' : 's'} done ({derived}%)
+          </span>
+          {derived !== current && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-[11px]"
+              onClick={() => setProgress(derived)}
+            >
+              <TrendingUp className="h-3 w-3 mr-1" />
+              Sync to {derived}%
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/commitments/detail/commitment-siblings.tsx
+++ b/src/components/commitments/detail/commitment-siblings.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+/**
+ * "From this session" — the client's other commitments from the same session.
+ *
+ * Reuses the existing list endpoint rather than adding a new one. The filter
+ * object is byte-identical to the one sessions/[sessionId]/page.tsx passes, so
+ * arriving here from a session page is a cache hit rather than a refetch.
+ */
+
+import Link from 'next/link'
+import { useCommitments } from '@/hooks/queries/use-commitments'
+import { cn } from '@/lib/utils'
+import type { Commitment } from '@/types/commitment'
+
+const MAX_SHOWN = 6
+
+const STATUS_DOT: Record<string, string> = {
+  draft: 'bg-line',
+  active: 'bg-ds-accent',
+  in_progress: 'bg-amber-token',
+  completed: 'bg-forest',
+  abandoned: 'bg-vermillion',
+}
+
+export function CommitmentSiblings({ commitment }: { commitment: Commitment }) {
+  const { data } = useCommitments({
+    session_id: commitment.session_id,
+    include_drafts: true,
+  })
+
+  if (!commitment.session_id) return null
+
+  // Unwrapped the same way the hub does (use-commitments-view.ts).
+  const siblings = ((data as { commitments?: Commitment[] })?.commitments ?? [])
+    .filter(c => c.id !== commitment.id)
+    .slice(0, MAX_SHOWN)
+
+  if (siblings.length === 0) return null
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-medium text-ink-3">From this session</h3>
+      <div className="space-y-1">
+        {siblings.map(sibling => (
+          <Link
+            key={sibling.id}
+            href={`/commitments/${sibling.id}`}
+            className="flex items-start gap-2 rounded px-2 py-1.5 -mx-2 hover:bg-surface-3 group"
+          >
+            <span
+              className={cn(
+                'h-1.5 w-1.5 rounded-full mt-1.5 shrink-0',
+                STATUS_DOT[sibling.status] || 'bg-line',
+              )}
+            />
+            <span className="text-xs text-ink-2 group-hover:text-ink line-clamp-2">
+              {sibling.title}
+            </span>
+          </Link>
+        ))}
+      </div>
+      {commitment.client_id && (
+        <Link
+          href={`/commitments?client=${commitment.client_id}`}
+          className="inline-block text-[11px] text-ink-3 hover:text-ink hover:underline"
+        >
+          View all for this client
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/src/components/commitments/detail/use-commitment-detail.ts
+++ b/src/components/commitments/detail/use-commitment-detail.ts
@@ -1,0 +1,247 @@
+'use client'
+
+/**
+ * Shared data + mutation controller for the commitment detail UI.
+ *
+ * Extracted from commitment-detail-panel.tsx so the slide-over panel and the
+ * full page at /commitments/[id] run the exact same logic instead of keeping
+ * two copies. Behaviour is deliberately identical to the original panel.
+ */
+
+import { useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { queryKeys } from '@/lib/query-client'
+import { CommitmentService } from '@/services/commitment-service'
+import { ClientCommitmentService } from '@/services/client-commitment-service'
+import { LiveMeetingService } from '@/services/live-meeting-service'
+import {
+  useUpdateCommitment,
+  useDiscardCommitment,
+} from '@/hooks/mutations/use-commitment-mutations'
+import {
+  useClientUpdateCommitment,
+  useClientDiscardCommitment,
+} from '@/hooks/mutations/use-client-commitment-mutations'
+import { useTargets } from '@/hooks/queries/use-targets'
+import { useSprints } from '@/hooks/queries/use-sprints'
+
+export interface GuestContext {
+  meetingToken: string
+  guestToken: string
+}
+
+export type CommitmentDetailMode = 'coach' | 'client' | 'guest'
+
+export interface CommitmentCapabilities {
+  canAttach: boolean
+  canMilestones: boolean
+  canActivity: boolean
+  canLinkOutcomes: boolean
+  /** Only the coach surface has a /commitments/[id] route to open. */
+  canOpenInPage: boolean
+  canSeeSiblings: boolean
+}
+
+export function resolveMode(
+  guestContext?: GuestContext,
+  clientMode?: boolean,
+): CommitmentDetailMode {
+  if (guestContext) return 'guest'
+  if (clientMode) return 'client'
+  return 'coach'
+}
+
+export function capabilitiesFor(
+  mode: CommitmentDetailMode,
+  hasSession: boolean,
+): CommitmentCapabilities {
+  return {
+    // Guest mode has no authenticated API for these three.
+    canAttach: mode !== 'guest',
+    canMilestones: mode !== 'guest',
+    canActivity: mode !== 'guest',
+    // Client portal has no TargetService.
+    canLinkOutcomes: mode !== 'client',
+    canOpenInPage: mode === 'coach',
+    canSeeSiblings: mode === 'coach' && hasSession,
+  }
+}
+
+// Prevents temp/optimistic ids (e.g. "temp-…", "None") reaching the API.
+export const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function useCommitment(
+  commitmentId: string | null,
+  guestContext?: GuestContext,
+  clientMode?: boolean,
+) {
+  const isValidId = !!commitmentId && UUID_RE.test(commitmentId)
+  return useQuery({
+    queryKey: queryKeys.commitments.detail(commitmentId || ''),
+    queryFn: () => {
+      if (guestContext) {
+        return LiveMeetingService.getCommitmentDetail(
+          guestContext.meetingToken,
+          guestContext.guestToken,
+          commitmentId!,
+        )
+      }
+      if (clientMode) {
+        return ClientCommitmentService.getCommitment(commitmentId!)
+      }
+      return CommitmentService.getCommitment(commitmentId!)
+    },
+    enabled: isValidId,
+    staleTime: 2 * 60 * 1000,
+  })
+}
+
+interface UseCommitmentDetailArgs {
+  commitmentId: string | null
+  clientId?: string
+  guestContext?: GuestContext
+  clientMode?: boolean
+  onCommitmentUpdate?: () => void
+  /** Called after a successful delete — panel closes, page navigates away. */
+  onDeleted?: () => void
+}
+
+export function useCommitmentDetail({
+  commitmentId,
+  clientId: clientIdProp,
+  guestContext,
+  clientMode,
+  onCommitmentUpdate,
+  onDeleted,
+}: UseCommitmentDetailArgs) {
+  const {
+    data: commitment,
+    isLoading,
+    error,
+  } = useCommitment(commitmentId, guestContext, clientMode)
+  const resolvedClientId = clientIdProp || commitment?.client_id
+
+  // Prefetch targets & sprints using the known clientId so they're cached
+  // before the linked-outcomes section mounts. In guest mode fetching is
+  // disabled — the cache is pre-seeded by ClientCommitmentPanel, and an
+  // authenticated call here would 403.
+  //
+  // NOTE: the filter object shape must stay EXACTLY `{ client_id }`. Guest
+  // pre-seeding writes that query key; a different shape is a different key
+  // and guests start 403ing.
+  const targetFilters = resolvedClientId
+    ? { client_id: resolvedClientId }
+    : undefined
+  const guestQueryOpts = guestContext
+    ? { enabled: false, staleTime: Infinity }
+    : {}
+  useTargets(targetFilters, guestQueryOpts)
+  useSprints(
+    resolvedClientId ? { client_id: resolvedClientId } : undefined,
+    guestQueryOpts,
+  )
+
+  // Both variants are called unconditionally and then picked between —
+  // never make these conditional, it would break hook order.
+  const coachUpdateCommitment = useUpdateCommitment({ silent: true })
+  const clientUpdateCommitment = useClientUpdateCommitment({ silent: true })
+  const updateCommitment = clientMode
+    ? clientUpdateCommitment
+    : coachUpdateCommitment
+  const coachDiscardCommitment = useDiscardCommitment()
+  const clientDiscardCommitment = useClientDiscardCommitment()
+  const discardCommitment = clientMode
+    ? clientDiscardCommitment
+    : coachDiscardCommitment
+
+  const queryClient = useQueryClient()
+
+  const handleFieldUpdate = useCallback(
+    (field: string, value: any) => {
+      if (!commitmentId) return
+
+      const key = queryKeys.commitments.detail(commitmentId)
+      // Snapshot before the optimistic write so a failure can roll back.
+      const previous = queryClient.getQueryData(key)
+      const rollback = () => {
+        queryClient.setQueryData(key, previous)
+        toast.error('Failed to update commitment')
+      }
+
+      queryClient.setQueryData(key, (old: any) => {
+        if (!old) return old
+        return { ...old, [field]: value }
+      })
+
+      if (guestContext) {
+        LiveMeetingService.updateCommitment(
+          guestContext.meetingToken,
+          guestContext.guestToken,
+          commitmentId,
+          { [field]: value },
+        )
+          .then(() => onCommitmentUpdate?.())
+          .catch(rollback)
+      } else {
+        updateCommitment.mutate(
+          { commitmentId, data: { [field]: value } },
+          {
+            onSuccess: () => onCommitmentUpdate?.(),
+            onError: rollback,
+          },
+        )
+      }
+    },
+    [
+      commitmentId,
+      updateCommitment,
+      queryClient,
+      onCommitmentUpdate,
+      guestContext,
+    ],
+  )
+
+  const handleDelete = useCallback(() => {
+    if (!commitmentId) return
+    if (guestContext) {
+      LiveMeetingService.deleteCommitment(
+        guestContext.meetingToken,
+        guestContext.guestToken,
+        commitmentId,
+      )
+        .then(() => {
+          onDeleted?.()
+          onCommitmentUpdate?.()
+        })
+        .catch(() => toast.error('Failed to delete commitment'))
+    } else {
+      discardCommitment.mutate(commitmentId, {
+        onSuccess: () => {
+          onDeleted?.()
+          onCommitmentUpdate?.()
+        },
+      })
+    }
+  }, [
+    commitmentId,
+    guestContext,
+    discardCommitment,
+    onDeleted,
+    onCommitmentUpdate,
+  ])
+
+  const mode = resolveMode(guestContext, clientMode)
+
+  return {
+    commitment,
+    isLoading,
+    error,
+    mode,
+    capabilities: capabilitiesFor(mode, !!commitment?.session_id),
+    handleFieldUpdate,
+    handleDelete,
+  }
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -46,11 +46,20 @@ function AlertDialogOverlay({
 
 function AlertDialogContent({
   className,
+  overlayClassName,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  /**
+   * Classes for the backdrop. Needed when the dialog opens from inside a
+   * stacking context above the default z-50 — e.g. the commitment detail
+   * panel sits at z-70, so without this the scrim renders *behind* the panel
+   * even when the dialog box itself is lifted.
+   */
+  overlayClassName?: string
+}) {
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay className={overlayClassName} />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(

--- a/src/types/commitment.ts
+++ b/src/types/commitment.ts
@@ -52,8 +52,6 @@ export interface CommitmentBase {
   start_date?: string // ISO date string
   target_date?: string // ISO date string
   measurement_criteria?: string
-  goal_id?: string | null // Direct link to goal
-  sprint_id?: string | null // Direct link to sprint
 }
 
 // Create commitment request
@@ -75,8 +73,6 @@ export interface CommitmentUpdate {
   target_date?: string
   progress_percentage?: number
   measurement_criteria?: string
-  goal_id?: string | null
-  sprint_id?: string | null
   assigned_to_id?: string | null // User ID of assignee. null = client, set = coach
   metadata?: Record<string, unknown>
 }
@@ -108,7 +104,6 @@ export interface Commitment extends CommitmentBase {
   creator_name?: string
   update_count?: number
   milestone_count?: number
-  days_until_deadline?: number
 
   // Related data
   attachments?: CommitmentAttachment[]
@@ -133,6 +128,7 @@ export interface CommitmentUpdateEntry {
   id: string
   commitment_id: string
   updated_by_id: string
+  updated_by_name?: string
   progress_percentage?: number
   status_change?: string
   note?: string
@@ -199,5 +195,4 @@ export interface CommitmentStats {
   total_completed: number
   completion_rate: number
   at_risk_count: number // commitments past deadline
-  due_soon_count: number // commitments due within 7 days
 }


### PR DESCRIPTION
Frontend half of the commitment detail work. Pairs with backend #98 (already merged), which adds the route scoping and the context fields this page renders.

## Why

A commitment had **no address**. The only detail UI was a 1,560-line hand-rolled slide-over mounted at six sites, each holding the open commitment in its own `useState` — so you could not refresh into a commitment, cmd-click one open, or paste one into Slack.

## Shape

The panel stays the fast path from lists and boards; the page is the shareable, readable surface. **Both run the same `useCommitmentDetail` controller and the same section components** — no second implementation to keep in sync, and **all six existing mount sites are unchanged**.

Layout follows the principle Linear's issue view uses: a measured content column with properties beside it, rather than a 640px panel stretched to 1400px. One JSX tree handles both breakpoints — below `lg` the properties rail stacks *above* the content, since on a phone you want status and due date first.

## Enrichments

- **Context header** (client / session / assignee). What the page most needs: in the panel you always arrive from a list that already shows whose commitment it is. Every field is optional-chained, so it degrades rather than breaks.
- **Activity timeline.** A single `commitment_updates` row can be *both* a system event and a comment — the same row can move progress to 60% *and* carry a note — so `buildActivityFeed` fans each row out into 1..n items, then sorts, and synthesizes creation/completion. This surfaces status and progress history that was already stored but never rendered. Pure function, no React.
- **Progress control with a one-click milestone rollup.** Deliberately an affordance, not automation: `progress_percentage` is written independently by four surfaces and most commitments have no milestones, so auto-deriving on every subtask toggle would silently overwrite real numbers.
- **Sibling commitments**, reusing the existing list endpoint with a filter object byte-identical to the session page's, so arriving from there is a cache hit rather than a refetch.

## Panel fixes, made in place first

Done before the extraction so they're reviewable against the original file and survive independently:

- **`in_progress` was missing from the status control** although the kanban board and three other surfaces write it — an In Progress commitment opened with **no chip selected**, and picking any option silently lost the state. Fixed as a *class*: an unknown status renders as a read-only chip, so `draft` can't repeat the bug.
- **Progress could only ever be 0 or 100**, as a side effect of the status toggle. Reopening a completed commitment now restores milestone-derived progress instead of hard-zeroing work that was actually done.
- **The attachment delete dialog rendered behind the panel.** `AlertDialogContent` renders its *own* `z-50` overlay with no className passthrough, so lifting only the content left the scrim underneath the `z-70` panel. Added `overlayClassName`.
- **Optimistic field updates never rolled back** on failure, leaving a wrong value until the next refetch — tolerable in a transient panel, wrong on a long-lived page.
- `navigator.platform` was read during render.

## Navigation

Hub rows become real `<Link>`s: cmd/middle-click opens the page in a new tab and the row gets a hover URL, while plain click still opens the panel. Plus a `Maximize2` button in the panel header and copy-link in both surfaces.

## Cleanup

Removes `goal_id`/`sprint_id` (columns dropped server-side by `f06135d685df`), `days_until_deadline` (recomputed client-side in `commitment-view.ts`) and `due_soon_count` (computed by the backend, rendered nowhere). All grep-verified unreferenced.

## Care taken

- Branched off `main` and cherry-picked, **not** PRed from `chore/design-sync-setup` — that branch sits 1 commit ahead with an unrelated 96-file design-sync chore. Verified: exactly 13 files, zero `components/ui/*` beyond the intentional `alert-dialog.tsx` change.
- The guest cache pre-seeding in `client-commitment-panel.tsx` depends on the `useTargets`/`useSprints` filter object being exactly `{ client_id }` — a changed shape is a changed query key and guests start 403ing. Preserved verbatim, with a comment.
- Both client/coach mutation hook variants stay called unconditionally, so hook order can't break.

## Verification

`tsc` and `eslint` clean; all three routes serve 200 including `/commitments/not-a-uuid`, which renders not-found without firing a request.

⚠️ **Not visually verified** — the local app requires login and I don't authenticate on the user's behalf. Worth a click-through of the six panel mount sites (coach, client-portal, guest) before relying on it.