### PR TITLE
Stop showing "Knowledge Base Not Available" when the check itself failed

### DIFF
--- a/src/app/clients/[clientId]/components/client-chat-unified.tsx
+++ b/src/app/clients/[clientId]/components/client-chat-unified.tsx
@@ -72,6 +72,7 @@ export function ClientChatUnified({
   const [input, setInput] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [stats, setStats] = useState<ChatStats | null>(null)
+  const [statsError, setStatsError] = useState(false)
   const [loadingStats, setLoadingStats] = useState(true)
   const [suggestedQuestions, setSuggestedQuestions] = useState<string[]>([])
   const [showSources, setShowSources] = useState<{ [key: number]: boolean }>({})
@@ -110,15 +111,14 @@ export function ClientChatUnified({
       const data = await chatService.getClientKnowledgeStats(clientId)
       setStats(data)
       setSuggestedQuestions(data.suggested_questions || [])
+      setStatsError(false)
     } catch (error) {
       console.error('Failed to fetch stats:', error)
-      // Set empty stats on error to prevent infinite loading
-      setStats({
-        total_chunks: 0,
-        unique_sessions: 0,
-        top_topics: [],
-        suggested_questions: [],
-      })
+      // Don't fake an empty knowledge base — "we couldn't check" and "this
+      // client has no indexed sessions" are different problems and need
+      // different messages.
+      setStats(null)
+      setStatsError(true)
     } finally {
       setLoadingStats(false)
     }
@@ -305,8 +305,8 @@ export function ClientChatUnified({
     )
   }
 
-  if (!stats || stats.total_chunks === 0) {
-    const hasSessionData = stats && stats.unique_sessions > 0
+  if (statsError || !stats || stats.total_chunks === 0) {
+    const hasSessionData = !statsError && stats && stats.unique_sessions > 0
 
     return (
       <div className="flex flex-col h-full p-4">
@@ -314,14 +314,18 @@ export function ClientChatUnified({
           <div className="text-center max-w-sm">
             <MessageSquare className="h-10 w-10 text-ink-2 mx-auto mb-3" />
             <h3 className="text-sm font-medium text-ink mb-1">
-              Knowledge Base Not Available
+              {statsError
+                ? "Couldn't Load Knowledge Base"
+                : 'Knowledge Base Not Available'}
             </h3>
             <p className="text-xs text-ink-3 mb-3">
-              {hasSessionData
-                ? 'The knowledge base is currently being indexed. Please try again in a few moments.'
-                : 'The AI assistant will be available after analyzing coaching sessions.'}
+              {statsError
+                ? "We couldn't reach the knowledge base just now — this doesn't mean your sessions are missing. Please retry."
+                : hasSessionData
+                  ? 'The knowledge base is currently being indexed. Please try again in a few moments.'
+                  : 'The AI assistant will be available after analyzing coaching sessions.'}
             </p>
-            {!hasSessionData && (
+            {!hasSessionData && !statsError && (
               <p className="text-xs text-ink-4 ">
                 Upload or record coaching sessions to enable AI-powered
                 insights.

--- a/src/app/sessions/[sessionId]/review/page.tsx
+++ b/src/app/sessions/[sessionId]/review/page.tsx
@@ -81,7 +81,10 @@ export default function SessionReviewPage({
     if (!sid) return
     if (autoRefreshedRef.current === sid) return
     if (data.video_unavailable) return
-    if (!data.is_owner && !data.is_admin) return // only owner/admin can refresh
+    // Recipients of a share are authorized to refresh too — the backend
+    // gates GET /sessions/{id}/video-url on can_view_session, not ownership.
+    // Without this, anyone who isn't the owner lands on an expired SigV4 URL
+    // (they last 7 days) and sees a dead player with no way to fix it.
     const url = data.video_url
     if (!url || !isPresignedUrlExpired(url)) return
     autoRefreshedRef.current = sid


### PR DESCRIPTION
Two UI bugs that both told a coach their data was missing when it wasn't. Pairs with backend #99.

## 1. Chat panel reported failures as "no data"

`fetchStats` caught **any** error and set `total_chunks: 0`, which renders the same **"Knowledge Base Not Available"** empty state as a client with genuinely no indexed sessions. A backend fault, a poisoned worker, and an unindexed client were indistinguishable in the UI.

That's what made the backend regression so confusing to diagnose: when a poisoned worker started returning zeros (see #99), coaches were told their sessions were gone — Mackie McAdam reported it for *every client*, while her chunks sat in Weaviate the whole time.

Failures now render a distinct **"Couldn't Load Knowledge Base"** state that says the data is probably fine and offers Retry. The genuine empty state is unchanged.

## 2. Share recipients landed on a dead video player

The review page gated its expired-URL auto-refresh on `is_owner || is_admin` (`review/page.tsx:84`). But the backend authorizes refresh via `can_view_session`, which honors `session_shares` and `is_shared_with_all_coaches` — verified in `_authorize_session_for_video`, whose own docstring says so.

Presigned URLs expire after 7 days, so every recipient of an org-wide share eventually hit a dead player with no way to fix it. That's Arron Chambers' "random videos on my Dashboard that are never active": all 6 org-wide shares had healthy S3 objects, just expired URLs.

The stale frontend guard is removed; the backend stays the authority on who may refresh.

## Testing

- `tsc --noEmit` clean (only a pre-existing unrelated `vitest` types error)
- eslint clean; lint-staged pre-commit hook passed
- Branched off `origin/main` — confirmed the unrelated `design-sync` chore did **not** leak (`git merge-base --is-ancestor f9cc656 HEAD` = false)

Not visually verified — the app requires login and I don't authenticate on the user's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)