### PR TITLE
Fix top frontend exception sources: WS gating, 401 handling, offline noise

### DIFF
--- a/src/components/auth/client-route.tsx
+++ b/src/components/auth/client-route.tsx
@@ -11,7 +11,7 @@ interface ClientRouteProps {
 }
 
 export function ClientRoute({ children }: ClientRouteProps) {
-  const { isAuthenticated, loading, hasRole, signOut } = useAuth()
+  const { isAuthenticated, loading, canAccessClientView, signOut } = useAuth()
   const router = useRouter()
 
   const handleGoBackToSignIn = async () => {
@@ -40,10 +40,13 @@ export function ClientRoute({ children }: ClientRouteProps) {
     return null
   }
 
-  // Check if user has client role (or is impersonating as super_admin)
+  // Require a usable client profile — role alone isn't enough: users hit by
+  // the onboarding gap have the client role but no client profile row, and
+  // rendering the portal for them just turns every backend call into a 403/404
+  // (or is impersonating as super_admin)
   const isImpersonating =
     typeof window !== 'undefined' && sessionStorage.getItem('view_as_client_id')
-  if (!hasRole('client') && !isImpersonating) {
+  if (!canAccessClientView() && !isImpersonating) {
     // Not a client - show friendly message instead of redirecting
     return (
       <div className="flex items-center justify-center min-h-screen bg-paper">

--- a/src/contexts/websocket-context.tsx
+++ b/src/contexts/websocket-context.tsx
@@ -44,15 +44,18 @@ interface WebSocketProviderProps {
 }
 
 export function WebSocketProvider({ children }: WebSocketProviderProps) {
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, isCoach, isAdmin } = useAuth()
   const [status, setStatus] = useState<WebSocketStatus>('disconnected')
+
+  // Only coach/admin surfaces consume the socket (session-processing toasts,
+  // live session page); client-portal users must not hold an idle connection.
+  const shouldConnect = isAuthenticated && (isCoach() || isAdmin())
 
   useEffect(() => {
     // Subscribe to status changes
     const unsubscribe = websocketService.onStatusChange(setStatus)
 
-    // Auto-connect WebSocket when authenticated
-    if (isAuthenticated) {
+    if (shouldConnect) {
       websocketService.connect()
     } else {
       websocketService.disconnect()
@@ -61,7 +64,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     return () => {
       unsubscribe()
     }
-  }, [isAuthenticated])
+  }, [shouldConnect])
 
   const connect = useCallback(() => {
     websocketService.connect()

--- a/src/hooks/queries/use-client-sessions.ts
+++ b/src/hooks/queries/use-client-sessions.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-client'
+import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
@@ -8,8 +9,10 @@ function getAuthHeaders(): Record<string, string> {
   const token =
     typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
     'Content-Type': 'application/json',
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
   }
   if (typeof window !== 'undefined') {
     const viewAsClient = sessionStorage.getItem('view_as_client_id')
@@ -25,9 +28,20 @@ function getAuthHeaders(): Record<string, string> {
 }
 
 async function clientFetch<T>(path: string): Promise<T> {
+  if (!isTokenValid()) {
+    handleAuthExpired()
+    throw Object.assign(new Error('Session expired'), { status: 401 })
+  }
   const res = await fetch(`${API_URL}${path}`, { headers: getAuthHeaders() })
+  if (res.status === 401) {
+    handleAuthExpired()
+  }
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${path}: ${res.status}`)
+    // status lets the query cache's 4xx filter suppress expected client
+    // errors from PostHog (see reportUnexpectedQueryError in query-client.ts)
+    throw Object.assign(new Error(`Failed to fetch ${path}: ${res.status}`), {
+      status: res.status,
+    })
   }
   return res.json()
 }

--- a/src/hooks/queries/use-questionnaire.ts
+++ b/src/hooks/queries/use-questionnaire.ts
@@ -61,6 +61,6 @@ export function useClientPreSession() {
   return useQuery<PreSessionPrep>({
     queryKey: questionnaireKeys.clientPreSession(),
     queryFn: () => QuestionnaireService.getClientPreSession(),
-    staleTime: 30 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -178,23 +178,34 @@ export class ApiClient {
       // These never reach a react-query onError with a usable status (the
       // request never completed), so report them here — throttled per endpoint
       // and flagged so the cache layer doesn't double-count.
+      // Offline/wake flaps aren't actionable: only report failures that
+      // happen while the browser believes it has a network connection.
+      const isOnline = typeof navigator === 'undefined' || navigator.onLine
       if (error instanceof Error && error.name === 'AbortError') {
         const timeoutError: ApiError = new Error(
           'Request timeout - please try again',
         )
         timeoutError.__phCaptured = true
-        captureExceptionThrottled(`api-timeout:${url}`, timeoutError, {
-          source: 'api-client',
-          reason: 'timeout',
-          url,
-        })
+        if (isOnline) {
+          captureExceptionThrottled(`api-timeout:${url}`, timeoutError, {
+            source: 'api-client',
+            reason: 'timeout',
+            url,
+          })
+        }
         throw timeoutError
       }
-      captureExceptionThrottled(`api-network:${url}`, error, {
-        source: 'api-client',
-        reason: 'network',
-        url,
-      })
+      if (isOnline) {
+        captureExceptionThrottled(`api-network:${url}`, error, {
+          source: 'api-client',
+          reason: 'network',
+          url,
+          visibility:
+            typeof document !== 'undefined'
+              ? document.visibilityState
+              : 'unknown',
+        })
+      }
       ;(error as ApiError).__phCaptured = true
       throw error
     }

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -6,6 +6,7 @@
  */
 
 import authService from '@/services/auth-service'
+import { isTokenValid, handleAuthExpired } from '@/lib/axios-config'
 import type {
   AgentEvent,
   AgentThreadDetail,
@@ -41,7 +42,10 @@ export interface StreamAgentArgs {
 
 function authHeader(): Record<string, string> {
   const token = authService.getToken()
-  if (!token) throw new Error('Not authenticated')
+  if (!token || !isTokenValid()) {
+    handleAuthExpired()
+    throw Object.assign(new Error('Not authenticated'), { status: 401 })
+  }
   return { Authorization: `Bearer ${token}` }
 }
 
@@ -74,6 +78,20 @@ async function unwrapError(res: Response, fallback: string): Promise<string> {
   return fallback
 }
 
+/**
+ * Build an Error carrying the HTTP status so the query cache's 4xx filter
+ * (query-client.ts) can suppress expected client errors from PostHog, and
+ * redirect to login on 401 like the axios interceptor does.
+ */
+async function httpError(res: Response, fallback: string): Promise<Error> {
+  if (res.status === 401) {
+    handleAuthExpired()
+  }
+  return Object.assign(new Error(await unwrapError(res, fallback)), {
+    status: res.status,
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Thread persistence
 // ---------------------------------------------------------------------------
@@ -85,9 +103,7 @@ export async function listAgentThreads(
     headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok) {
-    throw new Error(
-      await unwrapError(res, `Failed to load threads: ${res.status}`),
-    )
+    throw await httpError(res, `Failed to load threads: ${res.status}`)
   }
   return (await res.json()) as AgentThreadListResponse
 }
@@ -100,9 +116,7 @@ export async function getAgentThread(
     headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok) {
-    throw new Error(
-      await unwrapError(res, `Failed to load thread: ${res.status}`),
-    )
+    throw await httpError(res, `Failed to load thread: ${res.status}`)
   }
   return (await res.json()) as AgentThreadDetail
 }
@@ -116,9 +130,7 @@ export async function deleteAgentThread(
     headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok && res.status !== 204) {
-    throw new Error(
-      await unwrapError(res, `Failed to delete thread: ${res.status}`),
-    )
+    throw await httpError(res, `Failed to delete thread: ${res.status}`)
   }
 }
 
@@ -129,7 +141,7 @@ export async function fetchModels(
     headers: { ...authHeader(), ...viewAsHeaders() },
   })
   if (!res.ok) {
-    throw new Error(`Failed to load models: ${res.status}`)
+    throw await httpError(res, `Failed to load models: ${res.status}`)
   }
   return (await res.json()) as ModelsResponse
 }
@@ -186,9 +198,7 @@ export async function fetchAgentInsight({
   })
 
   if (!res.ok) {
-    throw new Error(
-      await unwrapError(res, `Failed to generate insight: ${res.status}`),
-    )
+    throw await httpError(res, `Failed to generate insight: ${res.status}`)
   }
   return (await res.json()) as AgentInsightResult
 }
@@ -222,7 +232,7 @@ export async function* streamAgent({
   })
 
   if (!res.ok) {
-    throw new Error(await unwrapError(res, `HTTP ${res.status}`))
+    throw await httpError(res, `HTTP ${res.status}`)
   }
 
   if (!res.body) {

--- a/src/services/websocket-service.ts
+++ b/src/services/websocket-service.ts
@@ -179,10 +179,8 @@ class WebSocketService {
         { source: 'websocket', reason: 'onerror' },
       )
       this.updateStatus('error')
-      // Schedule reconnect on error (if not intentional disconnect)
-      if (!this.intentionalDisconnect) {
-        this.scheduleReconnect()
-      }
+      // No scheduleReconnect here: onclose always follows a failed connection
+      // and schedules it — doing both burned two attempts per real failure.
     }
 
     this.ws.onclose = event => {
@@ -192,8 +190,15 @@ class WebSocketService {
       // Reconnect if not an intentional disconnect
       const isIntentionalClose =
         event.code === 1000 && event.reason === 'Client disconnect'
+      // 4001 = backend rejected the token (websocket/handlers.py); retrying
+      // with the same token can never succeed.
+      const isAuthRejection = event.code === 4001
 
-      if (!this.intentionalDisconnect && !isIntentionalClose) {
+      if (
+        !this.intentionalDisconnect &&
+        !isIntentionalClose &&
+        !isAuthRejection
+      ) {
         this.scheduleReconnect()
       }
     }


### PR DESCRIPTION
Fixes the 4 highest-ROI frontend exception sources identified in PostHog error tracking (~95% of active error volume over the last 7 days, nearly all client-portal).

## Changes

**1. WebSocket storm on the client portal (229 occurrences / 36 users — 60% of all volume)**
- `websocket-context.tsx`: only connect for coach/admin users. The socket's only consumers are coach features (processing toasts, live session page); client-portal users were holding an idle, storm-reconnecting connection on the dashboard.
- `websocket-service.ts`: treat backend auth-rejection close code 4001 as non-retryable, and stop scheduling reconnects from `onerror` (`onclose` always follows and already schedules — the double call burned two retry attempts per real failure).

**2. Raw-fetch islands missing the auth conventions (~25 occurrences + broken UX)**
- `use-client-sessions.ts` (`clientFetch`) and `agent-service.ts`: pre-flight `isTokenValid()`, redirect via `handleAuthExpired()` on 401, and attach `.status` to thrown errors so the query cache's existing 4xx filter suppresses expected client errors from PostHog. Also stops `clientFetch` sending literal `Bearer null`.

**3. Offline/wake network noise (~139 occurrences)**
- `api-client.ts`: skip network/timeout PostHog captures when `navigator.onLine` is false; tag surviving network captures with visibility state.
- `use-questionnaire.ts`: `useClientPreSession` staleTime 30s → 5min (was refetching on every window focus of the portal dashboard).

**4. Portal guard gap (8 occurrences, frontend face of the known portal-lockout bug)**
- `client-route.tsx`: require `canAccessClientView()` (role + `ownClientId`), so users with the client role but no client profile row get the friendly no-access screen instead of a 403/404 retry loop on `/client-portal/agent`.

## Verification
- `tsc --noEmit` clean (one pre-existing vitest-types error in an untouched test file), ESLint clean.
- Post-deploy: re-check PostHog error tracking after 24–48h; expect the WebSocket issue and client-portal 401 issues to stop accruing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)